### PR TITLE
security: constant-time tokens, tenant quota, HTTP timeouts, cookie SameSite flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1904,6 +1904,8 @@ dependencies = [
  "blake3",
  "globset",
  "grass",
+ "hyper",
+ "hyper-util",
  "imagesize",
  "oxc_allocator",
  "oxc_codegen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,9 @@ oxc_span = { git = "https://github.com/withastro/oxc", rev = "8bb526fc0c20beb464
 oxc_transformer = { git = "https://github.com/withastro/oxc", rev = "8bb526fc0c20beb4649b223d3ac39851505caa5a" }
 
 axum = "0.8"
-tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "sync", "signal"] }
+hyper = { version = "1", features = ["server", "http1"] }
+hyper-util = { version = "0.1", features = ["server-graceful", "service", "tokio"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "sync", "signal", "time"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
 tower = { version = "0.5", features = ["util"] }
 serde = { version = "1", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ Per-tenant state is the overlay (only edited files) plus a content-addressed
 transform cache shared by every tenant: two tenants with the same `Header.astro`
 share one compiled output. The cache has a byte budget (`--cache-mb`, default
 64), so its share of the daemon's memory is bounded regardless of tenant count;
-overlays grow with what tenants write.
+each overlay is capped by `--tenant-quota-mb` (default 64), and a write that
+would push a tenant past it is refused with `413`.
 
 ## Install
 
@@ -133,17 +134,28 @@ tenant. Every write shows up in the preview as it happens.
 --model NAME         Claude model for the chat endpoint (default claude-fable-5-1)
 --api-token TOKEN    require `Authorization: Bearer TOKEN` (or `?token=`) on /api/*
 --preview-secret S   tenant hosts require a per-tenant token derived from S
+--tenant-quota-mb N  edited files a tenant may hold, in MiB (default 64)
+--cookie-samesite lax|none
+                     SameSite of the preview cookie; none also sets Secure (default lax)
 ```
 
-`SANDBOX_LITE_API_TOKEN` and `SANDBOX_LITE_PREVIEW_SECRET` are read as defaults
-for the two auth flags. With a preview secret set, `/api/tenants` returns each
-tenant's `preview_token`; opening `http://<id>.<domain>/?sl_token=<token>` once
-sets a cookie for that host and redirects to the clean URL. Tokens are
-per-tenant, so a customer's link does not open another customer's preview.
+`SANDBOX_LITE_API_TOKEN`, `SANDBOX_LITE_PREVIEW_SECRET` and
+`SANDBOX_LITE_TENANT_QUOTA_MB` are read as defaults for those flags. With a
+preview secret set, `/api/tenants` returns each tenant's `preview_token`;
+opening `http://<id>.<domain>/?sl_token=<token>` once sets a cookie for that
+host and redirects to the clean URL. Tokens are per-tenant, so a customer's
+link does not open another customer's preview. The cookie is `SameSite=Lax`,
+which browsers send only on same-site requests: an editor that embeds previews
+from a different registrable domain (`app.example.com` framing
+`acme.preview.example.net`) needs `--cookie-samesite none`, which also marks
+the cookie `Secure`, so those previews must be served over HTTPS.
 
 In production put the daemon behind a wildcard DNS record (`*.preview.example.com`),
 pass `--domain preview.example.com`, set both secrets, and keep `/` and `/api`
-reachable only from your own backend.
+reachable only from your own backend. A connection that has not delivered a
+complete request head within 30 s — freshly opened or idle between keep-alive
+requests — is closed; streaming responses and uploads in progress are not
+affected.
 
 ### `check`: compile a project without serving it
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,10 +61,19 @@ credentials on the API side.
   (`DefaultBodyLimit`). No tenant-host handler reads a request body.
 - **Host matching** is exact: `a.b.<domain>` and `evil-<domain>` are not tenant
   hosts.
-- **The preview cookie** (`sl_t`) is set with `Path=/; HttpOnly; SameSite=Lax`
-  and no `Domain` attribute, so it is a host-only session cookie for that one
-  tenant host. `Secure` is added only when the request carried
-  `x-forwarded-proto: https`.
+- **The preview cookie** (`sl_t`) is set with `Path=/; HttpOnly` and no
+  `Domain` attribute, so it is a host-only session cookie for that one tenant
+  host. `--cookie-samesite` picks `SameSite=Lax` (the default; `Secure` is
+  added only when the request carried `x-forwarded-proto: https`) or
+  `SameSite=None; Secure`, which an editor on another registrable domain needs
+  before a framed preview will carry the cookie, and which browsers store only
+  over HTTPS.
+- **Connections** that have not delivered a complete request head within 30 s,
+  whether newly opened or idle between keep-alive requests, are closed.
+- **Per-tenant write volume** is capped by `--tenant-quota-mb` (default 64):
+  a write that would take the tenant's edited files past it is refused with
+  `413` before anything reaches disk or memory, and the chat `write_file` tool
+  gets the same error. Rewriting a file is charged only for the difference.
 
 The daemon sets no CORS, CSP, `X-Frame-Options` or `Referrer-Policy` headers.
 Cross-origin reads between tenant hosts are blocked by the browser's
@@ -107,7 +116,8 @@ endpoint, including `/__sl/raw/`, `/__sl/events` and `/__sl/check`.
 - `GET http://<id>.<domain>/any/path?sl_token=<token>`: a wrong token answers
   `403`; the right one answers `303` to the same path with the parameter
   removed and sets the `sl_t` cookie described above. Later requests are
-  accepted when the cookie equals the token, otherwise `403`.
+  accepted when the cookie equals the token, otherwise `403`. Both
+  comparisons, like the API token's, take constant time (`constant_time_eq`).
 - `/api/tenants` returns each tenant's `preview_token` and a ready-made
   `preview` link, so anyone with API access can open every preview.
 - The `preview` link the API builds is
@@ -175,12 +185,14 @@ editor stores the API token in `localStorage` and embeds tenant previews in an
 - Compilation is CPU work per request; `/__sl/check` and `/api/t/{id}/check`
   build every source file of a tenant on every call — a cache hit for an
   unchanged file, a compile for a changed one.
-- The transform cache is bounded by `--cache-mb`; tenant overlays are not. A
-  caller with API access can create any number of tenants and write files of
-  up to 64 MiB each. With persistence every write goes to disk under
-  `--data-dir`, and files over 256 KiB are kept only there and re-read on
-  demand; with `--no-persist`, every written file is held in memory whatever
-  its size.
+- No timeout once a request head has arrived: a body may trickle in, and a
+  response may be read slowly, for as long as the client likes.
+- The transform cache is bounded by `--cache-mb` and each tenant's overlay by
+  `--tenant-quota-mb`, but the number of tenants is not: a caller with API
+  access can create any number of them, each holding up to the quota. With
+  persistence every write goes to disk under `--data-dir`, and files over
+  256 KiB are kept only there and re-read on demand; with `--no-persist`,
+  every written file is held in memory whatever its size.
 - Tenant code is limited only by the visitor's browser.
 
 ## Deployment checklist
@@ -193,6 +205,7 @@ editor stores the API token in `localStorage` and embeds tenant previews in an
    and host; the TLS proxy sends `x-forwarded-proto: https` so the cookie is
    `Secure`.
 4. No secrets in base projects or tenant files.
-5. Your own limits on tenant count, write volume and request rate.
+5. Your own limits on tenant count and request rate; `--tenant-quota-mb`
+   bounds each tenant's write volume, not how many tenants there are.
 6. `ANTHROPIC_API_KEY` only if the chat endpoint is wanted, knowing what it
    sends and that the API token is the only thing gating it.

--- a/src/check.rs
+++ b/src/check.rs
@@ -60,7 +60,7 @@ fn is_npm_import(spec: &str) -> bool {
 pub fn inspect(dir: &Path) -> Result<Report, String> {
     let name = dir.file_name().map(|n| n.to_string_lossy().into_owned()).unwrap_or_else(|| dir.display().to_string());
     let base = Base::load("check", dir).map_err(|e| format!("{}: {e}", dir.display()))?;
-    let store = Store::new(None);
+    let store = Store::new(None, u64::MAX);
     store.add_base(base);
     let tenant = store.create_tenant("check", "check")?;
     let engine = Engine::new(Config { cdn: "https://esm.sh".into(), cache_bytes: 64 << 20 });

--- a/src/http/api.rs
+++ b/src/http/api.rs
@@ -13,7 +13,7 @@ use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::{Stream, StreamExt};
 
 use super::{AppState, State, mime};
-use crate::store::{Tenant, clean_path};
+use crate::store::{Tenant, WriteError, clean_path};
 use crate::transform::{Kind, is_source};
 
 pub async fn editor() -> Html<&'static str> {
@@ -134,6 +134,7 @@ pub async fn write_file(AxState(st): AxState<State>, Path((id, path)): Path<(Str
     let Some(path) = clean_path(&path) else { return err(StatusCode::BAD_REQUEST, "bad path") };
     match t.write(&path, body.to_vec()) {
         Ok(version) => Json(json!({ "path": path, "version": version })).into_response(),
+        Err(e @ WriteError::Quota { .. }) => err(StatusCode::PAYLOAD_TOO_LARGE, e.to_string()),
         Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
     }
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -2,8 +2,10 @@ pub mod ai;
 pub mod api;
 pub mod preview;
 
+use std::io::ErrorKind;
+use std::pin::pin;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use axum::Router;
 use axum::extract::{DefaultBodyLimit, Request, State as AxState};
@@ -12,6 +14,11 @@ use axum::http::{StatusCode, Uri};
 use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, post};
+use hyper::server::conn::http1;
+use hyper_util::rt::{TokioIo, TokioTimer};
+use hyper_util::server::graceful::GracefulShutdown;
+use hyper_util::service::TowerToHyperService;
+use tokio::net::TcpListener;
 use tower::ServiceExt;
 
 use crate::store::{Store, valid_id};
@@ -26,10 +33,61 @@ pub struct AppState {
     pub api_key: Option<String>,
     pub api_token: Option<String>,
     pub preview_secret: Option<String>,
+    pub cookie_samesite: SameSite,
     pub started: Instant,
 }
 
 pub type State = Arc<AppState>;
+
+#[derive(Clone, Copy)]
+pub enum SameSite {
+    Lax,
+    None,
+}
+
+impl std::str::FromStr for SameSite {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<SameSite, ()> {
+        match s.to_ascii_lowercase().as_str() {
+            "lax" => Ok(SameSite::Lax),
+            "none" => Ok(SameSite::None),
+            _ => Err(()),
+        }
+    }
+}
+
+const HEADER_READ_TIMEOUT: Duration = Duration::from_secs(30);
+const SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
+
+pub async fn serve(listener: TcpListener, app: Router, shutdown: impl Future<Output = ()>) {
+    let mut http = http1::Builder::new();
+    // hyper arms this timer whenever it waits for a request head, so it also closes idle keep-alive connections
+    http.timer(TokioTimer::new()).header_read_timeout(HEADER_READ_TIMEOUT);
+    let graceful = GracefulShutdown::new();
+    let mut shutdown = pin!(shutdown);
+    loop {
+        let stream = tokio::select! {
+            accepted = listener.accept() => match accepted {
+                Ok((stream, _)) => stream,
+                Err(e) => {
+                    if !matches!(e.kind(), ErrorKind::ConnectionRefused | ErrorKind::ConnectionAborted | ErrorKind::ConnectionReset) {
+                        eprintln!("accept: {e}");
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+                    }
+                    continue;
+                }
+            },
+            _ = &mut shutdown => break,
+        };
+        let conn = http.serve_connection(TokioIo::new(stream), TowerToHyperService::new(app.clone()));
+        tokio::spawn(graceful.watch(conn));
+    }
+    drop(listener);
+    if tokio::time::timeout(SHUTDOWN_GRACE, graceful.shutdown()).await.is_err() {
+        eprintln!("shutdown: closing connections still open after {}s", SHUTDOWN_GRACE.as_secs());
+    }
+}
 
 #[derive(Clone)]
 pub struct TenantId(pub String);
@@ -99,10 +157,20 @@ async fn require_api_token(AxState(st): AxState<State>, req: Request, next: Next
     }
     let header = req.headers().get(AUTHORIZATION).and_then(|h| h.to_str().ok()).and_then(|h| h.strip_prefix("Bearer "));
     let query = query_param(req.uri(), "token");
-    if header == Some(expected.as_str()) || query == Some(expected.as_str()) {
+    let valid = |given: Option<&str>| given.is_some_and(|g| constant_time_eq(g.as_bytes(), expected.as_bytes()));
+    if valid(header) || valid(query) {
         return next.run(req).await;
     }
     (StatusCode::UNAUTHORIZED, "missing or wrong api token\n").into_response()
+}
+
+pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    let mut diff = u8::from(a.len() != b.len());
+    for i in 0..a.len().max(b.len()) {
+        diff |= a.get(i).copied().unwrap_or(0) ^ b.get(i).copied().unwrap_or(0);
+    }
+    // black_box keeps the optimizer from turning the fold into an early exit
+    std::hint::black_box(diff) == 0
 }
 
 pub fn preview_token(secret: &str, tenant: &str) -> String {
@@ -117,13 +185,18 @@ async fn require_preview_token(AxState(st): AxState<State>, req: Request, next: 
     let Some(TenantId(id)) = req.extensions().get::<TenantId>().cloned() else { return next.run(req).await };
     let expected = preview_token(secret, &id);
     if let Some(token) = query_param(req.uri(), "sl_token") {
-        if token != expected {
+        if !constant_time_eq(token.as_bytes(), expected.as_bytes()) {
             return (StatusCode::FORBIDDEN, "wrong preview token\n").into_response();
         }
         let rest: Vec<&str> = req.uri().query().unwrap_or("").split('&').filter(|p| !p.starts_with("sl_token=")).collect();
         let location = if rest.is_empty() { req.uri().path().to_string() } else { format!("{}?{}", req.uri().path(), rest.join("&")) };
-        let secure = req.headers().get("x-forwarded-proto").and_then(|h| h.to_str().ok()) == Some("https");
-        let cookie = format!("{PREVIEW_COOKIE}={expected}; Path=/; HttpOnly; SameSite=Lax{}", if secure { "; Secure" } else { "" });
+        let forwarded_https = req.headers().get("x-forwarded-proto").and_then(|h| h.to_str().ok()) == Some("https");
+        let attributes = match st.cookie_samesite {
+            SameSite::Lax if forwarded_https => "SameSite=Lax; Secure",
+            SameSite::Lax => "SameSite=Lax",
+            SameSite::None => "SameSite=None; Secure",
+        };
+        let cookie = format!("{PREVIEW_COOKIE}={expected}; Path=/; HttpOnly; {attributes}");
         return (StatusCode::SEE_OTHER, [(LOCATION, location), (SET_COOKIE, cookie)]).into_response();
     }
     let has_cookie = req
@@ -132,7 +205,8 @@ async fn require_preview_token(AxState(st): AxState<State>, req: Request, next: 
         .iter()
         .filter_map(|c| c.to_str().ok())
         .flat_map(|c| c.split(';'))
-        .any(|c| c.trim().strip_prefix(PREVIEW_COOKIE).and_then(|r| r.strip_prefix('=')) == Some(expected.as_str()));
+        .filter_map(|c| c.trim().strip_prefix(PREVIEW_COOKIE).and_then(|r| r.strip_prefix('=')))
+        .any(|given| constant_time_eq(given.as_bytes(), expected.as_bytes()));
     if has_cookie {
         return next.run(req).await;
     }
@@ -178,7 +252,18 @@ pub fn mime(path: &str) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::{preview_token, tenant_from_host};
+    use super::{constant_time_eq, preview_token, tenant_from_host};
+
+    #[test]
+    fn constant_time_eq_compares_whole_slices() {
+        assert!(constant_time_eq(b"", b""));
+        assert!(constant_time_eq(b"token", b"token"));
+        assert!(!constant_time_eq(b"token", b"Token"));
+        assert!(!constant_time_eq(b"token", b"tokem"));
+        assert!(!constant_time_eq(b"token", b"toke"));
+        assert!(!constant_time_eq(b"token", b"tokens"));
+        assert!(!constant_time_eq(b"", b"a"));
+    }
 
     #[test]
     fn preview_tokens_are_stable_and_tenant_specific() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,11 +23,13 @@ struct Args {
     model: String,
     api_token: Option<String>,
     preview_secret: Option<String>,
+    tenant_quota_mb: u64,
+    cookie_samesite: http::SameSite,
 }
 
 fn usage() -> ! {
     eprintln!(
-        "sandbox-lite {}\n\nUsage: sandbox-lite [options]\n       sandbox-lite check [--json] DIR...   compile every source file of an Astro project and print diagnostics + a feature census\n\n  --listen ADDR       bind address (default 127.0.0.1:4321)\n  --domain NAME       preview domain; tenants are served at http://<id>.NAME:PORT/ (default localhost)\n  --bases DIR         directory whose sub-directories are base projects (default ./examples if present)\n  --base NAME=PATH    add one base project (repeatable)\n  --data-dir DIR      where tenant edits are persisted (default ./data)\n  --no-persist        keep tenant edits in memory only\n  --cdn URL           where bare npm imports are fetched from in the browser (default https://esm.sh)\n  --cache-mb N        transform cache budget in MiB (default 64)\n  --model NAME        Claude model for the built-in chat (default claude-fable-5-1)\n  --api-token TOKEN   require `Authorization: Bearer TOKEN` (or ?token=) on /api/*\n  --preview-secret S  tenant hosts need a per-tenant token derived from S (the API hands it out)\n\nEnvironment: ANTHROPIC_API_KEY enables the chat endpoint; SANDBOX_LITE_API_TOKEN and SANDBOX_LITE_PREVIEW_SECRET are read as defaults for the two flags.",
+        "sandbox-lite {}\n\nUsage: sandbox-lite [options]\n       sandbox-lite check [--json] DIR...   compile every source file of an Astro project and print diagnostics + a feature census\n\n  --listen ADDR        bind address (default 127.0.0.1:4321)\n  --domain NAME        preview domain; tenants are served at http://<id>.NAME:PORT/ (default localhost)\n  --bases DIR          directory whose sub-directories are base projects (default ./examples if present)\n  --base NAME=PATH     add one base project (repeatable)\n  --data-dir DIR       where tenant edits are persisted (default ./data)\n  --no-persist         keep tenant edits in memory only\n  --cdn URL            where bare npm imports are fetched from in the browser (default https://esm.sh)\n  --cache-mb N         transform cache budget in MiB (default 64)\n  --model NAME         Claude model for the built-in chat (default claude-fable-5-1)\n  --api-token TOKEN    require `Authorization: Bearer TOKEN` (or ?token=) on /api/*\n  --preview-secret S   tenant hosts need a per-tenant token derived from S (the API hands it out)\n  --tenant-quota-mb N  edited files a tenant may hold, in MiB; a write past it is refused with 413 (default 64)\n  --cookie-samesite lax|none\n                       SameSite of the preview cookie; none also sets Secure (default lax)\n\nEnvironment: ANTHROPIC_API_KEY enables the chat endpoint; SANDBOX_LITE_API_TOKEN, SANDBOX_LITE_PREVIEW_SECRET and SANDBOX_LITE_TENANT_QUOTA_MB are read as defaults for those flags.",
         env!("CARGO_PKG_VERSION")
     );
     std::process::exit(2)
@@ -45,6 +47,11 @@ fn parse_args() -> Args {
         model: "claude-fable-5-1".into(),
         api_token: std::env::var("SANDBOX_LITE_API_TOKEN").ok().filter(|v| !v.is_empty()),
         preview_secret: std::env::var("SANDBOX_LITE_PREVIEW_SECRET").ok().filter(|v| !v.is_empty()),
+        tenant_quota_mb: std::env::var("SANDBOX_LITE_TENANT_QUOTA_MB")
+            .ok()
+            .filter(|v| !v.is_empty())
+            .map_or(64, |v| v.parse().unwrap_or_else(|_| usage())),
+        cookie_samesite: http::SameSite::Lax,
     };
     let mut it = std::env::args().skip(1);
     while let Some(a) = it.next() {
@@ -65,6 +72,8 @@ fn parse_args() -> Args {
             "--model" => args.model = value(),
             "--api-token" => args.api_token = Some(value()),
             "--preview-secret" => args.preview_secret = Some(value()),
+            "--tenant-quota-mb" => args.tenant_quota_mb = value().parse().unwrap_or_else(|_| usage()),
+            "--cookie-samesite" => args.cookie_samesite = value().parse().unwrap_or_else(|_| usage()),
             "-h" | "--help" => usage(),
             _ => usage(),
         }
@@ -92,7 +101,7 @@ async fn main() {
         check_command(&argv[1..]);
     }
     let args = parse_args();
-    let store = store::Store::new(args.data_dir.clone());
+    let store = store::Store::new(args.data_dir.clone(), args.tenant_quota_mb.saturating_mul(1 << 20));
     let mut bases = args.bases.clone();
     if let Some(dir) = &args.bases_dir {
         match std::fs::read_dir(dir) {
@@ -140,6 +149,7 @@ async fn main() {
         api_key,
         api_token: args.api_token.clone(),
         preview_secret: args.preview_secret.clone(),
+        cookie_samesite: args.cookie_samesite,
         started: Instant::now(),
     });
     let listener = match tokio::net::TcpListener::bind(&args.listen).await {
@@ -158,7 +168,7 @@ async fn main() {
         if state.preview_secret.is_some() { "required" } else { "off" }
     );
     let app = http::app(state);
-    axum::serve(listener, app).with_graceful_shutdown(shutdown_signal()).await.unwrap();
+    http::serve(listener, app, shutdown_signal()).await;
 }
 
 async fn shutdown_signal() {

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, HashMap};
+use std::fmt;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -118,6 +119,31 @@ fn now_millis() -> u64 {
     SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_millis() as u64).unwrap_or(1)
 }
 
+#[derive(Debug)]
+pub enum WriteError {
+    Quota { quota: u64, after: u64 },
+    Io(io::Error),
+}
+
+impl fmt::Display for WriteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            WriteError::Quota { quota, after } => {
+                write!(f, "tenant quota exceeded: edited files would total {after} bytes, the quota is {quota} bytes (--tenant-quota-mb)")
+            }
+            WriteError::Io(e) => fmt::Display::fmt(e, f),
+        }
+    }
+}
+
+impl std::error::Error for WriteError {}
+
+impl From<io::Error> for WriteError {
+    fn from(e: io::Error) -> WriteError {
+        WriteError::Io(e)
+    }
+}
+
 pub struct Tenant {
     pub id: String,
     pub base: Arc<Base>,
@@ -125,6 +151,7 @@ pub struct Tenant {
     version: AtomicU64,
     pub events: broadcast::Sender<String>,
     dir: Option<PathBuf>,
+    quota: u64,
 }
 
 pub struct Entry {
@@ -134,9 +161,9 @@ pub struct Entry {
 }
 
 impl Tenant {
-    fn new(id: String, base: Arc<Base>, dir: Option<PathBuf>) -> Tenant {
+    fn new(id: String, base: Arc<Base>, dir: Option<PathBuf>, quota: u64) -> Tenant {
         let (events, _) = broadcast::channel(64);
-        Tenant { id, base, overlay: RwLock::new(BTreeMap::new()), version: AtomicU64::new(now_millis()), events, dir }
+        Tenant { id, base, overlay: RwLock::new(BTreeMap::new()), version: AtomicU64::new(now_millis()), events, dir, quota }
     }
 
     pub fn version(&self) -> u64 {
@@ -180,7 +207,14 @@ impl Tenant {
         out.into_iter().map(|(path, (size, modified))| Entry { path, size, modified }).collect()
     }
 
-    pub fn write(&self, path: &str, bytes: Vec<u8>) -> io::Result<u64> {
+    pub fn write(&self, path: &str, bytes: Vec<u8>) -> Result<u64, WriteError> {
+        // held across the disk write so a concurrent write cannot slip past the quota check
+        let mut overlay = self.overlay.write().unwrap();
+        let replaced = overlay.get(path).and_then(|d| d.as_ref()).map_or(0, |d| d.size());
+        let after = overlay_bytes(&overlay) - replaced + bytes.len() as u64;
+        if after > self.quota {
+            return Err(WriteError::Quota { quota: self.quota, after });
+        }
         if let Some(dir) = &self.dir {
             let target = dir.join("files").join(path);
             if let Some(parent) = target.parent() {
@@ -192,11 +226,8 @@ impl Tenant {
             Some(dir) if bytes.len() as u64 > INLINE_LIMIT => FileData::Disk(dir.join("files").join(path), bytes.len() as u64),
             _ => FileData::Mem(bytes.into()),
         };
-        let was_tombstone = {
-            let mut overlay = self.overlay.write().unwrap();
-            let prev = overlay.insert(path.to_string(), Some(data));
-            matches!(prev, Some(None))
-        };
+        let was_tombstone = matches!(overlay.insert(path.to_string(), Some(data)), Some(None));
+        drop(overlay);
         if was_tombstone {
             self.persist_tombstones()?;
         }
@@ -248,8 +279,7 @@ impl Tenant {
 
     pub fn overlay_stats(&self) -> (usize, u64) {
         let overlay = self.overlay.read().unwrap();
-        let bytes = overlay.values().filter_map(|d| d.as_ref()).map(|d| d.size()).sum();
-        (overlay.len(), bytes)
+        (overlay.len(), overlay_bytes(&overlay))
     }
 
     fn restore_overlay(&self, dir: &Path) -> io::Result<()> {
@@ -272,15 +302,20 @@ impl Tenant {
     }
 }
 
+fn overlay_bytes(overlay: &BTreeMap<String, Option<FileData>>) -> u64 {
+    overlay.values().flatten().map(|d| d.size()).sum()
+}
+
 pub struct Store {
     bases: RwLock<HashMap<String, Arc<Base>>>,
     tenants: RwLock<HashMap<String, Arc<Tenant>>>,
     data_dir: Option<PathBuf>,
+    tenant_quota: u64,
 }
 
 impl Store {
-    pub fn new(data_dir: Option<PathBuf>) -> Store {
-        Store { bases: RwLock::new(HashMap::new()), tenants: RwLock::new(HashMap::new()), data_dir }
+    pub fn new(data_dir: Option<PathBuf>, tenant_quota: u64) -> Store {
+        Store { bases: RwLock::new(HashMap::new()), tenants: RwLock::new(HashMap::new()), data_dir, tenant_quota }
     }
 
     pub fn add_base(&self, base: Base) {
@@ -311,7 +346,7 @@ impl Store {
             std::fs::write(dir.join("tenant.json"), format!(r#"{{"base":{}}}"#, serde_json::to_string(base_name).unwrap()))
                 .map_err(|e| e.to_string())?;
         }
-        let tenant = Arc::new(Tenant::new(id.to_string(), base, dir));
+        let tenant = Arc::new(Tenant::new(id.to_string(), base, dir, self.tenant_quota));
         self.tenants.write().unwrap().insert(id.to_string(), tenant.clone());
         Ok(tenant)
     }
@@ -360,7 +395,7 @@ impl Store {
                 eprintln!("tenant {id}: base '{base_name}' is not loaded, skipping");
                 continue;
             };
-            let tenant = Tenant::new(id.clone(), base, Some(dir.clone()));
+            let tenant = Tenant::new(id.clone(), base, Some(dir.clone()), self.tenant_quota);
             tenant.restore_overlay(&dir)?;
             self.tenants.write().unwrap().insert(id, Arc::new(tenant));
             n += 1;
@@ -371,7 +406,47 @@ impl Store {
 
 #[cfg(test)]
 mod tests {
-    use super::{clean_path, is_private_path};
+    use super::*;
+
+    fn tenant(quota: u64, dir: Option<PathBuf>) -> Tenant {
+        let base = Base { name: "b".into(), root: PathBuf::from("."), files: BTreeMap::new() };
+        Tenant::new("t".into(), Arc::new(base), dir, quota)
+    }
+
+    #[test]
+    fn quota_bounds_the_overlay_after_the_write() {
+        let t = tenant(10, None);
+        t.write("a", vec![0; 6]).unwrap();
+        let err = t.write("b", vec![0; 5]).unwrap_err();
+        assert!(matches!(err, WriteError::Quota { quota: 10, after: 11 }), "{err}");
+        assert!(err.to_string().contains("quota"));
+        assert_eq!(t.overlay_stats(), (1, 6));
+        t.write("a", vec![0; 10]).unwrap();
+        assert!(t.write("a", vec![0; 11]).is_err());
+        t.delete("a").unwrap();
+        t.write("b", vec![0; 10]).unwrap();
+        assert_eq!(t.overlay_stats(), (1, 10));
+    }
+
+    #[test]
+    fn io_errors_keep_their_message() {
+        let err = WriteError::from(io::Error::new(io::ErrorKind::NotFound, "boom"));
+        assert_eq!(err.to_string(), "boom");
+    }
+
+    #[test]
+    fn quota_counts_disk_entries_and_refuses_before_touching_disk() {
+        let dir = std::env::temp_dir().join(format!("sandbox-lite-quota-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let big = INLINE_LIMIT as usize + 1;
+        let t = tenant(2 * big as u64 - 1, Some(dir.clone()));
+        t.write("big", vec![0; big]).unwrap();
+        assert!(matches!(t.data("big"), Some(FileData::Disk(_, n)) if n == big as u64));
+        assert!(matches!(t.write("big2", vec![0; big]), Err(WriteError::Quota { .. })));
+        assert!(!dir.join("files").join("big2").exists());
+        assert_eq!(t.overlay_stats(), (1, big as u64));
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
 
     #[test]
     fn private_paths() {


### PR DESCRIPTION
Closes #6

Four server-side hardenings, each verified against a daemon running locally (`--listen 127.0.0.1:4506 --bases examples --no-persist --api-token t --preview-secret s --tenant-quota-mb 1`). Rebased onto `main` after #22 and the SIGTERM change; upstream's `shutdown_signal()` now drives the new serve loop.

**Constant-time token comparison.** `require_api_token` and `require_preview_token` compared secrets with `==`. Both now go through `constant_time_eq` (`src/http/mod.rs`), which folds every byte of both slices: a length mismatch is one more bit in the fold rather than an early return, and `black_box` keeps the optimizer from short-circuiting. Unit test covers equal, first-byte, last-byte, shorter, longer and empty inputs.

**Per-tenant overlay quota.** `--tenant-quota-mb N` (default 64, env `SANDBOX_LITE_TENANT_QUOTA_MB`). `Tenant::write` now returns `Result<u64, WriteError>`. The check runs under the overlay write lock *before* the disk write, so a concurrent write cannot slip past it and a refused write never reaches disk or memory; it counts Mem and Disk entries alike and charges a rewrite only for its delta. `PUT /api/t/{id}/file/{path}` maps `WriteError::Quota` to `413 {"error":"tenant quota exceeded: edited files would total N bytes, the quota is M bytes (--tenant-quota-mb)"}`; the chat `write_file` tool returns `error: <same message>` through its existing Display path. Two unit tests in `src/store.rs` (Mem accounting with rewrite delta and delete; a Disk entry counted, and the next write refused before its file is created), plus one pinning that an `Io` error keeps its message.

**HTTP timeouts.** `axum::serve` in the pinned 0.8.9 never calls `.timer()`, so hyper's default 30 s header-read timeout was inert (hyper only `warn!`s through `tracing`, which nothing subscribes to). Measured on the unmodified binary: a socket that sends nothing, one that sends half a request line, and an idle keep-alive connection after a completed request all stayed open past 45 s. `http::serve` now runs the accept loop over `hyper::server::conn::http1::Builder` with a `TokioTimer` and `header_read_timeout(30 s)`; hyper re-arms that timer whenever it waits for a request head, so the same knob closes idle keep-alive connections. I used hyper's http1 builder rather than `hyper_util::server::conn::auto::Builder`: `server-auto` pulls in h2 and would start serving h2c, which the daemon does not do today (axum's `http2` feature is off), so this keeps the protocol surface and the dependency tree as they were (only `hyper` and `hyper-util`, both already compiled, become direct dependencies). Graceful shutdown is kept through `hyper_util::server::graceful::GracefulShutdown` and is now bounded to 5 s: on the unmodified binary, ctrl-c with one SSE client attached hung the process until that client went away; now it exits after 5 s with `shutdown: closing connections still open after 5s`, and within 50 ms when nothing is streaming.

**`--cookie-samesite lax|none`** (default lax). `none` always adds `Secure`; `lax` keeps the `x-forwarded-proto: https` → `Secure` behaviour. Documented in the README flag block and auth paragraph, and in SECURITY.md.

No new routes. `SECURITY.md`'s cookie, overlay and limits statements were rewritten to match the code; `ARCHITECTURE.md` has no sentence this changes.

## Verified

- **Quota** (`curl -X PUT --data-binary @file`, quota 1 MiB): 2 MiB → 413; 512 KiB → 200; +600 KiB → 413; rewrite 512 KiB → 900 KiB → 200 and `/api/tenants` reports `overlay_bytes: 921600`; DELETE then exactly 1 MiB → 200; 1 MiB + 1 → 413; a 1-byte write with the quota full → 413. The same 413 with `SANDBOX_LITE_TENANT_QUOTA_MB=1` and no flag.
- **API token**: none / wrong / longer bearer → 401; `Authorization: Bearer t` and `?token=t` → 200; `/health` exempt.
- **Preview token**: no cookie → 403; wrong `?sl_token` → 403; right one → `303 Location: /?keep=1` with `Set-Cookie: sl_t=…; Path=/; HttpOnly; SameSite=Lax`; cookie → 200; altered cookie → 403. With `--cookie-samesite none`: `SameSite=None; Secure` over plain http and behind `x-forwarded-proto: https`; with the default and `x-forwarded-proto: https`: `SameSite=Lax; Secure`.
- **Timeouts** (python raw sockets): silent socket, half-sent request line, and idle keep-alive after a `200` all closed by the server at 30.0 s; the unmodified binary kept all three open at 45 s. `curl -N -m 45` on `/api/t/x/events?token=t` and on `/__sl/events` (with the cookie) stayed open for the full 45 s (hello event plus keep-alive comments; curl exit 28). A 700 KiB PUT at `--limit-rate 20k` (35 s, longer than the header timeout) → 200 and the file reads back byte-identical.
- **Shutdown**: SIGINT with an SSE client attached → exit after ~5 s with the log line; SIGINT / SIGTERM with no clients → 44 ms / 23 ms.
- **Flags**: `--cookie-samesite strict`, `--tenant-quota-mb lots` and `SANDBOX_LITE_TENANT_QUOTA_MB=abc` exit 2 with the usage text.
- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (18 passed), `cargo build --release && ./target/release/sandbox-lite check examples/*` (0 errors for starter, tailwind, react).

## Checklist

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [x] `cargo build --release && ./target/release/sandbox-lite check examples/*`
- [ ] If `src/transform/`, `src/resolve.rs`, `assets/shell.js` or a shim changed: opened the affected example in a browser — none of them changed
- [x] If behaviour changed: `README.md` / `ARCHITECTURE.md` / `SECURITY.md` updated and each sentence checked against the code
- [x] New routes: none
- [x] Comments only say what the code cannot (why, an outside constraint); no restated code, no changelog

## Noticed, did not fix

- The quota is checked after axum has buffered the whole body (up to the 64 MiB `DefaultBodyLimit`); a `Content-Length` pre-check in `write_file` would refuse a hopeless upload before reading it.
- Nothing times a request body in progress or a slow reader of a response (SECURITY.md now says so). `tower_http::timeout::RequestBodyTimeoutLayer` on the API router would close the body side without touching SSE; a slow reader needs a write timeout hyper does not offer.
- `Tenant::write` and `Tenant::delete` do blocking file IO on the async runtime thread: `write_file` and `delete_file` call them directly, unlike `check`, which uses `spawn_blocking`. With the quota check now under the overlay lock, a big persisted write also blocks that tenant's readers for the duration of the `fs::write`.
- A tenant restored from `--data-dir` while above the quota keeps its files; writes that would keep it above are refused and deletes always work. Reasonable, but undocumented.
- `?token=` and `?sl_token=` values are compared without percent-decoding (pre-existing); a token containing `+` or `%` would fail in the query form.
- The `preview` link built by `/api/tenants` is `http://…:<port>` whatever proxy is in front (already noted in SECURITY.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
