### PR TITLE
content: read content.config.ts statically (glob base, file loader, date fields)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -253,15 +253,29 @@ The transform cache never sees the version; it is content-addressed.
 
 ## Content collections and Markdown (`src/transform/content.rs`)
 
-`/__sl/content/<name>` reads `src/content/<name>/` and returns entries:
-`.md`/`.markdown` with parsed YAML frontmatter as `data`, the body, the
-rendered HTML and headings; `.mdx` with `data` and the body only; `.json`
-arrays as one entry per item, other JSON as one entry; `.yaml`/`.yml` as one
-entry. The `astro:content` shim fetches that JSON, revives ISO dates, and
-implements `getCollection`, `getEntry` and `render` on top of it; for an
-`.mdx` entry `render` imports the compiled module at `/__sl/m/<filePath>` and
-returns its `Content`, `getHeadings()` and `frontmatter`. `content.config.ts`
-is not executed.
+`/__sl/content/<name>` returns `{entries, dates}`. An entry is `.md`/
+`.markdown` with parsed YAML frontmatter as `data`, the body, the rendered
+HTML and headings; `.mdx` with `data` and the body only; `.json` arrays as one
+entry per item, other JSON as one entry; `.yaml`/`.yml` as one entry. The
+`astro:content` shim fetches that JSON and implements `getCollection`,
+`getEntry` and `render` on top of it; for an `.mdx` entry `render` imports the
+compiled module at `/__sl/m/<filePath>` and returns its `Content`,
+`getHeadings()` and `frontmatter`.
+
+Which files those are comes from `src/content.config.ts` (or the Astro 2–4
+`src/content/config.ts`), parsed with oxc and never executed. `parse_config`
+maps `export const collections = { name: … }` to the `defineCollection({…})`
+literal behind each name and reads three things out of it: a
+`glob({ pattern, base })` loader — patterns matched with `globset` under
+`base`, negations included, ids being the base-relative path without its
+extension, lower-cased; a `file(path)` loader — one JSON or YAML file whose
+top level is an array of objects with an `id` or an object keyed by id; and
+the `z.date()` / `z.coerce.date()` fields of a `schema: z.object({…})`
+literal, which become the `dates` list the shim turns into `Date` objects.
+Anything the reader cannot see through — a computed pattern, a custom loader,
+a schema built by a function — leaves that part unset, and the collection
+falls back to `src/content/<name>/` with the shim's ISO-shaped-string guess
+for dates.
 
 ## `check` (`src/check.rs`)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2167,6 +2167,7 @@ dependencies = [
  "hyper-util",
  "imagesize",
  "oxc_allocator 0.115.0",
+ "oxc_ast 0.115.0",
  "oxc_codegen 0.115.0",
  "oxc_diagnostics 0.115.0",
  "oxc_parser 0.115.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ description = "Multi-tenant live preview for Astro sites: one small daemon, no N
 [dependencies]
 astro_codegen = { git = "https://github.com/withastro/compiler-rs", rev = "228b54e8c74915d50ece7a9c317818816b7097e1" }
 oxc_allocator = { git = "https://github.com/withastro/oxc", rev = "8bb526fc0c20beb4649b223d3ac39851505caa5a" }
+oxc_ast = { git = "https://github.com/withastro/oxc", rev = "8bb526fc0c20beb4649b223d3ac39851505caa5a" }
 oxc_diagnostics = { git = "https://github.com/withastro/oxc", rev = "8bb526fc0c20beb4649b223d3ac39851505caa5a" }
 oxc_codegen = { git = "https://github.com/withastro/oxc", rev = "8bb526fc0c20beb4649b223d3ac39851505caa5a", default-features = false }
 oxc_parser = { git = "https://github.com/withastro/oxc", rev = "8bb526fc0c20beb4649b223d3ac39851505caa5a", features = ["astro"] }

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Tenant host (`<id>.<domain>`):
 | `/__sl/raw/<path>` | file as-is (assets, `@import`ed CSS) |
 | `/__sl/routes.json` | route table built from `src/pages`, in Astro priority order |
 | `/__sl/renderers.json` | framework renderers to register, derived from `package.json` (`@astrojs/react`, `@astrojs/preact`) or `sandbox-lite.json` |
-| `/__sl/content/<collection>` | `src/content/<collection>/*` as entries; Markdown arrives rendered, MDX entries render through their compiled module |
+| `/__sl/content/<collection>` | `{entries, dates}` — the collection's entries and the schema's date fields; Markdown arrives rendered, MDX entries render through their compiled module |
 | `/__sl/shim/astro-*.js` | browser stand-ins for `astro:content`, `astro:assets`, `astro:transitions`, …; `astro-jsx-runtime.js` is Astro's JSX runtime and `astro:jsx` renderer |
 | `/__sl/astro.js` | Astro's runtime + container API, bundled once per Astro version |
 | `/__sl/events` | same SSE stream as the API; the page reloads itself on it |
