### PR TITLE
docs: security model, contributing guide, architecture, templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,52 @@
+name: Bug
+description: Something the daemon or the preview does wrong
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A bug report is a scenario: the inputs, then the wrong outcome. Vulnerabilities go through SECURITY.md, not here.
+  - type: textarea
+    id: scenario
+    attributes:
+      label: What happened
+      description: The request or action, and what came back. Include the Host header and path for preview requests, and the daemon's stderr if it printed anything.
+      placeholder: |
+        PUT /api/t/acme/file/src/pages/index.astro with the file below, then GET http://acme.localhost:4321/ shows "Render failed: …"
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What should have happened
+    validations:
+      required: true
+  - type: textarea
+    id: files
+    attributes:
+      label: Files to reproduce it
+      description: The smallest tenant files that trigger it, or the base project (one of examples/*, or a link to the theme) plus the edit.
+      render: text
+  - type: textarea
+    id: check
+    attributes:
+      label: Output of `sandbox-lite check`
+      description: Run `./target/release/sandbox-lite check <project dir>` on the project and paste the output, if the bug is about compiling or rendering.
+      render: text
+  - type: input
+    id: commit
+    attributes:
+      label: Commit
+      description: Output of `git rev-parse HEAD` (there are no tagged releases).
+    validations:
+      required: true
+  - type: input
+    id: flags
+    attributes:
+      label: How the daemon was started
+      placeholder: ./target/release/sandbox-lite --domain preview.example.com --api-token … --preview-secret …
+  - type: input
+    id: browser
+    attributes:
+      label: Browser and version
+      description: Pages render in the browser, so this matters for preview bugs.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a vulnerability
+    url: https://github.com/productdevbook/sandbox-lite/security/advisories/new
+    about: Private report through GitHub security advisories. See SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,32 @@
+name: Feature
+description: Something the preview or the API should do and does not
+labels: [feature]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The most useful feature request is an Astro idiom the preview cannot render, shown with a real project. README.md lists what is out of scope today.
+  - type: textarea
+    id: idiom
+    attributes:
+      label: What does not work
+      description: The Astro feature, API endpoint or flag, and what the preview or the daemon does instead (the error page, the diagnostic, the wrong output).
+    validations:
+      required: true
+  - type: textarea
+    id: project
+    attributes:
+      label: A project that shows it
+      description: A link to a theme or repository, or the smallest files that use the idiom. Include the output of `sandbox-lite check <dir>` if it says anything about it.
+      render: text
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: Optional. Which part of the code (see ARCHITECTURE.md) and what it would do.
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - label: I checked the "What the preview does not do" section of README.md and this is not listed there as intentional

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+<!-- What changes and why. A measurement or a scenario beats an adjective. -->
+
+Closes #
+
+## Checklist
+
+- [ ] `cargo fmt --check`
+- [ ] `cargo clippy --all-targets -- -D warnings`
+- [ ] `cargo test`
+- [ ] `cargo build --release && ./target/release/sandbox-lite check examples/*`
+- [ ] If `src/transform/`, `src/resolve.rs`, `assets/shell.js` or a shim changed: opened the affected example in a browser
+- [ ] If behaviour changed: `README.md` / `ARCHITECTURE.md` / `SECURITY.md` updated and each sentence checked against the code
+- [ ] New routes: said above whether they are on the tenant host (open to preview viewers) or the API host (behind `--api-token`)
+- [ ] Comments only say what the code cannot (why, an outside constraint); no restated code, no changelog
+
+## Noticed, did not fix
+
+<!-- Anything you saw on the way that is out of scope for this PR. -->

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,303 @@
+# Architecture
+
+sandbox-lite is one process: an axum server on one listener, a tokio runtime
+with two worker threads, and compilation on the blocking pool. It never renders
+HTML. It serves a shell page and compiled ES modules; the visitor's browser
+renders the page with Astro's own runtime. This document follows a request
+through the code; file paths are given so each claim can be checked.
+
+## Host-based dispatch
+
+`http::app` (`src/http/mod.rs`) builds two routers and a fallback that picks
+one per request from the `Host` header (lowercased, port stripped):
+
+- `tenant_from_host(host, domain)` returns a tenant id when the host is
+  exactly `<label>.<domain>` and the label passes `valid_id`. The request goes
+  to the **tenant router** with the id in its extensions:
+  `/__sl/m/{*path}`, `/__sl/raw/{*path}`, `/__sl/routes.json`,
+  `/__sl/renderers.json`, `/__sl/events`, `/__sl/check`,
+  `/__sl/content/{name}`, `/__sl/shim/{name}`, `/__sl/astro.js`,
+  `/__sl/shell.js`, `/__sl/live.js`, `/__sl/missing.js`, and a fallback
+  (`preview::page`) for everything else. `require_preview_token` wraps all of
+  it.
+- Any other host goes to the **editor/API router**: `/` (the editor page),
+  `/health`, `/api/stats`, `/api/bases`, `/api/tenants`, `/api/tenants/{id}`,
+  `/api/t/{id}/files`, `/api/t/{id}/file/{*path}`, `/api/t/{id}/events`,
+  `/api/t/{id}/check`, `/api/t/{id}/chat`, with a 64 MiB body limit.
+  `require_api_token` wraps all of it.
+
+`SECURITY.md` describes the two middlewares.
+
+## Store: bases, overlays, versions (`src/store.rs`)
+
+A **base** is a project directory read once at startup (`Base::load`): every
+regular file, skipping `node_modules`, `.git`, `dist`, `.astro`, `.vercel`,
+`.netlify`, `.output`. Files up to 256 KiB are held in memory
+(`FileData::Mem`); larger ones stay on disk and are re-read on each access
+(`FileData::Disk`). Bases come from every sub-directory of `--bases` (default
+`./examples` when it exists) and from each `--base NAME=PATH`.
+
+A **tenant** is an `Arc<Base>` plus an overlay,
+`BTreeMap<String, Option<FileData>>`: `Some` is a file the tenant added or
+changed, `None` is a tombstone hiding a base file. `Tenant::data` consults the
+overlay first, so a tombstone makes the base file disappear; `Tenant::list`
+merges both views and flags overlay entries as `modified`. Two tenants on the
+same base share the base's memory; a tenant costs its overlay.
+
+Each tenant has a **version**, a `u64` of milliseconds since the epoch at
+creation. `write` and `delete` call `bump`, which sets it to
+`max(now, previous + 1)` — strictly increasing — and sends
+`{"type":"update"|"delete","path":…,"version":N}` on the tenant's
+`tokio::sync::broadcast` channel (64 slots). Both SSE endpoints
+(`/api/t/{id}/events`, `/__sl/events`) subscribe to that channel and open with
+an `event: hello` carrying the current version.
+
+With a `--data-dir`, the overlay is persisted as
+`<data-dir>/<id>/tenant.json` (`{"base": name}`), `<data-dir>/<id>/files/<path>`
+and `<data-dir>/<id>/deleted.json` (the tombstones). Every write goes to disk;
+files over 256 KiB are then kept only there. `Store::restore` rebuilds tenants
+at startup with a fresh version and skips any whose base is not loaded.
+`--no-persist` keeps everything in memory.
+
+## Rendering a page
+
+`GET http://acme.<domain>/blog/hello-world`, step by step:
+
+1. **Shell.** No route matches, so `preview::page` (`src/http/preview.rs`)
+   runs. It percent-decodes the path, and if `public/<path>` exists in the
+   tenant it serves that file. Otherwise it answers `assets/shell.html` with
+   `%TENANT%`, `%VERSION%` (the tenant's version), `%ASSETS%` (a hash of
+   `astro.js`, `shell.js`, `live.js`) and `%ENV%` filled in, `Cache-Control:
+   no-store`. `%ENV%` is `import.meta.env`: `DEV`, `PROD`, `MODE`, `SSR`,
+   `BASE_URL`, `SITE` (from `sandbox-lite.json`), and the `PUBLIC_*` lines of
+   the tenant's `.env`.
+2. **Scripts.** The shell loads `/__sl/live.js` and `/__sl/shell.js`
+   (`no-cache`, ETag = the assets hash). `live.js` opens an `EventSource` on
+   `/__sl/events`.
+3. **Route table.** `shell.js` fetches `/__sl/routes.json?v=<version>`.
+   `routes::build` (`src/routes.rs`) turns every file under `src/pages/` into
+   a route: `index` is dropped, files with a `_`-prefixed segment are skipped,
+   `[param]` becomes `([^/]+?)`, `[...rest]` becomes `(.*?)` (optional when it
+   is the whole segment), and the list is sorted by a per-segment key — 0 for
+   static, 1 for `[param]`, 2 for `[...rest]` — compared lexicographically,
+   so static routes come before dynamic ones and a route sorts before any
+   longer route it is a prefix of; equal keys are ordered by path. The kind is
+   `astro`, `md`, `mdx` or `endpoint`; the shell renders the first two and
+   shows an "unsupported route" page for the others.
+4. **Page module.** The shell imports `/__sl/astro.js` and
+   `/__sl/m/src/pages/blog/[slug].astro?v=<version>`. `preview::module`
+   cleans the path, reads the kind from the query, and on the blocking pool
+   builds a `Resolver` (which reads `tsconfig.json` `paths`,
+   `sandbox-lite.json` `imports` and `package.json` dependencies) and calls
+   `Engine::serve`. The response is `Cache-Control: public, max-age=31536000,
+   immutable` when the query has `v=`, `no-cache` otherwise.
+5. **Module graph.** The compiled page imports its layout and components as
+   `/__sl/m/…?v=N` URLs; each `<style>` block as
+   `/__sl/m/<file>.astro?astro&type=style&index=i&v=N`, each hoisted
+   `<script>` as `…type=script…`; `.css`/`.scss` files as modules that
+   register their CSS; `astro:*` as `/__sl/shim/astro-*.js`; bare specifiers
+   as CDN URLs; images as `{ src, width, height, format }` modules;
+   unresolvable specifiers as `/__sl/missing.js?spec=…&from=…`, which throws.
+   The browser follows the graph; each request repeats step 4.
+6. **Static paths.** If the route has params and the module exports
+   `getStaticPaths`, the shell calls it with its own `paginate`, keeps the
+   entry whose params equal the matched ones, and uses its `props`.
+7. **Render.** `experimental_AstroContainer.create({ resolve, astroConfig })`
+   — `resolve` maps ids the runtime asks for (island component paths,
+   `astro:*`) to daemon URLs. `/__sl/renderers.json` lists framework renderers
+   (`resolve::renderers`: `@astrojs/react` and `@astrojs/preact` from
+   `package.json`, or `sandbox-lite.json` `renderers`); each server renderer
+   is imported and registered, each client entrypoint recorded.
+   `container.renderToResponse(mod.default, { request, params, props })`
+   produces the HTML.
+8. **Document.** A `3xx` with `Location` becomes `location.replace`.
+   Otherwise every CSS string that modules registered in
+   `globalThis.__sl_css` becomes a `<style data-sl=key>` (with
+   `type="text/tailwindcss"` when it contains `@import "tailwindcss"` or
+   `@tailwind`), `live.js` is appended, the block is injected before
+   `</head>`, and `document.write` replaces the shell. If Tailwind was seen,
+   its browser build is loaded from jsDelivr.
+9. **Errors.** Any exception fetches `/__sl/check` and renders an error page
+   with the daemon's diagnostics; a missing route lists the routes. Error
+   pages also load `live.js`, so they reload when the file is fixed.
+
+The editor (`assets/editor.html`) is the other client: it embeds the preview
+in an `<iframe>` and edits files through `/api/t/{id}/file/{path}`.
+
+## The transform engine (`src/transform/mod.rs`)
+
+`Engine::build(tenant, path, kind)` returns an `Arc<Built>`; `Engine::serve`
+turns one into response text. The `kind` comes from the query string:
+`Module` (default), `Style(i)` and `Script(i)` (`?astro&type=…&index=i`),
+`Raw` (`?raw`), `Url` (`?url`).
+
+What `compile` does per kind and extension:
+
+| Input | Output |
+|---|---|
+| `.astro` | `astro_codegen` (`src/transform/astro.rs`): oxc parses, `<style lang="scss\|sass">` blocks are pre-compiled with grass, the compiler emits a module importing helpers from `/__sl/astro.js`; the CSS of each `<style>` and each hoisted `<script>` are kept aside; relative `client:component-path` values are made root-absolute |
+| `.ts` `.tsx` `.jsx` `.mts` | oxc transform (`src/transform/js.rs`): TypeScript stripped, JSX compiled |
+| `.js` `.mjs` | served as-is when it parses as ESM, otherwise transformed |
+| `.css` | a module that registers the text in `globalThis.__sl_css`, with relative `url()` and `@import` targets rewritten to `/__sl/raw/…` (`src/transform/css.rs`) |
+| `.scss` `.sass` | grass over the tenant's file tree (`src/transform/scss.rs`), then as `.css` |
+| `.md` | frontmatter + pulldown-cmark HTML, wrapped as a page component that renders through `layout:` when set (`src/transform/markdown.rs`) |
+| `.json` | `export default JSON.parse(…)` |
+| images | `export default { src: "/__sl/raw/…", width, height, format, fsPath }` |
+| `Style(i)` / `Script(i)` | builds the `.astro` module (cached) and returns its i-th CSS block or script as its own module |
+| `Raw` / `Url` | the text as a string export / the `/__sl/raw/` URL as a string export |
+| anything else | the `/__sl/raw/` URL as a string export |
+
+A `Built` holds the compiled `body`, plus what `serve` needs later: `specs`
+(byte ranges of every import specifier, from oxc's module record), `globs`
+(byte ranges and options of every `import.meta.glob(...)` call,
+`src/transform/glob.rs`), the CSS blocks, the hoisted scripts, warnings and
+an island count.
+
+### The cache key
+
+`build` hashes (xxh3-128) the following, NUL-separated, and uses the result
+as the cache key:
+
+1. the kind tag — `m`, `s<i>`, `j<i>`, `r`, `u`;
+2. the path;
+3. `site` from the tenant's `sandbox-lite.json`, or empty — the compiler
+   bakes it into the output (`astro_global_args`);
+4. only for `.scss`/`.sass` files and `.astro` files whose source contains
+   `lang="scss"` or `lang="sass"`: the Sass fingerprint (below);
+5. the file's bytes.
+
+Not in the key: the tenant id, the version, the CDN, `package.json`,
+`tsconfig.json`, and the tenant's other files except through the fingerprint.
+So the cache is content-addressed: two tenants with byte-identical files share
+one entry, and a changed file simply hashes to a new key — nothing is
+invalidated explicitly.
+
+The cache (`Engine::cache`) is a `HashMap<u128, Arc<Built>>` behind a mutex
+with a `VecDeque` of insertion order. The budget (`--cache-mb`, default 64
+MiB) counts `body` bytes; when exceeded, the oldest-inserted entries are
+dropped (FIFO, not LRU). `/api/stats` reports entries, bytes, hits and misses.
+
+### Why resolution and `import.meta.glob` happen at serve time
+
+The compiled body contains the specifiers as written — `./Header`,
+`@/data/products`, `react` — and `import.meta.glob("./posts/*.md")` calls as
+written. What they resolve to is a property of the tenant, not of the file:
+
+- `./Header` is `Header.astro` in one tenant and `Header.tsx` in another
+  (`Resolver::probe` tries extensions, then `index` files);
+- the set of files matching `./posts/*.md` is the tenant's file list;
+- every emitted URL must carry the tenant's current `?v=`.
+
+None of that can live in a content-addressed entry, so `Engine::serve` does it
+on every request: it resolves each `spec` with the `Resolver`, expands each
+glob against `tenant.list()` (`glob::expand` writes hoisted
+`import * as __sl_glob<i>_<j> from "/__sl/m/<file>?v=N"` statements for
+`eager: true`, or `() => import(...)` thunks otherwise, keyed relative to the
+importer or absolute when the pattern is), prepends
+`import.meta.env = globalThis.__sl_env || {};` when the module needs it, and
+splices the replacements into the body by byte range. The compile is cached;
+the splice is cheap and never is.
+
+### Resolution order (`src/resolve.rs`)
+
+For a specifier in `importer`, `Resolver::resolve` returns the first of:
+
+1. the specifier itself when it is external (`http://`, `https://`, `//`,
+   `data:`, `blob:`, `/__sl/`);
+2. `/__sl/shim/astro-<name>.js` for `astro:<name>`, and a shim for
+   `astro/components`, `astro/zod`, `astro/config`, `astro/loaders`,
+   `astro/types`;
+3. for `./`, `../`, `/`-rooted and `tsconfig` `paths` specifiers: the first
+   existing file among the candidate plus `""`, `.ts`, `.tsx`, `.js`, `.jsx`,
+   `.mjs`, `.mts`, `.json`, `.astro`, `.md`, `.mdx`, then `/index.*` — as
+   `/__sl/m/<path>?<query>&v=N`; or `/__sl/missing.js?spec=…&from=…` when
+   nothing exists;
+4. a `sandbox-lite.json` `imports` entry (exact key, or prefix when the key
+   ends with `/`);
+5. the CDN: `<cdn>/<name>@<range><subpath>` when `package.json` lists the
+   package with a plain version range, else `<cdn>/<specifier>`.
+
+The shim modules under `assets/shims/` go through the same resolver when
+served (`preview::shim`), so a shim can import `astro:*` or a bare package.
+
+### The Sass fingerprint
+
+`scss::fingerprint` XORs a hash of the path and content of every `.scss` and
+`.sass` file in the tenant. Because a Sass module's output depends on the
+partials it `@use`s, and those are other files, the fingerprint is part of the
+cache key of every Sass-consuming module: editing any Sass file changes the
+key of all of them. Coarse, and correct.
+
+## Versions, browser cache and SSE
+
+The version does three jobs:
+
+- **Cache busting.** Every module URL the daemon emits carries
+  `?v=<version at serve time>`, and `preview::module` marks such responses
+  `immutable`. After an edit the version is higher, every URL is new, and the
+  browser fetches fresh; the old URLs stay in its cache harmlessly. The daemon
+  does not read the value of `v` — it only checks that the parameter is
+  present — and always serves the file's current content.
+- **Reload.** `live.js` reloads the page on any `update`/`delete` event, and
+  on the `hello` event when the daemon's version is higher than the one baked
+  into the shell — which covers an edit that landed between the shell and the
+  `EventSource` connecting, and a daemon restart, since restored tenants get a
+  fresh version.
+- **Editor refresh.** The editor subscribes to `/api/t/{id}/events` to reload
+  its file list and the open file.
+
+The transform cache never sees the version; it is content-addressed.
+
+## Content collections and Markdown (`src/transform/content.rs`)
+
+`/__sl/content/<name>` reads `src/content/<name>/` and returns entries:
+`.md`/`.mdx`/`.markdown` with parsed YAML frontmatter as `data`, the body,
+the rendered HTML and headings; `.json` arrays as one entry per item, other
+JSON as one entry; `.yaml`/`.yml` as one entry. The `astro:content` shim
+fetches that JSON,
+revives ISO dates, and implements `getCollection`, `getEntry` and `render`
+on top of it. `content.config.ts` is not executed.
+
+## `check` (`src/check.rs`)
+
+`sandbox-lite check DIR…` loads each directory as a base, creates an
+in-memory tenant on it, and calls `Engine::build(…, Kind::Module)` on every
+source file under `src/` (`.astro`, `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`,
+`.mts`, `.md`). It prints diagnostics and a census — islands, glob calls,
+Sass, MDX, endpoints, `@astrojs/*` integrations, bare imports — and exits 1 on
+compile errors, 2 when a directory cannot be loaded. `/api/t/{id}/check` and
+`/__sl/check` run the same loop (`api::check_tenant`) on a live tenant; the
+error page uses the latter.
+
+## Chat (`src/http/ai.rs`)
+
+`POST /api/t/{id}/chat` runs a tool loop against the Anthropic Messages API
+with five tools scoped to the tenant — `list_files`, `read_file`,
+`write_file`, `delete_file`, `check_site` — for at most 16 rounds, and returns
+the model's last text, the changed paths and the tenant version. Writes go
+through the same `Tenant::write` as the editor, so previews follow.
+
+## Layout
+
+```
+src/main.rs            flags, base loading, restore, listener
+src/store.rs           Base, Tenant (overlay, version, events, persistence), Store, clean_path, valid_id
+src/http/mod.rs        routers, host dispatch, the two token middlewares, MIME table
+src/http/api.rs        editor page, /api handlers, SSE, check_tenant
+src/http/preview.rs    tenant-host handlers: shell, modules, raw, routes, renderers, shims, content
+src/http/ai.rs         chat tool loop
+src/resolve.rs         Resolver, CDN URLs, renderers, sandbox-lite.json, tsconfig paths
+src/routes.rs          src/pages → route table
+src/transform/mod.rs   Engine, cache, Built, serve-time splice
+src/transform/astro.rs astro_codegen wrapper
+src/transform/js.rs    oxc transform and import scanning
+src/transform/css.rs   CSS-as-module, relative URL rewriting
+src/transform/scss.rs  grass over the tenant tree, fingerprint
+src/transform/glob.rs  import.meta.glob detection and expansion
+src/transform/markdown.rs, content.rs   Markdown pages and collections
+src/check.rs           the check subcommand
+assets/shell.html, shell.js, live.js    the browser side of a render
+assets/editor.html     the editor
+assets/astro.js        Astro runtime + container, built by scripts/build-runtime.sh
+assets/shims/          browser stand-ins for astro:* modules and the React/Preact renderers
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,139 @@
+# Contributing
+
+sandbox-lite is one Rust binary plus a handful of browser assets. There is no
+Node.js in the build or at runtime: the Astro runtime the browser needs is
+committed as `assets/astro.js`, and every file under `assets/` is embedded in
+the binary with `include_str!`, so editing an asset means rebuilding.
+
+## Build and run
+
+A current stable toolchain is required: the crate is edition 2024 and uses let
+chains. CI runs the latest stable (`dtolnay/rust-toolchain@stable`). The
+compiler (`astro_codegen`) and the oxc fork it builds on are git dependencies
+pinned by revision in `Cargo.toml`, so the first build needs network access
+and takes a while.
+
+```sh
+cargo build --release
+./target/release/sandbox-lite --no-persist     # bases: ./examples/*, editor at http://localhost:4321/
+```
+
+`cargo run -- --no-persist` is the same without the release profile.
+Without `--no-persist`, tenant edits are written under `./data` (gitignored).
+Open the editor, create a tenant from a base, and the preview is at
+`http://<id>.localhost:4321/`. `sandbox-lite --help` lists every flag; `check`
+compiles a project without serving it:
+
+```sh
+./target/release/sandbox-lite check examples/*
+./target/release/sandbox-lite check --json path/to/theme
+```
+
+`ARCHITECTURE.md` says what each module does and how a page is rendered; read
+it before changing `src/transform/` or `assets/shell.js`.
+
+## The bundled Astro runtime
+
+`assets/astro.js` is Astro's server runtime plus the container API, bundled
+for the browser by `scripts/build-runtime.sh` (needs `npm`; `ASTRO_VERSION`
+and `ESBUILD_VERSION` select the versions, defaults in the script). The script
+also refreshes `assets/viewtransitions.css` and writes the version to
+`assets/astro.version`, which `/api/stats` reports as `astro`.
+
+**The compiler and the runtime move together.** The compiler in `Cargo.toml`
+(`astro_codegen`, a `rev` of `withastro/compiler-rs`) emits code that imports
+helpers from `/__sl/astro.js` (`src/transform/astro.rs` passes that URL as
+`internal_url`; `src/transform/markdown.rs` imports `createComponent`,
+`render`, `renderComponent`, `unescapeHTML` from it). A compiler from one
+Astro version calling into a runtime from another breaks every page. So a bump
+is one change:
+
+1. Move the `astro_codegen` `rev` (and the `withastro/oxc` revs it expects) in
+   `Cargo.toml`.
+2. Run `ASTRO_VERSION=x.y.z scripts/build-runtime.sh`; commit `assets/astro.js`,
+   `assets/viewtransitions.css` and `assets/astro.version`.
+3. `cargo test`, `sandbox-lite check examples/*`, and open each example in a
+   browser — the runtime only runs there.
+
+`assets/shell.js` and `assets/live.js` need no version bump when edited: the
+ETag the daemon sends for `/__sl/astro.js`, `/__sl/shell.js` and
+`/__sl/live.js` is a hash of the three files (`asset_version` in
+`src/http/preview.rs`).
+
+## Measuring memory
+
+```sh
+bench/mem.sh [tenants] [port]        # defaults: 200 tenants, port 4399
+```
+
+It starts the release binary with a temporary data dir, creates N tenants from
+`examples/starter`, writes one page in each, fetches each tenant's shell,
+routes, module graph and a content collection, and prints the daemon's RSS
+before and after plus the transform-cache statistics from `/api/stats`. It
+needs Linux (`/proc`), `curl` and `python3`. CI runs `bench/mem.sh 100 4398`.
+Quote its numbers in the pull request, not in code comments.
+
+## Before opening a pull request
+
+CI (`.github/workflows/ci.yml`) runs exactly this; run it locally first:
+
+```sh
+cargo fmt --check
+cargo clippy --all-targets -- -D warnings
+cargo test
+cargo build --release && ./target/release/sandbox-lite check examples/*
+```
+
+Formatting follows `rustfmt.toml` (140 columns). Clippy warnings are errors.
+`check` must exit 0 for every example — it is the compile-level regression
+test for the transform pipeline. CI also starts the daemon, creates a tenant
+with `curl`, and fetches one module, `routes.json` and the shell.
+
+Beyond what CI can see:
+
+- If you touched `src/transform/`, `src/resolve.rs`, `assets/shell.js` or a
+  shim, load the affected example in a browser. CI only `curl`s; rendering
+  happens in the browser.
+- If behaviour changed, change the document that describes it — `README.md`,
+  `ARCHITECTURE.md`, `SECURITY.md` — and verify the sentence against the code,
+  not against the issue that asked for the change.
+- A new route on the tenant host is open to whoever can open the preview; a
+  new route on the API host is behind `--api-token` unless you exempt it. Say
+  in the PR which one you added and why.
+
+The pull request template carries this list.
+
+## Comments
+
+Default: none. Let the code say it.
+
+Write a comment only when it says something the code cannot, and keep it to a
+line:
+
+- why a choice was made, not what the code does;
+- an outside constraint that makes correct code look wrong;
+- an outside system's odd behaviour.
+
+Two from this codebase: `src/transform/css.rs` explains why relative `url()`
+targets are rewritten ("the CSS ends up in a `<style>` tag whose base URL is
+the page, not the file"); `assets/shims/astro-content.js` explains why dates
+are revived ("YAML parses bare dates as timestamps; the daemon serialises them
+as strings").
+
+Do not write comments that restate the code, comments that describe what the
+code used to do, or measurements, run ids and PR numbers — those belong in the
+commit message and the pull request. If the comment is longer than the code, or
+the code already says it, delete it.
+
+## Commits, issues, labels
+
+- One concern per commit; the message says why. Commit messages so far use a
+  `scope: what` first line (`ci: …`, `sandbox-lite: …`).
+- Issues use the forms under `.github/ISSUE_TEMPLATE/`. `bug` and `feature`
+  are applied by the forms; `security`, `ops` and `docs` by hand.
+  `agent-task` marks an issue scoped tightly enough for an autonomous agent to
+  implement as a PR; `needs-review` marks a PR waiting for a maintainer.
+- Commenting `@claude` on an issue or pull request starts the assistant
+  workflow (`.github/workflows/claude.yml`); a weekly audit
+  (`.github/workflows/audit.yml`) opens issues for what it can demonstrate.
+- Vulnerabilities go through `SECURITY.md`, not the issue tracker.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ machine at all.
 Per-tenant state is the overlay (only edited files) plus a content-addressed
 transform cache shared by every tenant: two tenants with the same `Header.astro`
 share one compiled output. The cache has a byte budget (`--cache-mb`, default
-64) so the daemon's memory is bounded regardless of tenant count.
+64), so its share of the daemon's memory is bounded regardless of tenant count;
+overlays grow with what tenants write.
 
 ## Try it
 
@@ -170,7 +171,7 @@ Tenant host (`<id>.<domain>`):
 ## How a page renders
 
 1. `GET http://acme.localhost:4321/blog/hello-world` → the daemon answers with a
-   30-line shell that carries the tenant id, version and `import.meta.env`.
+   short shell page that carries the tenant id, version and `import.meta.env`.
 2. `shell.js` fetches `routes.json`, matches the path, and `import()`s
    `/__sl/m/src/pages/blog/[slug].astro?v=…`.
 3. The daemon compiles that file with `astro_codegen`, parses the output with
@@ -203,7 +204,7 @@ src/transform/         astro (astro_codegen), js (oxc), css, scss (grass), impor
 src/http/              host-based dispatch, auth, editor API, preview endpoints, Claude chat loop
 src/check.rs           the `check` subcommand
 assets/                shell.html, shell.js, live.js, editor.html, astro.js bundle, astro:* shims
-examples/starter       a dependency-free Astro 7 site used as the default base
+examples/starter       a dependency-free Astro 7 site; the base CI's smoke test and bench/mem.sh use
 examples/tailwind      Tailwind v4 through its browser build
 examples/react         a React island hydrated with client:load
 scripts/build-runtime.sh   regenerates assets/astro.js for a new Astro version
@@ -224,8 +225,11 @@ bench/mem.sh           the memory measurement above
   theme; custom loaders are ignored.
 - **`astro.config.*`** is not executed. `site` can be set in `sandbox-lite.json`
   (`{"site": "https://example.com", "imports": {"react": "https://esm.sh/react@19"}}`).
-- **Authentication.** The editor and `/api/*` trust every caller; put them
-  behind your product's own auth and expose only the tenant hosts to customers.
+- **Authentication.** There are no users: `--api-token` is one shared bearer
+  token for `/api/*`, and `--preview-secret` gates tenant hosts with per-tenant
+  links; both are off by default. Put the editor and `/api/*` behind your
+  product's own auth and expose only the tenant hosts to customers. See
+  `SECURITY.md`.
 - **Production builds.** This is the preview. Ship with `astro build` as usual;
   the compiled output is the same compiler, so what you see is what builds.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,198 @@
+# Security
+
+This document describes what sandbox-lite enforces, what it leaves to the
+operator, and how to report a vulnerability. Every statement below is about the
+code in `src/` and `assets/` as it is; where the README is looser, this
+document wins.
+
+## Reporting a vulnerability
+
+Report privately through GitHub's vulnerability reporting for this repository:
+<https://github.com/productdevbook/sandbox-lite/security/advisories/new>
+(Security tab → Advisories → Report a vulnerability). Do not open a public
+issue for anything that lets one tenant read or write another tenant, reach the
+editor or API from a preview host, or read files outside a tenant's tree.
+
+Include the commit (`git rev-parse HEAD` — there are no tagged releases; `main`
+is the only supported line), the flags the daemon was started with, and a
+reproduction as requests: `Host` header, path, body, and the tenant files
+involved.
+
+## What runs where
+
+One process, one listener (`--listen`, default `127.0.0.1:4321`). The `Host`
+header of each request decides which of two routers answers
+(`dispatch` and `tenant_from_host` in `src/http/mod.rs`):
+
+| Host | Router | Contents |
+|---|---|---|
+| `<id>.<domain>` — exactly one label before `--domain`, and the label is a valid tenant id (1–63 bytes of `a-z`, `0-9`, `-`, no leading or trailing dash) | tenant | the shell page, `public/` files and everything under `/__sl/` for that tenant |
+| anything else — the bare domain, the daemon's IP address, a name with two labels, a missing `Host` header | editor / API | `/` (the editor), `/health`, `/api/*` |
+
+So the editor and the API are not only "on the bare domain": they answer on
+every hostname that does not parse as a tenant host. Put the daemon behind a
+proxy that only forwards the hostnames you intend, and treat every request
+that reaches the editor/API router as coming from your own backend.
+
+Tenant files never run inside the daemon. The daemon compiles `.astro`
+(astro_codegen), TypeScript/JSX (oxc), Sass (grass), Markdown (pulldown-cmark)
+and parses JSON/YAML; the resulting JavaScript runs in the visitor's browser on
+the tenant origin, using Astro's own runtime bundled as `/__sl/astro.js`.
+
+Whoever can call `/api/*` owns every tenant: create, delete, read and write any
+file, drive the chat endpoint. There are no users, roles or per-tenant
+credentials on the API side.
+
+## What the daemon enforces
+
+- **Paths.** Every file path taken from a request — `/api/t/{id}/file/{path}`,
+  `/__sl/m/{path}`, `/__sl/raw/{path}`, the page fallback that serves
+  `public/`, and the paths the chat tools receive — goes through `clean_path`
+  (`src/store.rs`): the leading `/` is dropped, empty and `.` segments are
+  removed, and the path is rejected if it is empty, contains `\` or a NUL
+  byte, or has any `..` segment. Paths are relative to the tenant tree and
+  cannot leave it.
+- **Tenant ids** are validated by `valid_id` (same rule as the host label) and
+  are used as directory names under `--data-dir`.
+- **Base projects** are read once at startup. `node_modules`, `.git`, `dist`,
+  `.astro`, `.vercel`, `.netlify` and `.output` are skipped, and so is anything
+  that is not a regular file or directory (symbolic links are not followed).
+- **Request bodies** on the editor/API router are capped at 64 MiB
+  (`DefaultBodyLimit`). No tenant-host handler reads a request body.
+- **Host matching** is exact: `a.b.<domain>` and `evil-<domain>` are not tenant
+  hosts.
+- **The preview cookie** (`sl_t`) is set with `Path=/; HttpOnly; SameSite=Lax`
+  and no `Domain` attribute, so it is a host-only session cookie for that one
+  tenant host. `Secure` is added only when the request carried
+  `x-forwarded-proto: https`.
+
+The daemon sets no CORS, CSP, `X-Frame-Options` or `Referrer-Policy` headers.
+Cross-origin reads between tenant hosts are blocked by the browser's
+same-origin policy because no CORS headers are sent; framing and navigation
+between hosts are not restricted.
+
+## The two authentication flags
+
+Both are off unless set. `SANDBOX_LITE_API_TOKEN` and
+`SANDBOX_LITE_PREVIEW_SECRET` are read as defaults (empty values are ignored).
+The Docker image sets neither, so a container started without environment
+variables is fully open on `0.0.0.0:4321`.
+
+### `--api-token TOKEN` (`require_api_token`, `src/http/mod.rs`)
+
+Wraps the editor/API router. `/` and `/health` are exempt; everything else on
+that router answers `401` unless the request carries
+`Authorization: Bearer TOKEN` or `?token=TOKEN`.
+
+- It is one shared secret. There is no way to hand a caller access to a single
+  tenant through the API.
+- The query form exists because `EventSource` cannot set headers (the editor
+  uses it for `/api/t/{id}/events`); a token in a URL ends up in proxy and
+  access logs.
+- The editor page keeps the token in `localStorage` (`sl_api_token`) on the
+  editor origin.
+- It gates spending: every `POST /api/t/{id}/chat` can make up to 16 calls to
+  the Anthropic API with the daemon's `ANTHROPIC_API_KEY`.
+- It does nothing for tenant hosts.
+
+### `--preview-secret S` (`require_preview_token`, `src/http/mod.rs`)
+
+Wraps the whole tenant router: the shell, `public/` files and every `/__sl/`
+endpoint, including `/__sl/raw/`, `/__sl/events` and `/__sl/check`.
+
+- The per-tenant token is `preview_token(S, id)`: the first 32 hex characters
+  of a BLAKE3 keyed hash of the tenant id, with the key derived from `S`. It
+  is a pure function of the secret and the id: it never expires and cannot be
+  revoked for one tenant. Rotating `S` invalidates every tenant's link at once.
+- `GET http://<id>.<domain>/any/path?sl_token=<token>`: a wrong token answers
+  `403`; the right one answers `303` to the same path with the parameter
+  removed and sets the `sl_t` cookie described above. Later requests are
+  accepted when the cookie equals the token, otherwise `403`.
+- `/api/tenants` returns each tenant's `preview_token` and a ready-made
+  `preview` link, so anyone with API access can open every preview.
+- The `preview` link the API builds is
+  `http://<id>.<domain>:<port>/?sl_token=…` — plain `http` and the daemon's
+  own listen port, whatever proxy is in front. Behind TLS, build the link
+  yourself from `preview_token`.
+- It does nothing for the editor/API router.
+
+## Tenant files are public to anyone who can open the preview
+
+`/__sl/raw/<path>` returns any file of the tenant (base project plus overlay)
+as-is, and `/__sl/m/<path>?raw` returns it as a module. That includes `.env`,
+`package.json`, `sandbox-lite.json` and every source file. Only the shell's
+`import.meta.env` is filtered to `PUBLIC_*` keys; the `.env` file itself is
+not. The compiled output of every page and component is served too, because
+that is what the browser renders.
+
+Do not put secrets in base projects or tenant trees. With `--preview-secret`
+the audience is "whoever has the tenant's link"; without it, the audience is
+the network.
+
+## Put previews on their own registrable domain
+
+Tenant JavaScript runs on `<id>.<domain>`. The daemon's own cookie is
+host-only, but cookies set by the operator's other services are governed by
+browser rules, not by the daemon:
+
+- A cookie set with `Domain=example.com` is sent by the browser with every
+  request a page on `acme.preview.example.com` makes to `*.example.com`, and
+  is readable through `document.cookie` unless it is `HttpOnly`.
+- `SameSite=Lax` and `SameSite=Strict` compare registrable domains.
+  `acme.preview.example.com` and `app.example.com` are the same site, so
+  `SameSite` does not stop a tenant page from making credentialed requests to
+  `app.example.com`.
+
+The consequence: never set a cookie whose `Domain=` covers the preview hosts,
+and, because the second point holds even for host-only cookies on your
+product's domain, run previews on a separate registrable domain
+(`example-preview.net`, not `preview.example.com`) or on a name registered on
+the Public Suffix List. Keep the editor and the API off that domain: the
+editor stores the API token in `localStorage` and embeds tenant previews in an
+`<iframe>`, which is safe only while the two are different origins.
+
+## What leaves the machine
+
+- **Anthropic API.** When `ANTHROPIC_API_KEY` is set, `POST /api/t/{id}/chat`
+  sends to `https://api.anthropic.com/v1/messages`: the conversation the
+  caller supplies, a system prompt containing the tenant id and base name, and
+  every tool result — the file listing, the contents of any file the model
+  reads (up to 200 KiB per file, any path in the tenant), and `check`
+  diagnostics. `write_file` and `delete_file` take effect on the tenant
+  immediately, without confirmation. Without the key the endpoint answers
+  `503` and nothing is sent.
+- **CDN, in the visitor's browser.** Bare imports (`react`, `dayjs`) resolve to
+  `--cdn` (default `https://esm.sh`) with the version range from
+  `package.json`; React and Preact client entrypoints come from the same CDN.
+  `sandbox-lite.json` `imports` can map a specifier to any URL, and tenant
+  code can import any absolute URL directly. Tailwind's browser build is
+  always loaded from `https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4`
+  (hard-coded in `assets/shell.js`); `--cdn` does not change that.
+
+## Limits that do not exist
+
+- No rate limiting on any route.
+- Compilation is CPU work per request; `/__sl/check` and `/api/t/{id}/check`
+  build every source file of a tenant on every call — a cache hit for an
+  unchanged file, a compile for a changed one.
+- The transform cache is bounded by `--cache-mb`; tenant overlays are not. A
+  caller with API access can create any number of tenants and write files of
+  up to 64 MiB each. With persistence every write goes to disk under
+  `--data-dir`, and files over 256 KiB are kept only there and re-read on
+  demand; with `--no-persist`, every written file is held in memory whatever
+  its size.
+- Tenant code is limited only by the visitor's browser.
+
+## Deployment checklist
+
+1. Previews on their own registrable domain; wildcard DNS for it; `--domain`
+   set to that name.
+2. Editor and `/api/*` reachable only from your backend, on a hostname the
+   proxy does not expose; `--api-token` set as well.
+3. `--preview-secret` set; links built from `preview_token` with your scheme
+   and host; the TLS proxy sends `x-forwarded-proto: https` so the cookie is
+   `Secure`.
+4. No secrets in base projects or tenant files.
+5. Your own limits on tenant count, write volume and request rate.
+6. `ANTHROPIC_API_KEY` only if the chat endpoint is wanted, knowing what it
+   sends and that the API token is the only thing gating it.


### PR DESCRIPTION
Closes #5

Adds `SECURITY.md`, `CONTRIBUTING.md`, `ARCHITECTURE.md`, two issue forms (bug, feature) with a chooser config, and a pull request template. Every behavioural sentence was checked against `src/` and `assets/`, not against the README; file and function names are cited so the check can be repeated.

## README claims the code contradicts (corrected in this PR)

1. **"The cache has a byte budget … so the daemon's memory is bounded regardless of tenant count."** Only the transform cache is bounded (`Engine::insert`, `src/transform/mod.rs`). `Tenant::write` (`src/store.rs`) has no budget: with `--no-persist` every written file is held in memory whatever its size, up to the 64 MiB body limit per request, for any number of files and tenants. Reworded to say the cache's share is bounded.
2. **"Authentication. The editor and `/api/*` trust every caller."** Not once `--api-token` is set: `require_api_token` (`src/http/mod.rs`) answers 401 on everything but `/` and `/health`. Reworded to describe the two flags and point at `SECURITY.md`.
3. **"examples/starter … used as the default base."** Nothing selects a default: the editor fills its base `<select>` from `/api/bases`, which `Store::bases` sorts by name, so `react` is the first option. `starter` is what CI's smoke test and `bench/mem.sh` use. Reworded.
4. **"the daemon answers with a 30-line shell."** `assets/shell.html` is 12 lines. Reworded to "short shell page".

## README wording looser than the code (left as is; the new documents state it precisely)

- "Editor host (`localhost`)": the editor/API router answers on every `Host` that does not parse as `<id>.<domain>` — the bare domain, the raw IP, a two-label name, a missing `Host` header (`dispatch` / `tenant_from_host`). `SECURITY.md` says so and tells operators to forward only the intended hostnames.
- "keep `/` and `/api` reachable only from your own backend": right, and in addition the API's `preview` link is built as `http://<id>.<domain>:<port>/?sl_token=…` (`api::preview_url`) — plain http with the listen port regardless of any proxy — and the cookie is `Secure` only when the request carries `x-forwarded-proto: https`. `SECURITY.md` covers both.
- "two tenants with the same `Header.astro` share one compiled output": also requires the same `site` in `sandbox-lite.json` and, for Sass-using files, the same Sass fingerprint — both are in the cache key (`Engine::build`). `ARCHITECTURE.md` lists the key.
- The HTTP surface table omits `GET /health`, `GET /api/bases`, and the tenant-host `/__sl/check`, `/__sl/shell.js`, `/__sl/live.js`, `/__sl/missing.js`. `ARCHITECTURE.md` lists both routers in full.
- `--cdn` does not cover Tailwind: `assets/shell.js` hard-codes `https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4`. The README does not claim otherwise; `SECURITY.md` states it under "What leaves the machine".

## Needs a maintainer action

`SECURITY.md` and the issue chooser point at GitHub private vulnerability reporting (`/security/advisories/new`). That feature is currently **disabled** on this repository (`GET /repos/productdevbook/sandbox-lite/private-vulnerability-reporting` → `{"enabled": false}`). Please enable it under Settings → Code security and analysis → Private vulnerability reporting, or say which channel you prefer and I will change the document.

## Verified on this branch

`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (13 passed), `cargo build --release`, `./target/release/sandbox-lite check examples/*` (0 errors in react, starter, tailwind) — the checklist `CONTRIBUTING.md` and the PR template prescribe.

## Noticed, did not fix

- `src/routes.rs`: the sort's `.then(b.key.len().cmp(&a.key.len()))` can never decide anything — `then` only runs when the keys compare equal, and equal `Vec<u8>` have equal length. Harmless; `ARCHITECTURE.md` documents the order the code actually produces.
- `src/http/mod.rs`: the API token and the preview token are compared with `==`, not a constant-time comparison.
- `src/transform/mod.rs`: the cache budget counts `body.len()` only; each entry's `css`, `scripts`, `specs` and `globs` vectors are not counted.
- `src/http/preview.rs`: `%ENV%` is spliced into the shell's `<script>` as JSON without escaping `<`; a `PUBLIC_*` value containing `</script>` breaks out of the tag. It is the tenant's own origin, so not a boundary crossing, but `<`-escaping would close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
