### PR TITLE
ci: release binaries and GHCR image on tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,138 @@
+name: release
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch: # dry run: builds, packages and smoke-tests every target, publishes nothing
+
+env:
+  # Archives are named after the tag; a dry run from a branch gets "dev".
+  RELEASE_TAG: ${{ github.ref_type == 'tag' && github.ref_name || 'dev' }}
+  IMAGE: ghcr.io/${{ github.repository }}
+
+jobs:
+  linux:
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu]
+    runs-on: ubuntu-latest
+    # Built in the image the Dockerfile builds in, so the tarball runs wherever the image does
+    # (glibc 2.36, Debian 12, or newer); a build on ubuntu-latest itself would demand glibc 2.38.
+    container: rust:1-bookworm
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+      - name: aarch64 cross toolchain and qemu-user
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends gcc-aarch64-linux-gnu libc6-dev-arm64-cross qemu-user
+          rustup target add aarch64-unknown-linux-gnu
+          {
+            echo CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+            echo CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
+            echo AR_aarch64_unknown_linux_gnu=aarch64-linux-gnu-ar
+            echo STRIP=aarch64-linux-gnu-strip
+          } >> "$GITHUB_ENV"
+      - run: cargo build --release --locked --target ${{ matrix.target }}
+      - name: package
+        run: |
+          "${STRIP:-strip}" target/${{ matrix.target }}/release/sandbox-lite
+          mkdir dist smoke
+          cp target/${{ matrix.target }}/release/sandbox-lite LICENSE README.md dist/
+          tar -C dist -czf "sandbox-lite-$RELEASE_TAG-${{ matrix.target }}.tar.gz" sandbox-lite LICENSE README.md
+          tar -C smoke -xzf "sandbox-lite-$RELEASE_TAG-${{ matrix.target }}.tar.gz"
+      - name: smoke test the packaged binary
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: ./smoke/sandbox-lite check examples/starter
+      - name: smoke test the packaged binary under qemu-user
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: qemu-aarch64 -L /usr/aarch64-linux-gnu ./smoke/sandbox-lite check examples/starter
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: sandbox-lite-${{ matrix.target }}
+          path: sandbox-lite-*.tar.gz
+          if-no-files-found: error
+
+  macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [x86_64-apple-darwin, aarch64-apple-darwin]
+    runs-on: macos-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+      - uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87  # stable
+        with:
+          targets: ${{ matrix.target }}
+      - run: cargo build --release --locked --target ${{ matrix.target }}
+      - name: package
+        run: |
+          strip target/${{ matrix.target }}/release/sandbox-lite
+          mkdir dist smoke
+          cp target/${{ matrix.target }}/release/sandbox-lite LICENSE README.md dist/
+          tar -C dist -czf "sandbox-lite-$RELEASE_TAG-${{ matrix.target }}.tar.gz" sandbox-lite LICENSE README.md
+          tar -C smoke -xzf "sandbox-lite-$RELEASE_TAG-${{ matrix.target }}.tar.gz"
+      - name: smoke test the packaged binary
+        # The runner is arm64; the x86_64 build is cross-compiled here and would need Rosetta to run.
+        if: matrix.target == 'aarch64-apple-darwin'
+        run: ./smoke/sandbox-lite check examples/starter
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: sandbox-lite-${{ matrix.target }}
+          path: sandbox-lite-*.tar.gz
+          if-no-files-found: error
+
+  release:
+    needs: [linux, macos]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          pattern: sandbox-lite-*
+          merge-multiple: true
+          path: dist
+      - run: cd dist && sha256sum sandbox-lite-*.tar.gz > SHA256SUMS
+      - name: create the release, or replace the files of one that a re-run already created
+        run: |
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release upload --clobber "$GITHUB_REF_NAME" dist/*
+          else
+            gh release create "$GITHUB_REF_NAME" --verify-tag --title "$GITHUB_REF_NAME" --generate-notes dist/*
+          fi
+
+  docker:
+    needs: [linux, macos]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4
+      # The arm64 half compiles under emulation: expect it to take an hour or two, not minutes.
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
+        if: github.event_name == 'push'
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name == 'push' }}
+          tags: |
+            ${{ env.IMAGE }}:${{ env.RELEASE_TAG }}
+            ${{ env.IMAGE }}:latest
+          labels: org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -72,6 +72,36 @@ transform cache shared by every tenant: two tenants with the same `Header.astro`
 share one compiled output. The cache has a byte budget (`--cache-mb`, default
 64) so the daemon's memory is bounded regardless of tenant count.
 
+## Install
+
+Every [release](https://github.com/productdevbook/sandbox-lite/releases) carries
+a stripped binary for Linux (x86-64 and arm64, glibc 2.35 or newer) and macOS
+(Intel and Apple silicon) as `sandbox-lite-<tag>-<target>.tar.gz`, holding
+`sandbox-lite`, `LICENSE` and `README.md`, plus a `SHA256SUMS` file:
+
+```sh
+tag=v0.1.0
+target=x86_64-unknown-linux-gnu   # or aarch64-unknown-linux-gnu, x86_64-apple-darwin, aarch64-apple-darwin
+curl -fsSL "https://github.com/productdevbook/sandbox-lite/releases/download/$tag/sandbox-lite-$tag-$target.tar.gz" | tar xzf - sandbox-lite
+sudo install sandbox-lite /usr/local/bin/
+sandbox-lite --bases path/to/your/astro-projects
+```
+
+The same tag is published as a multi-arch image (`linux/amd64`, `linux/arm64`)
+at `ghcr.io/productdevbook/sandbox-lite:<tag>`, and `:latest` follows the newest
+release; see [Docker](#docker) for what the image bundles:
+
+```sh
+docker run -p 4321:4321 -v sandbox-data:/data ghcr.io/productdevbook/sandbox-lite:latest
+```
+
+Or build from source with a current stable Rust toolchain. The browser runtime
+is embedded in the binary, so nothing else is needed at run time:
+
+```sh
+cargo install --locked --git https://github.com/productdevbook/sandbox-lite   # --tag v0.1.0 pins a release
+```
+
 ## Try it
 
 ```sh


### PR DESCRIPTION
Closes #10

`.github/workflows/release.yml` runs on every `v*` tag, and on `workflow_dispatch` as a dry run that builds, packages and smoke-tests everything but publishes nothing.

- **linux** (`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`) runs inside `rust:1-bookworm`, the Dockerfile's own build stage, so the tarballs need glibc 2.35 and run on Debian 12, Ubuntu 22.04 and newer. aarch64 is cross-compiled with `gcc-aarch64-linux-gnu`. Each binary is stripped, packed with `LICENSE` and `README.md` as `sandbox-lite-<tag>-<target>.tar.gz`, extracted again, and `sandbox-lite check examples/starter` runs from the extracted archive (aarch64 under `qemu-aarch64` from Debian's `qemu-user`) before the upload.
- **macos** (`x86_64-apple-darwin`, `aarch64-apple-darwin`) on `macos-latest`; the x86_64 build is cross-compiled on the arm64 runner and only the arm64 artifact is smoke-tested there.
- **release** creates the GitHub release with `gh release create <tag> --generate-notes` and the four archives plus `SHA256SUMS`; a re-run that finds the release already there uploads with `--clobber` instead of failing.
- **docker** builds the existing Dockerfile with buildx for `linux/amd64,linux/arm64` and pushes `ghcr.io/productdevbook/sandbox-lite:<tag>` and `:latest` with `GITHUB_TOKEN` (`packages: write`).

Actions are pinned to commit SHAs with the `# vN` comments dependabot already tracks. README gets an **Install** section: release tarball, GHCR image, `cargo install --locked --git`.

### Why the Linux jobs build in a container

A build on `ubuntu-latest` itself links `fmod@GLIBC_2.38` (glibc re-versioned `fmod` in 2.38), so that binary refuses to start on Debian 12 or Ubuntu 22.04, and it would have failed a smoke test on the Docker image's own base. Inside `rust:1-bookworm` the newest symbol version needed is `GLIBC_2.35` (`hypotf`).

### Verified locally

- x86_64: `cargo build --release --locked --target x86_64-unknown-linux-gnu` in `rust:1-bookworm`, then the workflow's package and smoke lines verbatim: `starter: 14 source files, 0 errors`; 5.7 MB archive; `readelf` shows nothing above `GLIBC_2.35`.
- aarch64: the same image plus `gcc-aarch64-linux-gnu libc6-dev-arm64-cross qemu-user` and the workflow's environment variables. The first attempt without `libc6-dev-arm64-cross` died in ring's C build (`bits/libc-header-start.h: No such file or directory`), which is why that package is named explicitly. Package lines and `qemu-aarch64 -L /usr/aarch64-linux-gnu ./smoke/sandbox-lite check examples/starter`: `starter: 14 source files, 0 errors`; 12.3 MB `ELF 64-bit LSB pie executable, ARM aarch64 ... stripped`, 5.3 MB archive, nothing above `GLIBC_2.35`.
- `docker build` of the unchanged Dockerfile for amd64, then `sandbox-lite check /bases/starter` inside the image: `0 errors`; 3.5 minutes on 12 cores, 133 MB image (34 MB compressed).
- `cargo install --locked --path .` installs, and the installed binary passes `check`.
- `actionlint` 1.7.12 with shellcheck 0.11.0: clean.

### Only a real tag run will prove

- The macOS jobs: cross-compiling `x86_64-apple-darwin` on the arm64 runner, and Apple's `strip` on a binary the Cargo profile already stripped.
- `actions/checkout`, `$GITHUB_ENV` and `upload-artifact` inside the `rust:1-bookworm` job container.
- The GHCR push with `GITHUB_TOKEN`, and that the new package comes out public (check the package's visibility after the first release).
- The emulated `linux/arm64` half of the image: the Dockerfile compiles under qemu, which I expect to take an hour or two. If that is too slow, build each platform on its own runner (`ubuntu-24.04-arm` for arm64) and join them with `docker buildx imagetools create`.
- `gh release create --generate-notes` on the first tag, with no earlier tag to diff against.

### Noticed, did not fix

- No `.dockerignore`: a local `docker build .` ships `target/` (gigabytes) as the build context. CI checkouts have no `target/`, so the workflow is unaffected.
- Nothing checks that the tag matches the `version` in `Cargo.toml`; a `v0.2.0` tag on a `0.1.0` crate releases a binary that reports 0.1.0.
- A pre-release tag such as `v0.2.0-rc1` gets `:latest` on GHCR and a full (not pre-) release like any other.
- The README install snippet has to name a tag (`v0.1.0`) because the asset name carries it, so `releases/latest/download/...` cannot be used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
