### PR TITLE
editor: escape API data before inserting it into the DOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+      - run: node tests/editor-escaping.mjs
       - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87  # stable
         with:
           components: clippy, rustfmt

--- a/assets/editor.html
+++ b/assets/editor.html
@@ -73,6 +73,7 @@ dialog form{display:grid;gap:8px}dialog::backdrop{background:rgba(0,0,0,.5)}
 const $ = (s) => document.querySelector(s);
 const state = { stats: null, tenants: [], tenant: null, file: null, dirty: false, es: null, chat: [], saving: null };
 const BINARY = /\.(png|jpe?g|gif|webp|avif|ico|woff2?|ttf|otf|mp4|webm|mp3|pdf|wasm|zip)$/i;
+const esc = (v) => String(v).replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#39;");
 let apiToken = "";
 try { apiToken = localStorage.getItem("sl_api_token") || ""; } catch {}
 const authHeaders = () => (apiToken ? { authorization: `Bearer ${apiToken}` } : {});
@@ -97,7 +98,7 @@ const fmtKB = (kb) => kb == null ? "?" : kb > 10240 ? (kb / 1024).toFixed(1) + "
 async function refreshStats() {
   try { state.stats = await api("GET", "/api/stats"); } catch (e) { $("#stat").textContent = "daemon unreachable"; return; }
   const s = state.stats;
-  $("#stat").innerHTML = `daemon RSS <b>${fmtKB(s.rss_kb)}</b> · ${s.tenants} tenants · cache ${(s.cache.bytes / 1024).toFixed(0)} kB / ${s.cache.entries} · astro ${s.astro} · chat ${s.ai ? "on" : "off"}`;
+  $("#stat").innerHTML = `daemon RSS <b>${esc(fmtKB(s.rss_kb))}</b> · ${esc(s.tenants)} tenants · cache ${esc((s.cache.bytes / 1024).toFixed(0))} kB / ${esc(s.cache.entries)} · astro ${esc(s.astro)} · chat ${esc(s.ai ? "on" : "off")}`;
   $("#chatSend").disabled = !s.ai;
   if (!s.ai) $("#chatHint").textContent = "Chat is off: start the daemon with ANTHROPIC_API_KEY set to enable the built-in assistant. The file editor works without it.";
 }