@@ -264,9 +264,13 @@ e2e/                   Playwright suite for the browser side: every example page
   `client` entrypoint, listed under `renderers` in `sandbox-lite.json`.
 - **Endpoints.** `src/pages/*.ts` endpoints show an "unsupported route" page.
 - **Less/Stylus.** Sass works; other preprocessors are passed through untouched.
-- **`content.config.ts` loaders.** Collections are read straight from
-  `src/content/<name>/`, which is what the `glob` loader does for almost every
-  theme; custom loaders are ignored.
+- **`content.config.ts` loaders.** The config is read statically, never
+  executed: `glob({ pattern, base })` and `file(path)` with literal arguments
+  are honoured, and `z.date()` / `z.coerce.date()` fields in a `z.object({…})`
+  schema are revived as `Date` exactly. A loader the reader cannot see through
+  — a custom one, or a pattern built from a variable — falls back to reading
+  `src/content/<name>/`; a schema it cannot see through falls back to reviving
+  every ISO-shaped string.
 - **`astro.config.*`** is not executed. `site` can be set in `sandbox-lite.json`
   (`{"site": "https://example.com", "imports": {"react": "https://esm.sh/react@19"}}`).
 - **Authentication.** There are no users: `--api-token` is one shared bearer

--- a/assets/shims/astro-content.js
+++ b/assets/shims/astro-content.js
@@ -15,12 +15,25 @@ function reviveDates(value) {
   return value;
 }
 
