### PR TITLE
test: property tests for every parser fed untrusted input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1551,6 +1551,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1563,6 +1572,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bitflags",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
 ]
 
 [[package]]
@@ -1671,6 +1695,16 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
@@ -1681,10 +1715,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "rand_core"
@@ -1699,6 +1752,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1850,6 +1912,7 @@ dependencies = [
  "oxc_semantic",
  "oxc_span",
  "oxc_transformer",
+ "proptest",
  "pulldown-cmark",
  "reqwest",
  "serde",
@@ -2316,6 +2379,12 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,9 @@ globset = "0.4"
 blake3 = "1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 
+[dev-dependencies]
+proptest = { version = "1", default-features = false, features = ["std"] }
+
 [profile.release]
 opt-level = 3
 lto = "fat"

--- a/src/http/preview.rs
+++ b/src/http/preview.rs
@@ -231,14 +231,14 @@ pub async fn missing(RawQuery(query): RawQuery) -> Response {
 
 pub fn percent_decode(s: &str) -> String {
     let bytes = s.as_bytes();
+    let digit = |at: usize| bytes.get(at).and_then(|b| (*b as char).to_digit(16));
     let mut out = Vec::with_capacity(bytes.len());
     let mut i = 0;
     while i < bytes.len() {
         if bytes[i] == b'%'
-            && i + 2 < bytes.len()
-            && let Ok(v) = u8::from_str_radix(&s[i + 1..i + 3], 16)
+            && let (Some(hi), Some(lo)) = (digit(i + 1), digit(i + 2))
         {
-            out.push(v);
+            out.push((hi * 16 + lo) as u8);
             i += 3;
             continue;
         }
@@ -267,4 +267,18 @@ pub async fn page(AxState(st): AxState<State>, Extension(id): Extension<TenantId
         .replace("%ASSETS%", asset_version())
         .replace("%ENV%", &env.to_string());
     ([(header::CACHE_CONTROL, "no-store")], Html(html)).into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::percent_decode;
+
+    #[test]
+    fn percent_decode_takes_any_string() {
+        assert_eq!(percent_decode("%aé"), "%aé");
+        assert_eq!(percent_decode("%ࠀ"), "%ࠀ");
+        assert_eq!(percent_decode("%C3%A9%"), "é%");
+        assert_eq!(percent_decode("%+1%-1%2"), "%+1%-1%2");
+        assert_eq!(percent_decode("%FF"), "\u{fffd}");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,9 @@ mod routes;
 mod store;
 mod transform;
 
+#[cfg(test)]
+mod proptests;
+
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;

--- a/src/proptests.rs
+++ b/src/proptests.rs
@@ -1,0 +1,308 @@
+//! Property tests for the parsers that read attacker-controlled bytes: request
+//! paths, query strings, Host headers, tenant files and compiled module source.
+//! None may panic, and nothing path-shaped may climb out of the tenant.
+
+use proptest::prelude::*;
+use serde_json::{Map, Value, json};
+
+use crate::http::preview::percent_decode;
+use crate::http::tenant_from_host;
+use crate::resolve::{import_map, join, normalize, package_name, strip_jsonc, tsconfig_paths, urlenc};
+use crate::store::{clean_path, valid_id};
+use crate::transform::content::{parse_markdown, slugify, split_frontmatter, yaml_to_json};
+use crate::transform::css::rewrite_relative;
+use crate::transform::{Kind, glob, svg_size};
+
+#[rustfmt::skip]
+const TOKENS: &[&str] = &[
+    "/", "//", "\\", ".", "..", "/../", "/./", "src/pages", "index", ".astro", "public/", "@/",
+    "%", "%2", "%2e", "%2E%2e", "%2F", "%c3", "%A9", "%FF", "%00", "%+1", "%-1", "%%",
+    "\"", "'", "`", "\\\"", "\\\\", "(", ")", "[", "]", "{", "}", ",", ":", ";", "=", "&", "?", "#", "*", "!", "@", "-", "_", "<", ">",
+    " ", "\t", "\n", "\r", "\r\n", "\0", "\u{1}", "\u{b}", "\u{7f}", "\u{85}", "\u{a0}", "\u{feff}", "\u{200b}", "\u{2028}",
+    "é", "€", "𝄞", "字", "\u{301}", "\u{fffd}", "İ",
+    "true", "false", "null", "0", "1", "-1", "1e999", "inf", "NaN", "px",
+    "/*", "*/", "---", "...", "<svg", "<svg ", "width=", "height=", "viewBox=", "url(", "@import", "import.meta.glob(",
+    "eager", "query", "import", "as", "raw", "url", "type=", "index=", "v=", "style", "script",
+    "compilerOptions", "baseUrl", "paths", "imports", "&a", "*a", "<<", "!!binary", "- ", "? ", "|", "localhost",
+];
+
+const QUOTES: &[&str] = &["", "\"", "'"];
+
+fn tokens() -> impl Strategy<Value = String> {
+    prop::collection::vec(prop::sample::select(TOKENS), 0..24).prop_map(|v| v.concat())
+}
+
+fn unicode() -> impl Strategy<Value = String> {
+    prop::collection::vec(any::<char>(), 0..48).prop_map(String::from_iter)
+}
+
+fn short() -> impl Strategy<Value = String> {
+    prop_oneof![4 => tokens(), 1 => unicode(), 1 => "[ -~]{0,48}"]
+}
+
+/// A chunk repeated up to 64 KiB plus a tail: the shape that exposes a quadratic scan or an off-by-one at the end.
+fn long() -> impl Strategy<Value = String> {
+    (prop::sample::select(TOKENS), tokens(), 0usize..=65536, short()).prop_map(|(head, rest, len, tail)| {
+        let chunk = format!("{head}{rest}");
+        chunk.repeat(len / chunk.len()) + &tail
+    })
+}
+
+fn input() -> impl Strategy<Value = String> {
+    prop_oneof![7 => short(), 1 => long()]
+}
+
+fn jsonc() -> impl Strategy<Value = (String, Value)> {
+    (short(), short(), short()).prop_map(|(key, val, comment)| {
+        let line = comment.replace('\n', " ");
+        let block = comment.replace('*', " ");
+        let (k, v) = (Value::String(key.clone()), Value::String(val.clone()));
+        let text = format!("{{ // {line}\n /* {block} */ {k}: [ {v}, /* {block} */ ], // {line}\n }}");
+        (text, json!({ key: [val] }))
+    })
+}
+
+fn tsconfig() -> impl Strategy<Value = String> {
+    (short(), prop::collection::vec((short(), short()), 0..4)).prop_map(|(base, paths)| {
+        let paths: Map<String, Value> = paths.into_iter().map(|(k, v)| (k, json!([v]))).collect();
+        json!({ "compilerOptions": { "baseUrl": base, "paths": paths } }).to_string()
+    })
+}
+
+fn yaml() -> impl Strategy<Value = String> {
+    prop::collection::vec((short(), short()), 0..6).prop_map(|pairs| pairs.iter().map(|(k, v)| format!("{k}: {v}\n")).collect())
+}
+
+fn markdown() -> impl Strategy<Value = String> {
+    (yaml(), short()).prop_map(|(fm, body)| format!("---\n{fm}---\n{body}"))
+}
+
+fn svg() -> impl Strategy<Value = String> {
+    (short(), short(), short()).prop_map(|(w, h, vb)| format!("<svg xmlns=\"x\" width={w} height=\"{h}\" viewBox='{vb}'>"))
+}
+
+fn css() -> impl Strategy<Value = String> {
+    (short(), short(), prop::sample::select(QUOTES))
+        .prop_map(|(a, b, q)| format!("@import {q}{a}{q}; .x{{background:url({q}{b}{q})}} @import url({a})"))
+}
+
+fn assert_inside_tenant(path: &str) -> Result<(), TestCaseError> {
+    prop_assert!(!path.starts_with('/'), "absolute path {path:?}");
+    prop_assert!(path.is_empty() || path.split('/').all(|s| !s.is_empty() && s != "." && s != ".."), "dot segment in {path:?}");
+    Ok(())
+}
+
+fn longest_key_first(pairs: &[(String, String)]) -> bool {
+    pairs.windows(2).all(|w| w[0].0.len() >= w[1].0.len())
+}
+
+/// The paths `rewrite_relative` put after `/__sl/raw/`, cut at the delimiter that closes the construct they sit in.
+fn rewritten_paths(out: &str) -> Vec<&str> {
+    let mut paths = Vec::new();
+    for (i, _) in out.match_indices("/__sl/raw/") {
+        let (before, rest) = (&out[..i], &out[i + "/__sl/raw/".len()..]);
+        let quote = before.chars().last().filter(|c| *c == '"' || *c == '\'');
+        let path = if before.trim_end_matches(['"', '\'']).ends_with("url(") {
+            let value = &rest[..rest.find(')').unwrap_or(rest.len())];
+            quote.and_then(|q| value.strip_suffix(q)).unwrap_or(value)
+        } else {
+            &rest[..quote.and_then(|q| rest.find(q)).unwrap_or(rest.len())]
+        };
+        paths.push(path);
+    }
+    paths
+}
+
+proptest! {
+    #[test]
+    fn clean_path_never_escapes(raw in input()) {
+        for candidate in [raw.clone(), percent_decode(&raw)] {
+            if let Some(p) = clean_path(&candidate) {
+                prop_assert!(!p.is_empty() && !p.ends_with('/') && !p.contains('\0') && !p.contains('\\'), "{p:?}");
+                assert_inside_tenant(&p)?;
+                let again = clean_path(&p);
+                prop_assert_eq!(again.as_deref(), Some(p.as_str()));
+            }
+        }
+    }
+
+    #[test]
+    fn valid_id_is_a_dns_label(id in input()) {
+        if valid_id(&id) {
+            prop_assert!(id.is_ascii() && (1..=63).contains(&id.len()) && !id.starts_with('-') && !id.ends_with('-'));
+        }
+    }
+
+    #[test]
+    fn tenant_from_host_yields_only_valid_ids(host in input(), domain in input()) {
+        if let Some(id) = tenant_from_host(&host, &domain) {
+            prop_assert!(valid_id(&id));
+            prop_assert_eq!(format!("{id}.{domain}"), host);
+        }
+    }
+
+    #[test]
+    fn valid_ids_survive_the_host_round_trip(id in "[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?", domain in input()) {
+        prop_assert!(valid_id(&id));
+        prop_assert_eq!(tenant_from_host(&format!("{id}.{domain}"), &domain), Some(id));
+    }
+
+    #[test]
+    fn normalize_and_join_never_climb(dir in input(), rel in input()) {
+        let n = normalize(&rel);
+        assert_inside_tenant(&n)?;
+        prop_assert_eq!(normalize(&n), n);
+        let j = join(&dir, &rel);
+        assert_inside_tenant(&j)?;
+        prop_assert!(j.len() <= dir.len() + rel.len() + 1);
+    }
+
+    #[test]
+    fn package_name_splits_without_loss(spec in input()) {
+        let (name, subpath) = package_name(&spec);
+        prop_assert!(subpath.is_empty() || subpath.starts_with('/'));
+        prop_assert_eq!(format!("{name}{subpath}"), spec);
+    }
+
+    #[test]
+    fn strip_jsonc_never_grows(text in input()) {
+        prop_assert!(strip_jsonc(&text).len() <= text.len());
+    }
+
+    #[test]
+    fn strip_jsonc_keeps_the_value((text, value) in jsonc()) {
+        let stripped = strip_jsonc(&text);
+        let parsed: Value = serde_json::from_str(&stripped).map_err(|e| TestCaseError::fail(format!("{e} in {stripped:?}")))?;
+        prop_assert_eq!(parsed, value);
+    }
+
+    #[test]
+    fn tsconfig_targets_stay_inside_the_tenant(text in prop_oneof![input(), tsconfig()]) {
+        let aliases = tsconfig_paths(&text);
+        for (key, target) in &aliases {
+            prop_assert!(!key.ends_with('*'));
+            assert_inside_tenant(target.strip_suffix('/').unwrap_or(target))?;
+        }
+        prop_assert!(longest_key_first(&aliases));
+    }
+
+    #[test]
+    fn import_map_keeps_every_string_entry(entries in prop::collection::vec((short(), short()), 0..4), junk in input()) {
+        let map: Map<String, Value> = entries.into_iter().map(|(k, v)| (k, Value::String(v))).collect();
+        let mut want: Vec<(String, String)> = map.iter().map(|(k, v)| (k.clone(), v.as_str().unwrap_or_default().to_string())).collect();
+        let mut got = import_map(&json!({ "imports": map, "site": junk }).to_string());
+        prop_assert!(longest_key_first(&got));
+        got.sort();
+        want.sort();
+        prop_assert_eq!(got, want);
+        prop_assert!(longest_key_first(&import_map(&junk)));
+    }
+
+    #[test]
+    fn glob_spans_are_in_bounds(code in input()) {
+        let mut last = 0;
+        for g in glob::find(&code) {
+            prop_assert!(last <= g.start && g.start < g.end && g.end <= code.len(), "span {}..{} of {} bytes", g.start, g.end, code.len());
+            prop_assert!(code.is_char_boundary(g.start) && code.is_char_boundary(g.end));
+            prop_assert!(code[g.start..].starts_with("import.meta.glob("));
+            let closes = matches!(code.as_bytes()[g.end - 1], b')' | b']' | b'}');
+            prop_assert!(closes, "span ends in {:?}", &code[g.start..g.end]);
+            prop_assert!(!g.patterns.is_empty());
+            last = g.end;
+        }
+    }
+
+    #[test]
+    fn glob_options_round_trip(
+        pattern in "[^\"'`\\\\\\x00-\\x1f]{0,40}",
+        import in "[A-Za-z_$][A-Za-z0-9_$]{0,10}",
+        query in "[^\"'`\\\\\\x00-\\x1f]{0,20}",
+        eager in any::<bool>(),
+        pad in "[a-z0-9 ;=\\n]{0,48}",
+    ) {
+        let call = format!("import.meta.glob(\"{pattern}\", {{ eager: {eager}, import: '{import}', query: `{query}` }})");
+        let code = format!("{pad}const m = {call};{pad}");
+        let found = glob::find(&code);
+        prop_assert_eq!(found.len(), 1);
+        let g = &found[0];
+        prop_assert_eq!(&code[g.start..g.end], call.as_str());
+        prop_assert_eq!(&g.patterns, &vec![pattern]);
+        prop_assert_eq!(g.eager, eager);
+        prop_assert_eq!(g.import.as_deref(), Some(import.as_str()));
+        prop_assert_eq!(g.query.as_deref(), Some(query.trim_start_matches('?')).filter(|q| !q.is_empty()));
+    }
+
+    #[test]
+    fn percent_decode_never_grows(s in input()) {
+        let out = percent_decode(&s);
+        prop_assert!(out.len() <= s.len());
+        if !s.contains('%') {
+            prop_assert_eq!(out, s);
+        }
+    }
+
+    #[test]
+    fn percent_decode_inverts_urlenc(s in input()) {
+        prop_assert_eq!(percent_decode(&urlenc(&s)), s);
+    }
+
+    #[test]
+    fn frontmatter_split_partitions_the_source(src in prop_oneof![input(), markdown()]) {
+        let (fm, body) = split_frontmatter(&src);
+        let s = src.strip_prefix('\u{feff}').unwrap_or(&src);
+        prop_assert!(s.ends_with(body));
+        if let Some(fm) = fm {
+            prop_assert!(s.starts_with("---") && s.contains(fm));
+            prop_assert!(fm.len() + body.len() + 7 <= s.len());
+        }
+        let md = parse_markdown(&src);
+        prop_assert!(md.frontmatter.is_object());
+        prop_assert_eq!(md.body.as_str(), body);
+    }
+
+    #[test]
+    fn yaml_to_json_is_always_an_object(yaml in prop_oneof![input(), yaml()]) {
+        prop_assert!(yaml_to_json(&yaml).is_object());
+    }
+
+    #[test]
+    fn slugs_are_clean(text in input()) {
+        let slug = slugify(&text);
+        prop_assert!(!slug.starts_with('-') && !slug.ends_with('-') && !slug.contains("--"), "{slug:?}");
+        // `İ` lowercases to `i` plus a combining dot, which is not alphanumeric
+        prop_assert!(slug.chars().all(|c| c == '-' || c.is_alphanumeric() || c == '\u{307}'), "{slug:?}");
+    }
+
+    #[test]
+    fn svg_size_is_bounded(svg in prop_oneof![input(), svg()]) {
+        let (w, h) = svg_size(&svg);
+        prop_assert!(w <= u32::MAX as usize && h <= u32::MAX as usize, "{w}x{h}");
+    }
+
+    #[test]
+    fn svg_size_reads_quoted_dimensions(w in any::<u32>(), h in any::<u32>(), gap in " {1,3}") {
+        let want = (w as usize, h as usize);
+        prop_assert_eq!(svg_size(&format!("<svg{gap}width=\"{w}px\"{gap}height='{h}'>")), want);
+        prop_assert_eq!(svg_size(&format!("<svg{gap}viewBox=\"0 0 {w} {h}\">")), want);
+        prop_assert_eq!(svg_size(&format!("<svg{gap}viewBox=\"0,0,{w},{h}\"{gap}width=\"{w}\">")), want);
+    }
+
+    #[test]
+    fn css_rewrites_stay_inside_the_tenant(css in prop_oneof![input(), css()], dir in short()) {
+        prop_assume!(!css.contains("/__sl/raw/"));
+        let out = rewrite_relative(&css, &dir);
+        if !css.contains("url(") && !css.contains("@import") {
+            prop_assert_eq!(&out, &css);
+        }
+        for path in rewritten_paths(&out) {
+            assert_inside_tenant(path)?;
+        }
+    }
+
+    #[test]
+    fn kind_from_query_is_total(query in input()) {
+        let kind = Kind::from_query(&query);
+        let flagged = query.split('&').any(|p| p == "raw" || p == "url");
+        prop_assert_eq!(flagged, matches!(kind, Kind::Raw | Kind::Url));
+    }
+}

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -272,63 +272,58 @@ pub fn normalize(path: &str) -> String {
 pub fn strip_jsonc(text: &str) -> String {
     let bytes = text.as_bytes();
     let mut out = String::with_capacity(text.len());
-    let mut i = 0;
-    let mut in_str = false;
+    let (mut i, mut kept, mut in_str) = (0, 0, false);
     while i < bytes.len() {
         let c = bytes[i];
         if in_str {
-            out.push(c as char);
-            if c == b'\\' && i + 1 < bytes.len() {
-                out.push(bytes[i + 1] as char);
-                i += 2;
-                continue;
+            match c {
+                b'\\' => i += 2,
+                b'"' => {
+                    in_str = false;
+                    i += 1;
+                }
+                _ => i += 1,
             }
-            if c == b'"' {
-                in_str = false;
-            }
-            i += 1;
             continue;
         }
         match c {
             b'"' => {
                 in_str = true;
-                out.push('"');
                 i += 1;
             }
-            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'/' => {
+            b'/' if bytes.get(i + 1) == Some(&b'/') => {
+                out.push_str(&text[kept..i]);
                 while i < bytes.len() && bytes[i] != b'\n' {
                     i += 1;
                 }
+                kept = i;
             }
-            b'/' if i + 1 < bytes.len() && bytes[i + 1] == b'*' => {
+            b'/' if bytes.get(i + 1) == Some(&b'*') => {
+                out.push_str(&text[kept..i]);
                 i += 2;
                 while i + 1 < bytes.len() && !(bytes[i] == b'*' && bytes[i + 1] == b'/') {
                     i += 1;
                 }
-                i += 2;
+                i = (i + 2).min(bytes.len());
+                kept = i;
             }
-            b',' => {
-                let mut j = i + 1;
-                while j < bytes.len() && (bytes[j] as char).is_whitespace() {
-                    j += 1;
+            b'}' | b']' => {
+                out.push_str(&text[kept..i]);
+                let end = out.trim_end_matches([' ', '\t', '\n', '\r']).len();
+                if end > 0 && out.as_bytes()[end - 1] == b',' {
+                    out.remove(end - 1);
                 }
-                if j < bytes.len() && (bytes[j] == b'}' || bytes[j] == b']') {
-                    i += 1;
-                    continue;
-                }
-                out.push(',');
+                kept = i;
                 i += 1;
             }
-            _ => {
-                out.push(c as char);
-                i += 1;
-            }
+            _ => i += 1,
         }
     }
+    out.push_str(&text[kept..]);
     out
 }
 
-fn tsconfig_paths(text: &str) -> Vec<(String, String)> {
+pub(crate) fn tsconfig_paths(text: &str) -> Vec<(String, String)> {
     let Ok(json) = serde_json::from_str::<serde_json::Value>(&strip_jsonc(text)) else { return vec![] };
     let Some(co) = json.get("compilerOptions") else { return vec![] };
     let base_url = co.get("baseUrl").and_then(|b| b.as_str()).unwrap_or(".");
@@ -345,7 +340,7 @@ fn tsconfig_paths(text: &str) -> Vec<(String, String)> {
     out
 }
 
-fn import_map(text: &str) -> Vec<(String, String)> {
+pub(crate) fn import_map(text: &str) -> Vec<(String, String)> {
     let Ok(json) = serde_json::from_str::<serde_json::Value>(&strip_jsonc(text)) else { return vec![] };
     let Some(imports) = json.get("imports").and_then(|p| p.as_object()) else { return vec![] };
     let mut out: Vec<(String, String)> = imports.iter().filter_map(|(k, v)| v.as_str().map(|v| (k.clone(), v.to_string()))).collect();
@@ -370,6 +365,15 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&strip_jsonc(t)).unwrap();
         assert_eq!(v["b"], "//not");
         assert_eq!(v["a"].as_array().unwrap().len(), 2);
+    }
+
+    #[test]
+    fn strip_jsonc_keeps_multibyte_text_and_drops_commas_before_comments() {
+        let t = "{\n  \"site\": \"https://exämple.com\", // ünicode\n  \"x\": [\"字\", /* last */ ],\n}";
+        let v: serde_json::Value = serde_json::from_str(&strip_jsonc(t)).unwrap();
+        assert_eq!(v["site"], "https://exämple.com");
+        assert_eq!(v["x"][0], "字");
+        assert!(strip_jsonc(t).len() <= t.len());
     }
 
     #[test]

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -330,25 +330,34 @@ impl Engine {
     }
 }
 
-fn svg_size(svg: &str) -> (usize, usize) {
+pub(crate) fn svg_size(svg: &str) -> (usize, usize) {
     let Some(open) = svg.find("<svg") else { return (0, 0) };
     let tag = &svg[open..svg[open..].find('>').map(|i| open + i).unwrap_or(svg.len())];
-    let attr = |name: &str| -> Option<String> {
-        let i = tag.find(&format!(" {name}="))?;
-        let rest = &tag[i + name.len() + 2..];
-        let q = rest.chars().next()?;
-        let end = rest[1..].find(q)?;
-        Some(rest[1..1 + end].to_string())
-    };
-    let num = |v: String| v.trim().trim_end_matches("px").parse::<f64>().ok().map(|n| n.round() as usize);
-    match (attr("width").and_then(num), attr("height").and_then(num)) {
+    let length = |v: &str| v.trim().trim_end_matches("px").parse().ok().and_then(pixels);
+    match (svg_attr(tag, "width").and_then(length), svg_attr(tag, "height").and_then(length)) {
         (Some(w), Some(h)) => (w, h),
         _ => {
-            let vb = attr("viewBox").unwrap_or_default();
+            let vb = svg_attr(tag, "viewBox").unwrap_or_default();
             let parts: Vec<f64> = vb.split([' ', ',']).filter_map(|p| p.trim().parse().ok()).collect();
-            if parts.len() == 4 { (parts[2].round() as usize, parts[3].round() as usize) } else { (0, 0) }
+            match parts[..] {
+                [_, _, w, h] => (pixels(w).unwrap_or(0), pixels(h).unwrap_or(0)),
+                _ => (0, 0),
+            }
         }
     }
+}
+
+fn svg_attr<'a>(tag: &'a str, name: &str) -> Option<&'a str> {
+    let i = tag.find(&format!(" {name}="))?;
+    let rest = &tag[i + name.len() + 2..];
+    let quote = rest.chars().next().filter(|q| *q == '"' || *q == '\'')?;
+    let end = rest[1..].find(quote)?;
+    Some(&rest[1..1 + end])
+}
+
+/// `inf`, `NaN`, `1e999` and negatives parse as f64 but are not sizes an image can have.
+fn pixels(n: f64) -> Option<usize> {
+    (0.0..=u32::MAX as f64).contains(&n).then(|| n.round() as usize)
 }
 
 pub fn json_str(s: &str) -> String {
@@ -358,4 +367,18 @@ pub fn json_str(s: &str) -> String {
 pub fn is_source(path: &str) -> bool {
     matches!(path.rsplit_once('.').map(|(_, e)| e).unwrap_or(""), "astro" | "ts" | "tsx" | "js" | "jsx" | "mjs" | "mts" | "md")
         && path.starts_with("src/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::svg_size;
+
+    #[test]
+    fn svg_size_survives_junk_attributes() {
+        assert_eq!(svg_size("<svg width=€ height=\"1\">"), (0, 0));
+        assert_eq!(svg_size("<svg width=\"inf\" height=\"1e999\">"), (0, 0));
+        assert_eq!(svg_size("<svg viewBox=\"0 0 NaN -1\">"), (0, 0));
+        assert_eq!(svg_size("<svg width=\"24px\" height='16'>"), (24, 16));
+        assert_eq!(svg_size("<svg width=\"x\" viewBox=\"0,0,100.4,50.5\">"), (100, 51));
+    }
 }


### PR DESCRIPTION
Closes #11

Property tests (`proptest`, `std` feature only, as a dev-dependency) for every parser that reads attacker-controlled bytes: `clean_path`, `valid_id`, `strip_jsonc`, `tsconfig_paths`, `import_map`, `package_name`, `normalize`, `join`, `glob::find` and its option parser, `percent_decode`, `split_frontmatter`, `yaml_to_json`, `slugify`, `svg_size`, `rewrite_relative`, `Kind::from_query` and `tenant_from_host`. They live in `src/proptests.rs` and run as part of `cargo test`, so CI already covers them.

Inputs mix an adversarial token alphabet (dot segments, lone `%`, unbalanced quotes and brackets, comment openers, control characters, BOM, multi-byte UTF-8, `inf`/`NaN`/`1e999`, YAML anchors and aliases) with arbitrary Unicode, and one case in eight is a chunk repeated up to 64 KiB with a random tail. Invariants: nothing panics; `clean_path` output has no `..`/`.`/empty segment, no leading `/`, no `\`, and is a fixed point (also after `percent_decode`, the way the page handler uses it); `normalize`/`join` never yield a `..` segment and `join` is length-bounded; `percent_decode` output is never longer than its input and inverts `urlenc`; `strip_jsonc` output is never longer than its input and preserves the JSON value around comments and trailing commas; `svg_size` fits in `u32` and reads back generated `width`/`height`/`viewBox`; `glob::find` spans are in bounds, on char boundaries, sorted and non-overlapping, and generated calls round-trip through the option parser; `tenant_from_host` only returns a `valid_id` that reassembles the host; the frontmatter split is a partition of the source and `yaml_to_json` is always an object.

The default 256 cases per target finish in 0.2 s inside `cargo test`; `PROPTEST_CASES=20000 cargo test proptests` passes in 14 s.

## Bugs found (each fixed here, with a regression test next to the function)

**1. `percent_decode` (`src/http/preview.rs`) — one unauthenticated request aborts the daemon**
- input: `%aé` — a `%` with a multi-byte character inside the next two bytes (minimal case `%ࠀ`)
- panic: `byte index 3 is not a char boundary; it is inside 'é'`, from `&s[i + 1..i + 3]`
- reach: hyper passes raw non-ASCII bytes in the request target through to the `page` fallback handler, and the release profile is `panic = "abort"`. Sending `GET /%aé HTTP/1.1` to the pre-fix release binary killed it with SIGABRT (exit 134). Any visitor of any tenant host can do this; with preview tokens off it needs nothing at all.
- fix: read the two hex digits per byte; never slice the `&str`. Side effect: `%+1` is no longer decoded as `0x01` (`from_str_radix` accepted a sign).

**2. `svg_size` (`src/transform/mod.rs`) — one tenant file aborts the daemon**
- input: `<svg width=€ height="1">` saved as `src/logo.svg` and imported by any page
- panic: `start byte index 1 is not a char boundary; it is inside '€'`, from `rest[1..]` — whatever character followed `width=` was taken as the quote and sliced past its first byte
- reach: verified against the pre-fix release binary with `PUT /api/t/t/file/src/logo.svg` then `GET /__sl/m/src/logo.svg?v=1`: SIGABRT, every tenant gone. Reachable by anyone who can edit a tenant, including the chat tool's `write_file`.
- fix: attribute values must be quoted (the SVG grammar requires it anyway); sizes that parse as `inf`, `NaN`, `1e999` or negative are treated as absent instead of saturating to `usize::MAX` in the emitted module.

**3. `strip_jsonc` (`src/resolve.rs`) — two silent misparses**
- input: `"\u{85}"` — output grew from 2 to 4 bytes: every byte ≥ 0x80 was pushed `as char`, so `é` became `Ã©`. A non-ASCII `site` in `sandbox-lite.json` or a non-ASCII alias target in `tsconfig.json` was corrupted before it was ever looked up.
- input: `{ "": [ "", /* c */ ], // c\n }` — the trailing comma was only dropped when the bracket was the next non-whitespace byte, so a comment in between (the everyday `"strict": true, // why` before `}`) left it in place, serde_json rejected the file, and every alias was silently discarded.
- fix: copy ranges of the original text (comments and trailing commas are ASCII, so the ranges stay on char boundaries) and drop the comma once the closing bracket is reached.

## Test-spec corrections made during the run
The first draft also forbade `\` in `normalize`/`join`/`tsconfig_paths` output and failed on `dir = "\\\""`. Those paths are keys into an in-memory map and never reach a filesystem, so that rule now applies only to `clean_path`, which does.

## Checked, nothing there
- Nested YAML aliases in frontmatter (`a1: &a1 [*a0,*a0,…]`): serde_yaml refuses the document once expansion passes roughly 10⁴ nodes (180 B → 10⁴ nodes in 1.2 ms; the next level errors), so it is bounded.
- 64 KiB of `import.meta.glob(`, unclosed quotes, `/*`, `%`, `/..`, `@import '`: all linear, no span out of bounds.

## Noticed, not fixed
- `svg_attr` only matches a single space before the attribute name, so `<svg\twidth="1">` or `<svg\nwidth="1">` reads as no size (pre-existing).
- `glob`'s `string_literal` ignores backslash escapes while `matching_paren` honours them: `import.meta.glob("a\"b")` yields the pattern `a\`.
- `slugify("İ")` is `i` plus U+0307, a combining mark in a slug.

`tsconfig_paths`, `import_map` and `svg_size` are `pub(crate)` so the tests can reach them. No cargo-fuzz targets: proptest runs inside the existing `cargo test` CI step, and `PROPTEST_CASES=<n>` scales it locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