@@ -105,10 +106,10 @@ async function refreshStats() {
 async function loadTenants(selectId) {
   state.tenants = await api("GET", "/api/tenants");
   const sel = $("#tenant");
-  sel.innerHTML = state.tenants.map((t) => `<option value="${t.id}">${t.id} (${t.base})</option>`).join("");
+  sel.replaceChildren(...state.tenants.map((t) => new Option(`${t.id} (${t.base})`, t.id)));
   const id = selectId || state.tenant || (state.tenants[0] && state.tenants[0].id);
   if (id && state.tenants.some((t) => t.id === id)) { sel.value = id; await selectTenant(id); }
-  else { state.tenant = null; $("#frame").classList.add("hidden"); $("#empty").classList.remove("hidden"); $("#files").innerHTML = ""; }
+  else { state.tenant = null; $("#frame").classList.add("hidden"); $("#empty").classList.remove("hidden"); $("#files").replaceChildren(); }
 }
 
 async function selectTenant(id) {
@@ -130,7 +131,13 @@ async function selectTenant(id) {
 async function loadFiles() {
   if (!state.tenant) return;
   const { files } = await api("GET", `/api/t/${state.tenant}/files`);
-  $("#files").innerHTML = files.map((f) => `<div data-path="${f.path}" class="${f.modified ? "modified" : ""}${f.path === state.file ? " active" : ""}" title="${f.size} bytes">${f.path}</div>`).join("");
+  $("#files").replaceChildren(...files.map((f) => {
+    const d = document.createElement("div");
+    d.dataset.path = f.path; d.textContent = f.path; d.title = `${f.size} bytes`;
+    if (f.modified) d.classList.add("modified");
+    if (f.path === state.file) d.classList.add("active");
+    return d;
+  }));
 }
 
 async function openFile(path, silent) {
@@ -167,7 +174,7 @@ $("#tabs").addEventListener("click", (e) => {
 });
 const openDialog = async () => {
   const bases = await api("GET", "/api/bases");
-  $("#dlgBase").innerHTML = bases.map((b) => `<option value="${b.name}">${b.name} (${b.files} files)</option>`).join("");
+  $("#dlgBase").replaceChildren(...bases.map((b) => new Option(`${b.name} (${b.files} files)`, b.name)));
   $("#dlgId").value = ""; $("#dlg").showModal();
 };
 $("#newTenant").onclick = openDialog; $("#emptyNew").onclick = openDialog;
@@ -189,7 +196,11 @@ $("#frame").addEventListener("load", () => { try { $("#path").value = new URL($(
 
 function addMsg(role, text, changes) {
   const div = document.createElement("div"); div.className = "msg " + role; div.textContent = text;
-  if (changes && changes.length) { const c = document.createElement("div"); c.className = "chips"; c.innerHTML = changes.map((p) => `<span>${p}</span>`).join(""); div.appendChild(c); }
+  if (changes && changes.length) {
+    const c = document.createElement("div"); c.className = "chips";
+    for (const p of changes) { const s = document.createElement("span"); s.textContent = p; c.appendChild(s); }
+    div.appendChild(c);
+  }
   $("#msgs").appendChild(div); $("#msgs").scrollTop = 1e9; return div;
 }
 $("#chatForm").addEventListener("submit", async (e) => {

--- a/tests/editor-escaping.mjs
+++ b/tests/editor-escaping.mjs
@@ -1,0 +1,128 @@
+import { readFileSync } from "node:fs";
+import { relative } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const file = process.argv[2] || fileURLToPath(new URL("../assets/editor.html", import.meta.url));
+const name = ((r) => (r && !r.startsWith("..") ? r : file))(relative(process.cwd(), file));
+const html = readFileSync(file, "utf8");
+const SINK = /\.(innerHTML|outerHTML)\s*\+?=(?!=)|\.insertAdjacentHTML\s*\(/g;
+
+function mask(js) {
+  const out = js.split("");
+  const literals = [];
+  const blank = (a, b) => { for (let k = a; k < b; k++) if (out[k] !== "\n") out[k] = " "; };
+  const regexStart = (i) => {
+    let k = i - 1;
+    while (k >= 0 && /\s/.test(out[k])) k--;
+    return k < 0 || /[(,=:[!&|?{};+\-*%<>~^]/.test(out[k]) || /(^|[^\w$])(return|typeof|case|in|of|delete|void|throw|new|do|else)$/.test(js.slice(0, k + 1));
+  };
+  const string = (i, q) => {
+    for (let j = i + 1; j < js.length; j++) {
+      if (js[j] === "\\") j++;
+      else if (js[j] === q) return j + 1;
+      else if (js[j] === "\n") return j;
+    }
+    return js.length;
+  };
+  const regex = (i) => {
+    let cls = false;
+    for (let j = i + 1; j < js.length; j++) {
+      const c = js[j];
+      if (c === "\\") j++;
+      else if (c === "\n") return j;
+      else if (cls) cls = c !== "]";
+      else if (c === "[") cls = true;
+      else if (c === "/") { j++; while (/[a-z]/i.test(js[j] || "")) j++; return j; }
+    }
+    return js.length;
+  };
+  const template = (i) => {
+    let j = i + 1;
+    while (j < js.length && js[j] !== "`") {
+      if (js[j] === "$" && js[j + 1] === "{") { j = code(j + 2, true); continue; }
+      const n = js[j] === "\\" ? 2 : 1;
+      blank(j, j + n);
+      j += n;
+    }
+    return j + 1;
+  };
+  const code = (i, interpolation) => {
+    let depth = 0;
+    while (i < js.length) {
+      const c = js[i], n = js[i + 1];
+      if (c === "/" && n === "/") { const j = js.indexOf("\n", i); const e = j < 0 ? js.length : j; blank(i, e); i = e; }
+      else if (c === "/" && n === "*") { const j = js.indexOf("*/", i + 2); const e = j < 0 ? js.length : j + 2; blank(i, e); i = e; }
+      else if (c === '"' || c === "'") { const e = string(i, c); literals.push([i, e]); blank(i + 1, e - 1); i = e; }
+      else if (c === "`") { const e = template(i); literals.push([i, e]); i = e; }
+      else if (c === "/" && regexStart(i)) { const e = regex(i); blank(i + 1, e); i = e; }
+      else if (c === "{") { depth++; i++; }
+      else if (c === "}") { if (interpolation && depth === 0) return i + 1; depth--; i++; }
+      else i++;
+    }
+    return i;
+  };
+  code(0, false);
+  return { masked: out.join(""), literals };
+}
+
+const matchClose = (text, open, a, b) => {
+  let depth = 0;
+  for (let k = open; k < text.length; k++) {
+    if (text[k] === a) depth++;
+    else if (text[k] === b && --depth === 0) return k;
+  }
+  return text.length;
+};
+
+const statementEnd = (text, i) => {
+  let depth = 0;
+  for (let k = i; k < text.length; k++) {
+    const c = text[k];
+    if ("([{".includes(c)) depth++;
+    else if (")]}".includes(c)) { if (depth === 0) return k; depth--; }
+    else if (c === ";" && depth === 0) return k;
+  }
+  return text.length;
+};
+
+const findings = [];
+let sinks = 0, scripts = 0;
+for (const m of html.matchAll(/<script\b[^>]*>([\s\S]*?)<\/script>/g)) {
+  scripts++;
+  const js = m[1], offset = m.index + m[0].indexOf(js);
+  const { masked, literals } = mask(js);
+  let depth = 0;
+  for (const c of masked) { if ("([{".includes(c)) depth++; else if (")]}".includes(c)) depth--; }
+  if (depth !== 0) { console.error(`${name}: could not tokenise the script (brackets do not balance once literals are masked)`); process.exit(2); }
+  for (const s of masked.matchAll(SINK)) {
+    sinks++;
+    const start = s.index, from = start + s[0].length, end = statementEnd(masked, from);
+    const where = `${name}:${html.slice(0, offset + start).split("\n").length}`;
+    const sink = s[0].trim();
+    const outside = masked.slice(from, end).split("");
+    for (const it of masked.slice(from, end).matchAll(/\$\{/g)) {
+      const open = from + it.index + 1, close = matchClose(masked, open, "{", "}");
+      const inner = masked.slice(open + 1, close);
+      const lead = inner.match(/^\s*esc\s*\(/);
+      const wrapped = lead && /^\s*$/.test(inner.slice(matchClose(inner, lead[0].length - 1, "(", ")") + 1));
+      if (!wrapped) findings.push(`${where}: \${${js.slice(open + 1, close).trim()}} reaches ${sink} without esc()`);
+      for (let k = it.index; k <= close - from; k++) outside[k] = " ";
+    }
+    if (outside.includes("+")) findings.push(`${where}: string concatenation into ${sink}; use one template literal with every value in esc()`);
+    if (!literals.some(([a]) => a >= from && a < end)) findings.push(`${where}: ${sink} takes a non-literal expression; build the markup from a template literal with every value in esc()`);
+  }
+}
+
+if (!scripts) { console.error(`${name}: no inline <script> found; the check only covers script blocks in this file`); process.exit(2); }
+const def = html.match(/^[ \t]*const esc = .*$/m);
+if (sinks && !def) findings.push(`${name}: HTML sinks exist but esc() is not defined`);
+if (def) {
+  let esc;
+  try { esc = new Function(`${def[0]}\nreturn esc;`)(); } catch (e) { findings.push(`${name}: cannot evaluate the esc() definition: ${e.message}`); }
+  const hostile = `<img src=x onerror=alert(1)>.astro & "q" 'a'`;
+  const escaped = "&lt;img src=x onerror=alert(1)&gt;.astro &amp; &quot;q&quot; &#39;a&#39;";
+  if (esc && (esc(hostile) !== escaped || esc(7) !== "7")) findings.push(`${name}: esc() does not escape & < > " '`);
+}
+
+if (findings.length) { console.error(findings.join("\n")); process.exit(1); }
+console.log(`editor-escaping: ${name}: ${sinks} HTML sink${sinks === 1 ? "" : "s"}, every interpolation goes through esc()`);


### PR DESCRIPTION
Closes #1

## What changed

`assets/editor.html` rendered file paths, tenant ids, base names and the chat's change chips with template strings into `innerHTML`. A file written through `PUT /api/t/{id}/file/<path>` with a name like `<img src=x onerror=alert(1)>.astro` executed in the editor origin, which keeps the API token in `localStorage` (`clean_path` only rejects `\`, NUL and `..`, so the name is accepted as-is).

- The file list, the tenant and base `<select>`s and the change chips are now built with `createElement`/`textContent`/`new Option`, so no API value is parsed as HTML. That follows the issue's "prefer `textContent`/`createElement` where the markup is trivial" — all four sites are a single element per item.
- The one place that keeps inline markup, the stats line, goes through a new `esc()` helper on every interpolation.
- `tests/editor-escaping.mjs` is the regression check (no dependencies, Node only). It tokenises the editor's `<script>` — strings, template literals with nested interpolations, comments, regex literals — finds every `innerHTML` / `outerHTML` / `insertAdjacentHTML` statement, and fails when an interpolation is not exactly `${esc(...)}`, when strings are concatenated into the sink, or when the sink takes a non-literal expression. It also evaluates the file's own `esc()` against a hostile sample, so an identity or partial escaper fails too. It is a scanner rather than the grep the issue sketches because a grep for ``innerHTML = ` `` would have passed the chips line (``c.innerHTML = changes.map((p) => `<span>${p}</span>`).join("")``), which was one of the five injection sites.
- `.github/workflows/ci.yml` runs it as the first step of the existing job; the Rust steps are untouched.

Everything else is unchanged: autosave, Ctrl/Cmd+S, Tab insertion, tenant switching, chat, and the token prompt on 401 are not touched.

## How I verified it

- Built the daemon, ran it on `127.0.0.1:4501` with `--bases examples --no-persist`, created tenant `t1` and `PUT` a file named `src/pages/<img src=x onerror=alert(1)>.astro`. `/api/t/t1/files` returns the path verbatim and `/` serves the new editor.
- Loaded the editor in Chrome with `alert`/`confirm`/`prompt` hooked to record calls instead of blocking:
  - new code: no dialog; the row shows the literal name, its `dataset.path` is intact, and there is no `<img>` element anywhere in the document; clicking the row opens the file (`<h1>hostile</h1>` appears in the editor); chips for `<img …>.astro` and `a&b.css` render as text; the base dropdown lists `react` / `starter` / `tailwind` with the right values; the console is clean.
  - the old template, run in the same page against the same API data: `alert(1)` fired and the injected `<img>` swallowed the row's text.
- The check passes on the new file (`1 HTML sink, every interpolation goes through esc()`), fails on the old file with 19 findings across lines 100, 108, 133, 170 and 192 plus "esc() is not defined", and fails when one `esc(` is removed from the new file (`assets/editor.html:101: ${s.astro} reaches .innerHTML = without esc()`). 21 further mutations — partial wrap `${esc(x) + y}`, concatenation, non-literal right-hand side, `map`/`join`, `+=`, `insertAdjacentHTML`, `outerHTML`, a multi-line template, an identity `esc`, a missing `esc`, comments and strings that mention `innerHTML`, a regex containing quotes before the sink, comparisons and reads of `innerHTML` — all behave as expected.

## Noticed, did not fix

- File paths go into API URLs unencoded (`/api/t/${tenant}/file/${path}` in `openFile` and `save`). A file named `src/pages/a#b.astro` shows up in the listing, but opening it requests `/api/t/t1/file/src/pages/a` (the browser drops the fragment), which rejects with "no such file", so the editor keeps showing the previously opened file's content under the new name; `a?b.astro` fails the same way, and saving such a file would write to the wrong path. Pre-existing and unrelated to escaping; the fix is `path.split("/").map(encodeURIComponent).join("/")` at those call sites.
- `Store::restore` (`src/store.rs`) takes the tenant id from the data directory's entry name without running `valid_id`, so a persisted directory with an arbitrary name becomes a tenant whose id the editor renders and puts into `previewUrl`. It needs filesystem access, and the id is now rendered as text, but it is the one path where a tenant id reaches the editor unvalidated.
- `assets/shell.js` (the preview origin) already escapes its overlay through its own `esc()`; the check covers `editor.html` only, as the issue scopes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