+// The daemon read `z.date()` / `z.coerce.date()` out of the schema, so guessing by shape is not needed.
+function reviveFields(data, paths) {
+  for (const path of paths) {
+    const keys = path.split(".");
+    let obj = data;
+    for (let i = 0; i < keys.length - 1 && obj; i++) obj = obj[keys[i]];
+    const key = keys[keys.length - 1];
+    const value = obj?.[key];
+    if (typeof value === "string" || typeof value === "number") obj[key] = new Date(value);
+  }
+  return data;
+}
+
 function load(name) {
   if (!cache.has(name)) {
     cache.set(name, fetch(`/__sl/content/${encodeURIComponent(name)}?v=${globalThis.__sl?.version ?? ""}`).then(async (r) => {
       if (!r.ok) throw new Error(`content collection '${name}' is not available (${r.status})`);
-      const entries = await r.json();
-      for (const e of entries) e.data = reviveDates(e.data);
+      const { entries, dates } = await r.json();
+      for (const e of entries) e.data = dates ? reviveFields(e.data, dates) : reviveDates(e.data);
       return entries;
     }));
   }

--- a/e2e/pages.spec.ts
+++ b/e2e/pages.spec.ts
@@ -42,6 +42,15 @@ test.describe('starter', () => {
     await expect(page.locator('article pre code')).toContainText('AstroContainer.create()');
   });
 
+  test('/team', async ({ daemon, page }) => {
+    const site = await daemon.tenant('starter', 'starter');
+    await page.goto(site.url('/team'));
+    await expect(page).toHaveTitle('Team · Lumen Studio');
+    // Ordered by `joined`, which only sorts if the schema's z.coerce.date() field came back as a Date.
+    await expect(page.locator('.team strong')).toHaveText(['Mara Okafor', 'Deniz Yilmaz', 'Iris Lambert']);
+    await expect(page.locator('.team span').first()).toHaveText('Design lead · joined Apr 2, 2019');
+  });
+
   test('/docs', async ({ daemon, page }) => {
     const site = await daemon.tenant('starter', 'starter');
     await page.goto(site.url('/docs'));

--- a/examples/starter/src/components/Header.astro
+++ b/examples/starter/src/components/Header.astro
@@ -8,6 +8,7 @@ const links = [
   { href: "/", label: "Home" },
   { href: "/about", label: "About" },
   { href: "/blog", label: "Blog" },
+  { href: "/team", label: "Team" },
   { href: "/docs", label: "Docs" },
   { href: "/mdx-demo", label: "MDX" },
 ];

--- a/examples/starter/src/content.config.ts
+++ b/examples/starter/src/content.config.ts
@@ -1,5 +1,5 @@
 import { defineCollection, z } from "astro:content";
-import { glob } from "astro/loaders";
+import { file, glob } from "astro/loaders";
 
 const posts = defineCollection({
   loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/posts" }),
@@ -11,4 +11,14 @@ const posts = defineCollection({
   }),
 });
 
-export const collections = { posts };
+const team = defineCollection({
+  loader: file("src/content/team.json"),
+  schema: z.object({
+    name: z.string(),
+    role: z.string(),
+    bio: z.string(),
+    joined: z.coerce.date(),
+  }),
+});
+
+export const collections = { posts, team };

--- a/examples/starter/src/content/team.json
+++ b/examples/starter/src/content/team.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "mara",
+    "name": "Mara Okafor",
+    "role": "Design lead",
+    "joined": "2019-04-02",
+    "bio": "Draws the first sketch and signs off on the last pixel."
+  },
+  {
+    "id": "deniz",
+    "name": "Deniz Yilmaz",
+    "role": "Engineering",
+    "joined": "2021-09-13",
+    "bio": "Keeps the build honest and the bundle small."
+  },
+  {
+    "id": "iris",
+    "name": "Iris Lambert",
+    "role": "Words",
+    "joined": "2023-01-30",
+    "bio": "Writes the case studies nobody skims."
+  }
+]

--- a/examples/starter/src/pages/team.astro
+++ b/examples/starter/src/pages/team.astro
@@ -1,0 +1,26 @@
+---
+import Layout from "../layouts/Layout.astro";
+import { getCollection } from "astro:content";
+
+const team = (await getCollection("team")).sort((a, b) => a.data.joined.getTime() - b.data.joined.getTime());
+---
+<Layout title="Team" description="The people behind the studio">
+  <h1>Team</h1>
+  <p class="lede">Loaded from <code>src/content/team.json</code> through the <code>file()</code> loader.</p>
+  <ul class="team">
+    {team.map((m) => (
+      <li>
+        <strong>{m.data.name}</strong>
+        <span>{m.data.role} · joined {m.data.joined.toLocaleDateString("en", { dateStyle: "medium" })}</span>
+        <p>{m.data.bio}</p>
+      </li>
+    ))}
+  </ul>
+</Layout>
+
+<style>
+  .lede { color: var(--muted); }
+  .team { list-style: none; padding: 0; display: grid; gap: 18px; }
+  .team span { margin-left: 10px; color: var(--muted); font-size: 14px; }
+  .team p { margin: 4px 0 0; color: var(--muted); }
+</style>

--- a/src/http/preview.rs
+++ b/src/http/preview.rs
@@ -129,7 +129,8 @@ pub async fn content(AxState(st): AxState<State>, Extension(id): Extension<Tenan
     if !name.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_') {
         return err(StatusCode::BAD_REQUEST, "bad collection name");
     }
-    let out = tokio::task::spawn_blocking(move || content::collection_json(&t, &name)).await.unwrap_or(Value::Null);
+    let out =
+        tokio::task::spawn_blocking(move || content::collection_json(&t, &name)).await.unwrap_or_else(|_| content::empty_collection());
     ([(header::CACHE_CONTROL, "no-cache")], Json(out)).into_response()
 }
 

--- a/src/transform/content.rs
+++ b/src/transform/content.rs
@@ -1,7 +1,16 @@
+use std::borrow::Cow;
+use std::collections::BTreeMap;
+
+use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
+use oxc_allocator::Allocator;
+use oxc_ast::ast::{BindingPattern, CallExpression, Declaration, Expression, ObjectExpression, ObjectPropertyKind, Statement};
+use oxc_parser::Parser as JsParser;
+use oxc_span::SourceType;
 use pulldown_cmark::{Event, HeadingLevel, Options, Parser, Tag, TagEnd, html};
 use serde::Serialize;
-use serde_json::{Map, Value};
+use serde_json::{Map, Value, json};
 
+use crate::resolve::{join, normalize};
 use crate::store::Tenant;
 
 #[derive(Serialize, Clone)]
