### PR TITLE
ci: Playwright end-to-end suite for the browser side

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,29 @@ jobs:
           curl -sf -H 'Host: ci.localhost' 'http://127.0.0.1:4399/__sl/routes.json' | grep -q '"/blog/\[slug\]"'
           curl -sf -H 'Host: ci.localhost' 'http://127.0.0.1:4399/' | grep -q shell.js
       - run: bench/mem.sh 100 4398
+  e2e:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --release
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: e2e/package-lock.json
+      - run: npm ci
+        working-directory: e2e
+      - run: npx playwright install --with-deps chromium
+        working-directory: e2e
+      - run: npx playwright test
+        working-directory: e2e
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: |
+            e2e/playwright-report
+            e2e/test-results

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /data
 node_modules
 /.claude/
+/e2e/test-results
+/e2e/playwright-report

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ examples/tailwind      Tailwind v4 through its browser build
 examples/react         a React island hydrated with client:load
 scripts/build-runtime.sh   regenerates assets/astro.js for a new Astro version
 bench/mem.sh           the memory measurement above
+e2e/                   Playwright suite for the browser side: every example page, live reload, hydration, the error overlay
 ```
 
 ## What the preview does not do

--- a/e2e/daemon.ts
+++ b/e2e/daemon.ts
@@ -1,0 +1,97 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { createServer, type AddressInfo } from 'node:net';
+import path from 'node:path';
+
+const root = path.resolve(__dirname, '..');
+const binary = process.env.SANDBOX_LITE_BIN ?? path.join(root, 'target', 'release', 'sandbox-lite');
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address() as AddressInfo;
+      server.close((err) => (err ? reject(err) : resolve(port)));
+    });
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class Tenant {
+  constructor(
+    private readonly daemon: Daemon,
+    readonly id: string,
+  ) {}
+
+  url(pathname = '/'): string {
+    return `http://${this.id}.localhost:${this.daemon.port}${pathname}`;
+  }
+
+  async read(file: string): Promise<string> {
+    const res = await fetch(`${this.daemon.api}/api/t/${this.id}/file/${file}`);
+    if (!res.ok) throw new Error(`GET ${file} on tenant ${this.id}: ${res.status} ${await res.text()}`);
+    return res.text();
+  }
+
+  async write(file: string, body: string): Promise<void> {
+    const res = await fetch(`${this.daemon.api}/api/t/${this.id}/file/${file}`, { method: 'PUT', body });
+    if (!res.ok) throw new Error(`PUT ${file} on tenant ${this.id}: ${res.status} ${await res.text()}`);
+  }
+}
+
+export class Daemon {
+  readonly api: string;
+
+  constructor(
+    readonly port: number,
+    private readonly child: ChildProcess,
+  ) {
+    this.api = `http://127.0.0.1:${port}`;
+  }
+
+  // Deleting first keeps a retried or repeated test on a pristine copy of the base.
+  async tenant(id: string, base: string): Promise<Tenant> {
+    await fetch(`${this.api}/api/tenants/${id}`, { method: 'DELETE' });
+    const res = await fetch(`${this.api}/api/tenants`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ id, base }),
+    });
+    if (res.status !== 201) throw new Error(`POST /api/tenants {${id}, ${base}}: ${res.status} ${await res.text()}`);
+    return new Tenant(this, id);
+  }
+
+  async stop(): Promise<void> {
+    if (this.child.exitCode !== null) return;
+    const exited = new Promise<void>((resolve) => this.child.once('exit', () => resolve()));
+    this.child.kill();
+    await Promise.race([exited, sleep(2000)]);
+    if (this.child.exitCode === null) this.child.kill('SIGKILL');
+  }
+}
+
+export async function startDaemon(): Promise<Daemon> {
+  const port = await freePort();
+  const args = ['--listen', `127.0.0.1:${port}`, '--bases', path.join(root, 'examples'), '--no-persist'];
+  const child = spawn(binary, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+  let stderr = '';
+  child.stderr!.on('data', (chunk) => (stderr += chunk));
+  await new Promise<void>((resolve, reject) => {
+    child.once('spawn', resolve);
+    child.once('error', reject);
+  });
+  const deadline = Date.now() + 10_000;
+  for (;;) {
+    if (child.exitCode !== null) throw new Error(`${binary} exited with ${child.exitCode} before answering /health\n${stderr}`);
+    const healthy = await fetch(`http://127.0.0.1:${port}/health`).then((res) => res.ok, () => false);
+    if (healthy) return new Daemon(port, child);
+    if (Date.now() > deadline) {
+      child.kill();
+      throw new Error(`${binary} did not answer /health within 10 s\n${stderr}`);
+    }
+    await sleep(50);
+  }
+}

--- a/e2e/error-overlay.spec.ts
+++ b/e2e/error-overlay.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from './fixtures';
+
+test('a compile error shows the overlay with file:line:column and the fix recovers', async ({ daemon, page, browserLog }) => {
+  const site = await daemon.tenant('broken', 'starter');
+  await page.goto(site.url('/'));
+  await expect(page).toHaveTitle('Home · Lumen Studio');
+
+  const original = await site.read('src/pages/index.astro');
+  const broken = original.replace('const headline = "Design that ships.";', 'const headline = ;');
+  expect(broken).not.toBe(original);
+  await site.write('src/pages/index.astro', broken);
+
+  await expect(page).toHaveTitle('Render failed');
+  await expect(page.locator('h1')).toHaveText('Render failed');
+  await expect(page.locator('li b')).toHaveText(/^src\/pages\/index\.astro:6:\d+$/);
+  await expect(page.locator('li')).toContainText('Unexpected token');
+
+  const { consoleErrors, failedRequests } = browserLog.take();
+  expect(failedRequests.length, 'the module request fails').toBeGreaterThan(0);
+  expect(consoleErrors.length, 'the failure is logged').toBeGreaterThan(0);
+  for (const entry of [...failedRequests, ...consoleErrors]) {
+    expect(entry, 'nothing fails except the broken module').toContain('/__sl/m/src/pages/index.astro');
+  }
+
+  await site.write('src/pages/index.astro', original);
+  await expect(page).toHaveTitle('Home · Lumen Studio');
+  await expect(page.locator('h1')).toHaveText('Design that ships.');
+});

--- a/e2e/fixtures.ts
+++ b/e2e/fixtures.ts
@@ -1,0 +1,59 @@
+import { test as base, expect, type ConsoleMessage, type Page } from '@playwright/test';
+import { type Daemon, startDaemon } from './daemon';
+
+export { expect };
+
+// The react example renders through esm.sh and the tailwind example styles through jsdelivr.
+export const CDN_TIMEOUT = 45_000;
+
+function format(message: ConsoleMessage): string {
+  const { url } = message.location();
+  return url ? `${message.text()} (${url})` : message.text();
+}
+
+export class BrowserLog {
+  readonly consoleErrors: string[] = [];
+  readonly failedRequests: string[] = [];
+
+  constructor(page: Page) {
+    page.on('console', (message) => {
+      if (message.type() === 'error') this.consoleErrors.push(format(message));
+    });
+    page.on('pageerror', (error) => this.consoleErrors.push(`uncaught ${error.message}`));
+    page.on('requestfailed', (request) => this.failedRequests.push(`${request.method()} ${request.url()}: ${request.failure()?.errorText}`));
+    page.on('response', (response) => {
+      if (response.status() >= 400) this.failedRequests.push(`${response.request().method()} ${response.url()}: ${response.status()}`);
+    });
+  }
+
+  take(): { consoleErrors: string[]; failedRequests: string[] } {
+    const taken = { consoleErrors: [...this.consoleErrors], failedRequests: [...this.failedRequests] };
+    this.consoleErrors.length = 0;
+    this.failedRequests.length = 0;
+    return taken;
+  }
+
+  expectClean(): void {
+    expect.soft(this.consoleErrors, 'console errors').toEqual([]);
+    expect.soft(this.failedRequests, 'failed requests').toEqual([]);
+  }
+}
+
+export const test = base.extend<{ browserLog: BrowserLog }, { daemon: Daemon }>({
+  daemon: [
+    async ({}, use) => {
+      const daemon = await startDaemon();
+      await use(daemon);
+      await daemon.stop();
+    },
+    { scope: 'worker' },
+  ],
+  browserLog: [
+    async ({ page }, use) => {
+      const log = new BrowserLog(page);
+      await use(log);
+      log.expectClean();
+    },
+    { auto: true },
+  ],
+});

--- a/e2e/hydration.spec.ts
+++ b/e2e/hydration.spec.ts
@@ -1,0 +1,16 @@
+import { CDN_TIMEOUT, expect, test } from './fixtures';
+
+test('a client:load React island hydrates and handles clicks', async ({ daemon, page }) => {
+  const site = await daemon.tenant('react', 'react');
+  await page.goto(site.url('/'));
+  const count = page.locator('.counter strong');
+  await expect(count).toHaveText('41', { timeout: CDN_TIMEOUT });
+  await expect(page.locator('astro-island:not([ssr])'), 'island hydrated').toHaveCount(1, { timeout: CDN_TIMEOUT });
+
+  await page.getByRole('button', { name: 'increment' }).click();
+  await expect(count).toHaveText('42');
+  await expect(page.locator('.counter')).toHaveAttribute('data-count', '42');
+
+  await page.getByRole('button', { name: 'decrement' }).click();
+  await expect(count).toHaveText('41');
+});

--- a/e2e/live-reload.spec.ts
+++ b/e2e/live-reload.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from './fixtures';
+
+test('a written component shows up in the open preview within 3 s', async ({ daemon, page }) => {
+  const site = await daemon.tenant('live', 'starter');
+  await page.goto(site.url('/'));
+  await expect(page.locator('footer')).toContainText('rendered live by Astro');
+
+  const footer = await site.read('src/components/Footer.astro');
+  const edited = footer.replace('rendered live by', 'edited by e2e and rendered live by');
+  expect(edited).not.toBe(footer);
+  await site.write('src/components/Footer.astro', edited);
+
+  await expect(page.locator('footer')).toContainText('edited by e2e and rendered live by Astro', { timeout: 3_000 });
+  await expect(page).toHaveTitle('Home · Lumen Studio');
+});

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,76 @@
+{
+  "name": "sandbox-lite-e2e",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sandbox-lite-e2e",
+      "devDependencies": {
+        "@playwright/test": "1.63.0",
+        "@types/node": "^24.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
+      "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "sandbox-lite-e2e",
+  "private": true,
+  "scripts": {
+    "test": "playwright test"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.63.0",
+    "@types/node": "^24.0.0"
+  }
+}

--- a/e2e/pages.spec.ts
+++ b/e2e/pages.spec.ts
@@ -1,0 +1,85 @@
+import { CDN_TIMEOUT, expect, test } from './fixtures';
+
+test.describe('starter', () => {
+  test('/', async ({ daemon, page }) => {
+    const site = await daemon.tenant('starter', 'starter');
+    await page.goto(site.url('/'));
+    await expect(page).toHaveTitle('Home · Lumen Studio');
+    await expect(page.locator('h1')).toHaveText('Design that ships.');
+    await expect(page.locator('.card')).toHaveCount(3);
+    // The like button is wired by a hoisted <script> that arrives after the page, so a click is retried until it counts.
+    const like = page.locator('[data-like]').first();
+    await expect.poll(async () => {
+      await like.click();
+      return like.locator('span').textContent();
+    }).not.toBe('0');
+  });
+
+  test('/about', async ({ daemon, page }) => {
+    const site = await daemon.tenant('starter', 'starter');
+    await page.goto(site.url('/about'));
+    await expect(page).toHaveTitle('About · Lumen Studio');
+    await expect(page.locator('h1')).toHaveText('About the studio');
+    await expect(page.locator('main li')).toHaveText([/Mara/, /Deniz/]);
+    await expect(page.locator('nav a.active')).toHaveText('About');
+  });
+
+  test('/blog', async ({ daemon, page }) => {
+    const site = await daemon.tenant('starter', 'starter');
+    await page.goto(site.url('/blog'));
+    await expect(page).toHaveTitle('Journal · Lumen Studio');
+    await expect(page.locator('h1')).toHaveText('Journal');
+    await expect(page.locator('.posts a')).toHaveText(['Why we render previews in the browser', 'Launching the journal']);
+    await expect(page.locator('.posts a').first()).toHaveAttribute('href', '/blog/hello-world');
+  });
+
+  test('/blog/hello-world', async ({ daemon, page }) => {
+    const site = await daemon.tenant('starter', 'starter');
+    await page.goto(site.url('/blog/hello-world'));
+    await expect(page).toHaveTitle('Why we render previews in the browser · Lumen Studio');
+    await expect(page.locator('h1')).toHaveText('Why we render previews in the browser');
+    await expect(page.locator('.toc a')).toHaveText(['The problem', 'The trick']);
+    await expect(page.locator('article pre code')).toContainText('AstroContainer.create()');
+  });
+
+  test('/docs', async ({ daemon, page }) => {
+    const site = await daemon.tenant('starter', 'starter');
+    await page.goto(site.url('/docs'));
+    await expect(page).toHaveTitle('Editing this site · Lumen Studio');
+    await expect(page.locator('h1')).toHaveText('Editing this site');
+    await expect(page.locator('article h2')).toHaveText(['What you can edit', 'What happens when you save']);
+    await expect(page.locator('article ol li')).toHaveCount(3);
+  });
+});
+
+test.describe('tailwind', () => {
+  test('/', async ({ daemon, page }) => {
+    const site = await daemon.tenant('tailwind', 'tailwind');
+    await page.goto(site.url('/'));
+    await expect(page).toHaveTitle('Northwind Bakery');
+    await expect(page.locator('h1')).toHaveText('Bread worth crossing town for.');
+    await expect(page.locator('main article h2')).toHaveText(['Baked at 5am', 'Local flour', 'No waste']);
+    await expect(page.locator('h1'), 'text-5xl applied by the Tailwind browser build').toHaveCSS('font-size', '48px', { timeout: CDN_TIMEOUT });
+  });
+
+  test('/menu', async ({ daemon, page }) => {
+    const site = await daemon.tenant('tailwind', 'tailwind');
+    await page.goto(site.url('/menu'));
+    await expect(page).toHaveTitle('Menu · Northwind Bakery');
+    await expect(page.locator('h1')).toHaveText('Menu');
+    await expect(page.locator('main li')).toHaveCount(4);
+    await expect(page.locator('h1'), 'text-4xl applied by the Tailwind browser build').toHaveCSS('font-size', '36px', { timeout: CDN_TIMEOUT });
+  });
+});
+
+test.describe('react', () => {
+  test('/', async ({ daemon, page }) => {
+    const site = await daemon.tenant('react', 'react');
+    await page.goto(site.url('/'));
+    await expect(page).toHaveTitle('Islands', { timeout: CDN_TIMEOUT });
+    await expect(page.locator('h1')).toHaveText('Islands in the preview');
+    await expect(page.locator('.counter strong')).toHaveText('41');
+    await expect(page.locator('.greeting h2')).toHaveText('Hello, static React');
+    await expect(page.locator('astro-island:not([ssr])'), 'island hydrated').toHaveCount(1, { timeout: CDN_TIMEOUT });
+  });
+});

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: '.',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  timeout: 60_000,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+  use: {
+    trace: 'retain-on-failure',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+});


### PR DESCRIPTION
Closes #3

## What is covered

`e2e/` is a Chromium-only Playwright suite. A worker-scoped fixture starts `target/release/sandbox-lite --bases examples --no-persist` on a free port and waits for `/health`; every test creates the tenant it uses through `POST /api/tenants` (deleting an earlier copy first), so a test that writes files never leaks into a page test running next to it.

| Spec | Checks |
|---|---|
| `pages.spec.ts` | starter `/`, `/about`, `/blog`, `/blog/hello-world`, `/docs`; tailwind `/`, `/menu`; react `/` — the title, an expected element (the three cards and a working hoisted `<script>` on the like button, the nav `active` class from `Astro.url`, the journal sorted by date, the TOC and code block of a rendered post, the markdown headings, Tailwind's `text-5xl`/`text-4xl` actually applied, a hydrated island) |
| `live-reload.spec.ts` | `PUT src/components/Footer.astro`; the open page shows the new text within 3 s, polled with `expect`, no sleeps |
| `hydration.spec.ts` | the `client:load` counter answers increment and decrement once its `astro-island` has dropped `ssr` |
| `error-overlay.spec.ts` | a broken frontmatter (`const headline = ;`) shows `Render failed` listing `src/pages/index.astro:6:<col> — Unexpected token`; restoring the file recovers the page |

Every test gets an automatic `browserLog` fixture that records `console.error`, uncaught exceptions, `requestfailed` and any response ≥ 400, and asserts at teardown that all of it is empty — no spec can skip the check. The overlay test `take()`s the expected 500 and the two console errors and checks that nothing but the broken module URL is in them. I ran a throwaway spec against the fixture (a `console.error`, a thrown error, a fetch of a 404, a connection failure): all four were reported.

## CI

New `e2e` job with `needs: test`: builds release, `npm ci`, `npx playwright install --with-deps chromium`, `npx playwright test`; the HTML report and traces are uploaded on failure. The `test` job's steps are untouched.

## How long

11 tests, about 4 s locally on warm caches and 10 s cold (6 workers); 3× repeat on 2 workers (33 tests) in 26 s; single worker, one daemon for every file, 6 s. The react example renders through esm.sh and the tailwind one styles through jsdelivr, so those assertions have a 45 s budget and the suite needs network for them. On CI the job's wall time is the release build.

## Noticed, did not fix

- When the page module answers 500, the browser reports it as `TypeError: Failed to fetch dynamically imported module: <url>`; the real diagnostic reaches the overlay only because `shell.js` then fetches `/__sl/check`, which compiles every source file of the tenant. The overlay is right, but its headline is Chromium's generic text and each failed render costs a full check.
- The compiler's column looks 0-based: `const headline = ;` is reported as `6:17` and `const = 3;` as `4:6`, the index of the offending token counted from 0, while the line is 1-based. Read as an editor's `file:line:column` it lands one character early. The spec asserts the line and only `\d+` for the column so it encodes neither convention.
- `main.rs` waits for `ctrl_c()` only, so SIGTERM — what `docker stop` and a plain `kill` send — ends the process without the graceful shutdown. Harmless for the suite (the helper sends SIGTERM and the daemon exits at once); in Docker it means in-flight requests are cut on stop.
- The `e2e` job builds the release binary a second time (with `lto = "fat"` that is most of its wall time) and `Swatinem/rust-cache` keys its cache by job, so it shares nothing with `test`. An `upload-artifact` step at the end of `test`, or a `shared-key` in both jobs, would remove the rebuild; both touch the `test` job, which this PR leaves alone.
- Chromium never reported the SSE stream (`/__sl/events`) as a failed request when the page reloaded itself, so the failed-request assertion has no allow-list. If a Chromium update starts reporting the cancelled stream as `net::ERR_ABORTED`, the live-reload and overlay tests will say so; the fix would be to ignore aborts of `/__sl/events` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