@@ -105,38 +114,112 @@ pub fn slugify(text: &str) -> String {
 }
 
 pub fn collection_json(tenant: &Tenant, name: &str) -> Value {
+    let def = config(tenant).remove(name).unwrap_or_default();
+    let entries = match &def.loader {
+        Some(Loader::Glob { patterns, base }) => glob_entries(tenant, name, patterns, base),
+        Some(Loader::File { path }) => file_entries(tenant, name, path),
+        None => dir_entries(tenant, name),
+    };
+    json!({ "entries": entries, "dates": def.dates })
+}
+
+pub fn empty_collection() -> Value {
+    json!({ "entries": [], "dates": Value::Null })
+}
+
+fn dir_entries(tenant: &Tenant, name: &str) -> Vec<Value> {
     let prefix = format!("src/content/{name}/");
     let mut entries = Vec::new();
     for e in tenant.list() {
-        let Some(rest) = e.path.strip_prefix(&prefix) else { continue };
-        let Some((stem, ext)) = rest.rsplit_once('.') else { continue };
-        let Some(text) = tenant.read_text(&e.path) else { continue };
-        let id = stem.to_ascii_lowercase();
-        match ext {
-            "md" | "markdown" => {
-                let md = parse_markdown(&text);
-                entries.push(entry(&id, name, md.frontmatter, Some(&md.body), Some((md.html, md.headings)), &e.path));
-            }
-            "mdx" => {
-                let (fm, body) = split_frontmatter(&text);
-                let data = fm.map(yaml_to_json).unwrap_or_else(|| Value::Object(Map::new()));
-                entries.push(entry(&id, name, data, Some(body.trim()), None, &e.path));
-            }
-            "json" => match serde_json::from_str::<Value>(&text) {
-                Ok(Value::Array(items)) => {
-                    for (i, item) in items.into_iter().enumerate() {
-                        let item_id = item.get("id").and_then(|v| v.as_str()).map(|s| s.to_string()).unwrap_or_else(|| i.to_string());
-                        entries.push(entry(&item_id, name, item, None, None, &e.path));
-                    }
-                }
-                Ok(v) => entries.push(entry(&id, name, v, None, None, &e.path)),
-                Err(_) => {}
-            },
-            "yaml" | "yml" => entries.push(entry(&id, name, yaml_to_json(&text), None, None, &e.path)),
-            _ => {}
-        }
+        let Some(id) = e.path.strip_prefix(&prefix).and_then(entry_id) else { continue };
+        push_file(tenant, name, &e.path, &id, &mut entries);
     }
-    Value::Array(entries)
+    entries
+}
+
+fn glob_entries(tenant: &Tenant, name: &str, patterns: &[String], base: &str) -> Vec<Value> {
+    let files: Vec<String> = tenant.list().into_iter().map(|e| e.path).collect();
+    let mut entries = Vec::new();
+    for (path, id) in glob_matches(&files, patterns, base) {
+        push_file(tenant, name, &path, &id, &mut entries);
+    }
+    entries
+}
+
+/// The files a glob loader picks up, each with the id Astro derives from its path relative to `base`.
+fn glob_matches(files: &[String], patterns: &[String], base: &str) -> Vec<(String, String)> {
+    let (mut pos, mut neg) = (GlobSetBuilder::new(), GlobSetBuilder::new());
+    for p in patterns {
+        let (negated, p) = match p.strip_prefix('!') {
+            Some(rest) => (true, rest),
+            None => (false, p.as_str()),
+        };
+        let Ok(g) = GlobBuilder::new(&join(base, p)).literal_separator(true).build() else { continue };
+        if negated { &mut neg } else { &mut pos }.add(g);
+    }
+    let (Ok(pos), Ok(neg)): (Result<GlobSet, _>, Result<GlobSet, _>) = (pos.build(), neg.build()) else { return Vec::new() };
+    let prefix = if base.is_empty() { String::new() } else { format!("{base}/") };
+    files
+        .iter()
+        .filter(|p| pos.is_match(p.as_str()) && !neg.is_match(p.as_str()))
+        .filter_map(|p| Some((p.clone(), entry_id(p.strip_prefix(prefix.as_str())?)?)))
+        .collect()
+}
+
+fn entry_id(relative: &str) -> Option<String> {
+    let (stem, _) = relative.rsplit_once('.')?;
+    Some(stem.to_ascii_lowercase())
+}
+
+fn file_entries(tenant: &Tenant, name: &str, path: &str) -> Vec<Value> {
+    let Some(text) = tenant.read_text(path) else { return Vec::new() };
+    let parsed = match path.rsplit_once('.').map(|(_, ext)| ext) {
+        Some("yaml" | "yml") => serde_yaml::from_str::<Value>(&text).ok(),
+        _ => serde_json::from_str::<Value>(&text).ok(),
+    };
+    match parsed {
+        Some(Value::Array(items)) => {
+            items.into_iter().enumerate().map(|(i, item)| entry(&item_id(&item, i), name, item, None, None, path)).collect()
+        }
+        Some(Value::Object(items)) => items.into_iter().map(|(id, item)| entry(&id, name, item, None, None, path)).collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn item_id(item: &Value, index: usize) -> String {
+    let field = item.get("id").or_else(|| item.get("slug"));
+    match field {
+        Some(Value::String(s)) => s.clone(),
+        Some(v @ Value::Number(_)) => v.to_string(),
+        _ => index.to_string(),
+    }
+}
+
+fn push_file(tenant: &Tenant, name: &str, path: &str, id: &str, entries: &mut Vec<Value>) {
+    let Some((_, ext)) = path.rsplit_once('.') else { return };
+    let Some(text) = tenant.read_text(path) else { return };
+    match ext {
+        "md" | "markdown" => {
+            let md = parse_markdown(&text);
+            entries.push(entry(id, name, md.frontmatter, Some(&md.body), Some((md.html, md.headings)), path));
+        }
+        "mdx" => {
+            let (fm, body) = split_frontmatter(&text);
+            let data = fm.map(yaml_to_json).unwrap_or_else(|| Value::Object(Map::new()));
+            entries.push(entry(id, name, data, Some(body.trim()), None, path));
+        }
+        "json" => match serde_json::from_str::<Value>(&text) {
+            Ok(Value::Array(items)) => {
+                for (i, item) in items.into_iter().enumerate() {
+                    entries.push(entry(&item_id(&item, i), name, item, None, None, path));
+                }
+            }
+            Ok(v) => entries.push(entry(id, name, v, None, None, path)),
+            Err(_) => {}
+        },
+        "yaml" | "yml" => entries.push(entry(id, name, yaml_to_json(&text), None, None, path)),
+        _ => {}
+    }
 }
 
 fn entry(id: &str, collection: &str, data: Value, body: Option<&str>, rendered: Option<(String, Vec<Heading>)>, path: &str) -> Value {
@@ -153,6 +236,194 @@ fn entry(id: &str, collection: &str, data: Value, body: Option<&str>, rendered: 
         m.insert("rendered".into(), serde_json::json!({ "html": html, "metadata": { "headings": headings } }));
     }
     Value::Object(m)
+}
+
+/// Where a collection's entries come from, as far as `content.config.ts` could be read without running it.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Loader {
+    Glob { patterns: Vec<String>, base: String },
+    File { path: String },
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct Definition {
+    /// `None` when the loader is missing or dynamic; the caller then reads `src/content/<name>/`.
+    pub loader: Option<Loader>,
+    /// Fields declared `z.date()` or `z.coerce.date()`, dotted for nested objects. `None` when no schema was understood.
+    pub dates: Option<Vec<String>>,
+}
+
+const CONFIG_PATHS: [&str; 6] = [
+    "src/content.config.ts",
+    "src/content.config.js",
+    "src/content.config.mjs",
+    "src/content/config.ts",
+    "src/content/config.js",
+    "src/content/config.mjs",
+];
+
+pub fn config(tenant: &Tenant) -> BTreeMap<String, Definition> {
+    CONFIG_PATHS.iter().find_map(|p| tenant.read_text(p)).map(|src| parse_config(&src)).unwrap_or_default()
+}
+
+pub fn parse_config(source: &str) -> BTreeMap<String, Definition> {
+    let allocator = Allocator::default();
+    let ret = JsParser::new(&allocator, source, SourceType::ts()).parse();
+    if !ret.errors.is_empty() {
+        return BTreeMap::new();
+    }
+    let mut bindings: BTreeMap<&str, &Expression> = BTreeMap::new();
+    for stmt in &ret.program.body {
+        let decl = match stmt {
+            Statement::VariableDeclaration(d) => &**d,
+            Statement::ExportNamedDeclaration(e) => match e.declaration.as_ref() {
+                Some(Declaration::VariableDeclaration(d)) => &**d,
+                _ => continue,
+            },
+            _ => continue,
+        };
+        for d in &decl.declarations {
+            if let (BindingPattern::BindingIdentifier(id), Some(init)) = (&d.id, d.init.as_ref()) {
+                bindings.insert(id.name.as_str(), init);
+            }
+        }
+    }
+    let Some(Expression::ObjectExpression(collections)) = bindings.get("collections").copied() else { return BTreeMap::new() };
+    let mut out = BTreeMap::new();
+    for (name, value) in props(collections) {
+        let value = match value {
+            Expression::Identifier(id) => match bindings.get(id.name.as_str()) {
+                Some(e) => *e,
+                None => continue,
+            },
+            other => other,
+        };
+        out.insert(name.into_owned(), definition(value));
+    }
+    out
+}
+
+fn definition(expr: &Expression) -> Definition {
+    let Some(Expression::ObjectExpression(obj)) = call(expr, "defineCollection").and_then(|c| arg(c, 0)) else {
+        return Definition::default();
+    };
+    let mut def = Definition::default();
+    for (key, value) in props(obj) {
+        match key.as_ref() {
+            "loader" => def.loader = loader(value),
+            "schema" => def.dates = date_fields(value),
+            _ => {}
+        }
+    }
+    def
+}
+
+fn loader(expr: &Expression) -> Option<Loader> {
+    if let Some(c) = call(expr, "glob") {
+        let Expression::ObjectExpression(obj) = arg(c, 0)? else { return None };
+        let (mut patterns, mut base) = (None, String::new());
+        for (key, value) in props(obj) {
+            match key.as_ref() {
+                "pattern" => patterns = Some(strings(value)?),
+                "base" => base = normalize(&string(value)?),
+                _ => {}
+            }
+        }
+        return Some(Loader::Glob { patterns: patterns?, base });
+    }
+    let c = call(expr, "file")?;
+    Some(Loader::File { path: normalize(&string(arg(c, 0)?)?) })
+}
+
+fn date_fields(expr: &Expression) -> Option<Vec<String>> {
+    let expr = match expr {
+        Expression::ArrowFunctionExpression(f) => f.get_expression()?,
+        other => other,
+    };
+    let mut out = Vec::new();
+    collect_dates(zod_object(expr)?, "", &mut out);
+    Some(out)
+}
+
+fn collect_dates(obj: &ObjectExpression, prefix: &str, out: &mut Vec<String>) {
+    for (key, value) in props(obj) {
+        let path = if prefix.is_empty() { key.into_owned() } else { format!("{prefix}.{key}") };
+        if is_date(value) {
+            out.push(path);
+        } else if let Some(nested) = zod_object(value) {
+            collect_dates(nested, &path, out);
+        }
+    }
+}
+
+/// The object literal of the nearest `.object({…})` call in a chain like `z.object({…}).partial()`.
+fn zod_object<'a>(expr: &'a Expression<'a>) -> Option<&'a ObjectExpression<'a>> {
+    let mut cur = expr;
+    loop {
+        let Expression::CallExpression(c) = cur else { return None };
+        let Expression::StaticMemberExpression(m) = &c.callee else { return None };
+        if m.property.name == "object" {
+            return match arg(c, 0) {
+                Some(Expression::ObjectExpression(o)) => Some(o),
+                _ => None,
+            };
+        }
+        cur = &m.object;
+    }
+}
+
+fn is_date(expr: &Expression) -> bool {
+    let mut chain: Vec<&str> = Vec::new();
+    let mut cur = expr;
+    loop {
+        match cur {
+            Expression::CallExpression(c) => cur = &c.callee,
+            Expression::StaticMemberExpression(m) => {
+                chain.push(m.property.name.as_str());
+                cur = &m.object;
+            }
+            Expression::Identifier(_) => break,
+            _ => return false,
+        }
+    }
+    chain.reverse();
+    matches!(chain.as_slice(), ["date", ..] | ["coerce", "date", ..])
+}
+
+fn props<'a>(obj: &'a ObjectExpression<'a>) -> impl Iterator<Item = (Cow<'a, str>, &'a Expression<'a>)> {
+    obj.properties.iter().filter_map(|p| {
+        let ObjectPropertyKind::ObjectProperty(p) = p else { return None };
+        Some((p.key.static_name()?, &p.value))
+    })
+}
+
+fn call<'a>(expr: &'a Expression<'a>, name: &str) -> Option<&'a CallExpression<'a>> {
+    match expr {
+        Expression::CallExpression(c) => match &c.callee {
+            Expression::Identifier(id) if id.name == name => Some(c),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn arg<'a>(c: &'a CallExpression<'a>, index: usize) -> Option<&'a Expression<'a>> {
+    c.arguments.get(index)?.as_expression()
+}
+
+fn string(expr: &Expression) -> Option<String> {
+    match expr {
+        Expression::StringLiteral(s) => Some(s.value.to_string()),
+        Expression::TemplateLiteral(t) => t.single_quasi().map(|q| q.to_string()),
+        _ => None,
+    }
+}
+
+fn strings(expr: &Expression) -> Option<Vec<String>> {
+    match expr {
+        Expression::ArrayExpression(a) => a.elements.iter().map(|e| string(e.as_expression()?)).collect(),
+        other => string(other).map(|s| vec![s]),
+    }
 }
 
 #[cfg(test)]
@@ -175,5 +446,103 @@ mod tests {
         assert_eq!(md.frontmatter["title"], "T");
         assert_eq!(md.headings[0].slug, "hello-world");
         assert!(md.html.contains("<h2>Hello World</h2>"));
+    }
+
+    fn glob(patterns: &[&str], base: &str) -> Loader {
+        Loader::Glob { patterns: patterns.iter().map(|p| p.to_string()).collect(), base: base.to_string() }
+    }
+
+    #[test]
+    fn reads_glob_loader_and_date_fields() {
+        let cfg = parse_config(
+            r#"import { defineCollection, z } from "astro:content";
+import { glob } from "astro/loaders";
+
+const posts = defineCollection({
+  loader: glob({ pattern: "**/*.{md,mdx}", base: "./src/content/posts" }),
+  schema: z.object({
+    title: z.string(),
+    date: z.coerce.date(),
+    updated: z.date().optional(),
+    version: z.string(),
+    meta: z.object({ published: z.coerce.date() }),
+  }),
+});
+
+export const collections = { posts };
+"#,
+        );
+        assert_eq!(cfg["posts"].loader, Some(glob(&["**/*.{md,mdx}"], "src/content/posts")));
+        assert_eq!(cfg["posts"].dates.as_deref(), Some(["date", "updated", "meta.published"].map(String::from).as_slice()));
+    }
+
+    #[test]
+    fn reads_file_loader_and_array_patterns() {
+        let cfg = parse_config(
+            r#"import { defineCollection } from "astro:content";
+import { file, glob } from "astro/loaders";
+
+const team = defineCollection({ loader: file("src/content/team.json") });
+const docs = defineCollection({ loader: glob({ base: `./src/docs`, pattern: ["**/*.md", "!**/_*.md"] }) });
+
+export const collections = { team, docs: docs };
+"#,
+        );
+        assert_eq!(cfg["team"].loader, Some(Loader::File { path: "src/content/team.json".into() }));
+        assert_eq!(cfg["team"].dates, None);
+        assert_eq!(cfg["docs"].loader, Some(glob(&["**/*.md", "!**/_*.md"], "src/docs")));
+    }
+
+    #[test]
+    fn schema_may_be_a_function_of_the_image_helper() {
+        let cfg = parse_config(
+            r#"import { defineCollection, z } from "astro:content";
+const authors = defineCollection({
+  schema: ({ image }) => z.object({ avatar: image(), joined: z.coerce.date() }),
+});
+export const collections = { authors };
+"#,
+        );
+        assert_eq!(cfg["authors"].loader, None);
+        assert_eq!(cfg["authors"].dates.as_deref(), Some(["joined".to_string()].as_slice()));
+    }
+
+    #[test]
+    fn dynamic_config_falls_back() {
+        let dynamic = parse_config(
+            r#"import { defineCollection } from "astro:content";
+import { glob } from "astro/loaders";
+const base = process.env.CONTENT_DIR;
+const posts = defineCollection({ loader: glob({ pattern: patternsFor("posts"), base }), schema: buildSchema() });
+export const collections = { posts };
+"#,
+        );
+        assert_eq!(dynamic["posts"], Definition::default());
+
+        assert!(parse_config(r#"export const collections = await loadCollections();"#).is_empty());
+        assert!(parse_config("export const collections = {").is_empty());
+    }
+
+    #[test]
+    fn glob_ids_are_relative_to_the_base() {
+        let files: Vec<String> = ["src/content/posts/Hello World.md", "src/content/posts/nested/Deep.md", "src/content/posts/_wip.md"]
+            .iter()
+            .chain(["src/content/posts/notes.txt", "src/content/other/skip.md", "src/pages/index.astro"].iter())
+            .map(|p| p.to_string())
+            .collect();
+        let patterns = ["**/*.{md,mdx}".to_string(), "!**/_*.md".to_string()];
+        assert_eq!(
+            glob_matches(&files, &patterns, "src/content/posts"),
+            vec![
+                ("src/content/posts/Hello World.md".to_string(), "hello world".to_string()),
+                ("src/content/posts/nested/Deep.md".to_string(), "nested/deep".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn an_empty_base_matches_from_the_project_root() {
+        let files = ["src/blog/a.md".to_string(), "src/blog/b.mdx".to_string()];
+        assert_eq!(glob_matches(&files, &["src/blog/*.md".to_string()], ""), vec![("src/blog/a.md".to_string(), "src/blog/a".to_string())]);
     }
 }


### PR DESCRIPTION
Closes #14

`src/transform/content.rs` read `src/content/<name>/` no matter what the config
said, so a `glob` loader with any other `base` returned nothing and a `file()`
loader returned nothing at all. `content.config.ts` is now parsed with oxc —
never executed — and read as data.

## What is parsed

`parse_config` walks the top-level `const`/`export const` bindings, finds
`export const collections = { name: … }`, and resolves each value (an
identifier one hop, or an inline call) to a `defineCollection({…})` literal.
Out of that literal it takes:

- **`loader: glob({ pattern, base })`** — `pattern` as a string, template
  literal without expressions, or array of those; `base` normalised
  (`"./src/content/posts"` → `src/content/posts`, omitted → project root).
  Matching is `globset` with `literal_separator(true)`, so `*` stops at `/`
  and `**` crosses it; `!`-prefixed patterns are negations; braces work
  (`**/*.{md,mdx}`). An entry's id is its path relative to `base`, minus the
  extension, lower-cased, slashes kept — `nested/Deep.md` → `nested/deep`.
- **`loader: file(path)`** — one JSON or YAML file whose top level is an array
  of objects (id from `id`, else `slug`, else the index) or an object keyed by
  id. Ids are kept verbatim, as Astro does.
- **`schema: z.object({…})`** — the fields declared `z.date()` or
  `z.coerce.date()`, following the chain through modifiers
  (`z.date().optional()`) and into nested `z.object({…})` literals as dotted
  paths. `schema: ({ image }) => z.object({…})` is unwrapped too.

Config paths tried, first one found wins:
`src/content.config.{ts,js,mjs}`, then the Astro 2–4
`src/content/config.{ts,js,mjs}`.

## What falls back

Per collection, and per part of it — nothing is all-or-nothing:

- A loader the reader cannot see through (a custom loader, `glob({ pattern:
  patternsFor("posts") })`, `base` from a variable, a syntactically broken
  config, no `collections` object literal) → the collection is read from
  `src/content/<name>/`, exactly as before.
- A schema it cannot see through (`schema: buildSchema()`, or no schema at
  all) → `dates` is `null` and the shim keeps its old regex guess, turning
  every ISO-shaped string into a `Date`.

## The date sidecar

`/__sl/content/<name>` now returns `{entries, dates}` instead of a bare array;
`dates` is the field list above, or `null`. The `astro:content` shim revives
exactly those paths when the list is present. That fixes both halves of the
old guess: a `z.coerce.date()` field written as `Jan 5 2024` used to stay a
string, and a `z.string()` field holding `"2024-01-01"` used to be corrupted
into a `Date`.

## Verification

- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test` —
  54 passing, 6 of them new in `content.rs`: glob + date extraction from a
  config importing `glob` from `astro/loaders`, `file()` + array patterns +
  template-literal `base`, an `({ image }) => z.object(…)` schema, three
  shapes of dynamic config, and id derivation relative to `base` (including
  negations and an empty base).
- `sandbox-lite check examples/starter` — 17 files, 0 errors.
- Against a live daemon on `:4513` with a tenant off `starter`:
  - `/__sl/content/posts` → `dates: ["date"]`, ids `hello-world`, `launch`,
    `writing-in-mdx` (the `.mdx` entry arrives through the `{md,mdx}` brace).
  - `/__sl/content/team` → `dates: ["joined"]`, ids `mara`, `deniz`, `iris`
    from `src/content/team.json`.
  - Rewriting the tenant's config to `glob({ pattern: ["**/*.md",
    "!**/_*.md"], base: "./src/journal" })` moved the collection: only
    `src/journal/2024/Deep Dive.md` came back, as `2024/deep dive`, with
    `_wip.md` excluded and `src/content/posts/*` no longer matched.
  - A collection absent from the config (`notes`) still reads
    `src/content/notes/` and reports `dates: null`.
- Playwright: the `starter` suite passes (8 tests) including a new `/team`
  test that asserts the order produced by sorting on `joined`, which only
  sorts if that field came back as a `Date`.

The starter example gains that `team` collection, `src/content/team.json`, a
`/team` page and a nav link, so the `file()` path is exercised by
`sandbox-lite check` and the e2e suite rather than only by unit tests.

## Noticed, did not fix

- **Ids are lower-cased, not slugified.** Astro runs each path segment through
  github-slugger and strips a trailing `/index`, so `My Post.md` is
  `my-post` there and `my post` here, and `docs/index.md` is `docs` there and
  `docs/index` here. This matches what the code did before this PR; changing
  it would move every existing id.
- **`generateId` is ignored.** A `glob({ generateId })` collection is still
  treated as a plain glob, so its ids will be wrong rather than absent.
- **Loader calls are matched by callee name.** `import { glob as g } from
  "astro/loaders"` is not recognised, and a locally defined `glob`/`file`
  would be. The import list is parsed by nothing here.
- **Dates inside arrays are missed.** `z.array(z.object({ at: z.date() }))`
  produces no dotted path, and because a parsed schema replaces the regex
  entirely, those stay strings. Nested plain objects are covered.
- **`reference()` fields are not resolved.** `getEntry({ collection, id })`
  works, but a `reference("authors")` field arrives as the raw string.
- **The config is re-parsed on every request**, and the whole file list is
  walked to match the globs. Both are cheap on the sizes involved and neither
  is cached against the tenant version.
- **`file()` ignores a `parser` argument**, so `.csv` collections come back
  empty rather than falling back to the directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
