### PR TITLE
islands: resolve package components for client:component-path

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -125,6 +125,8 @@ exact.
    register their CSS; `astro:*` as `/__sl/shim/astro-*.js`; bare specifiers
    as CDN URLs; images as `{ src, width, height, format }` modules;
    unresolvable specifiers as `/__sl/missing.js?spec=…&from=…`, which throws.
+   The `client:component-path` of an island imported from a package is
+   rewritten the same way, so the island's `component-url` is the CDN URL.
    The browser follows the graph; each request repeats step 4.
 6. **Static paths.** If the route has params and the module exports
    `getStaticPaths`, the shell calls it with its own `paginate`, keeps the
@@ -164,7 +166,7 @@ What `compile` does per kind and extension:
 
 | Input | Output |
 |---|---|
-| `.astro` | `astro_codegen` (`src/transform/astro.rs`): oxc parses, `<style lang="scss\|sass">` blocks are pre-compiled with grass, the compiler emits a module importing helpers from `/__sl/astro.js`; the CSS of each `<style>` and each hoisted `<script>` are kept aside; relative `client:component-path` values are made root-absolute |
+| `.astro` | `astro_codegen` (`src/transform/astro.rs`): oxc parses, `<style lang="scss\|sass">` blocks are pre-compiled with grass, the compiler emits a module importing helpers from `/__sl/astro.js`; the CSS of each `<style>` and each hoisted `<script>` are kept aside; relative `client:component-path` values are made root-absolute, and the byte range of every package one is recorded for `serve` |
 | `.ts` `.tsx` `.jsx` `.mts` | oxc transform (`src/transform/js.rs`): TypeScript stripped, JSX compiled |
 | `.js` `.mjs` | served as-is when it parses as ESM, otherwise transformed |
 | `.css` | a module that registers the text in `globalThis.__sl_css`, with relative `url()` and `@import` targets rewritten to `/__sl/raw/…` (`src/transform/css.rs`) |
@@ -178,8 +180,11 @@ What `compile` does per kind and extension:
 | anything else | the `/__sl/raw/` URL as a string export |
 
 A `Built` holds the compiled `body`, plus what `serve` needs later: `specs`
-(byte ranges of every import specifier, from oxc's module record), `globs`
-(byte ranges and options of every `import.meta.glob(...)` call,
+(byte ranges of every import specifier, from oxc's module record),
+`component_paths` (byte ranges of every `client:component-path` /
+`server:component-path` the compiler could not make root-absolute — a package
+or a `tsconfig` alias — so an island resolves like any other specifier),
+`globs` (byte ranges and options of every `import.meta.glob(...)` call,
 `src/transform/glob.rs`), the CSS blocks, the hoisted scripts, warnings and
 an island count.
 
@@ -216,12 +221,14 @@ written. What they resolve to is a property of the tenant, not of the file:
 - `./Header` is `Header.astro` in one tenant and `Header.tsx` in another
   (`Resolver::probe` tries extensions, then `index` files);
 - the set of files matching `./posts/*.md` is the tenant's file list;
+- `react-countup` is `https://esm.sh/react-countup@<range>` at the range that
+  tenant's `package.json` pins;
 - every emitted URL must carry the tenant's current `?v=`.
 
 None of that can live in a content-addressed entry, so `Engine::serve` does it
-on every request: it resolves each `spec` with the `Resolver`, expands each
-glob against `tenant.list()` (`glob::expand` writes hoisted
-`import * as __sl_glob<i>_<j> from "/__sl/m/<file>?v=N"` statements for
+on every request: it resolves each `spec` and each `component_path` with the
+`Resolver`, expands each glob against `tenant.list()` (`glob::expand` writes
+hoisted `import * as __sl_glob<i>_<j> from "/__sl/m/<file>?v=N"` statements for
 `eager: true`, or `() => import(...)` thunks otherwise, keyed relative to the
 importer or absolute when the pattern is), prepends
 `import.meta.env = globalThis.__sl_env || {};` when the module needs it, and

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ dynamic routes with `getStaticPaths` and `paginate`;
 `import.meta.glob` (eager and lazy, `import:`/`query:` options); `import.meta.env`
 and `.env` `PUBLIC_*` variables; `tsconfig` path aliases; npm packages from a
 CDN pinned to the versions in `package.json`; React and Preact islands
-(`client:load` and friends hydrate with the framework's own client entrypoint);
+(`client:load` and friends hydrate with the framework's own client entrypoint,
+whether the component is a file in `src/` or a component imported from a
+package);
 `<script>` tags, `public/` files and live reload.
 
 ## What it costs
@@ -291,7 +293,7 @@ src/check.rs           the `check` subcommand
 assets/                shell.html, shell.js, live.js, editor.html, astro.js and astro-jsx.js bundles, astro:* shims
 examples/starter       a framework-free Astro 7 site (Markdown, MDX, content collections); the base used by CI's smoke test and bench/mem.sh
 examples/tailwind      Tailwind v4 through its browser build
-examples/react         a React island hydrated with client:load
+examples/react         React islands hydrated with client:load, one local and one imported from npm
 scripts/build-runtime.sh   regenerates assets/astro.js and assets/astro-jsx.js for a new Astro version
 bench/mem.sh           the memory measurement above
 e2e/                   Playwright suite for the browser side: every example page, live reload, hydration, the error overlay

--- a/e2e/hydration.spec.ts
+++ b/e2e/hydration.spec.ts
@@ -5,7 +5,7 @@ test('a client:load React island hydrates and handles clicks', async ({ daemon, 
   await page.goto(site.url('/'));
   const count = page.locator('.counter strong');
   await expect(count).toHaveText('41', { timeout: CDN_TIMEOUT });
-  await expect(page.locator('astro-island:not([ssr])'), 'island hydrated').toHaveCount(1, { timeout: CDN_TIMEOUT });
+  await expect(page.locator('astro-island:not([ssr])'), 'islands hydrated').toHaveCount(2, { timeout: CDN_TIMEOUT });
 
   await page.getByRole('button', { name: 'increment' }).click();
   await expect(count).toHaveText('42');
@@ -13,4 +13,13 @@ test('a client:load React island hydrates and handles clicks', async ({ daemon, 
 
   await page.getByRole('button', { name: 'decrement' }).click();
   await expect(count).toHaveText('41');
+});
+
+test('an island imported from an npm package hydrates from the CDN', async ({ daemon, page }) => {
+  const site = await daemon.tenant('react-npm', 'react');
+  await page.goto(site.url('/'));
+  const island = page.locator('.countup astro-island');
+  await expect(island).toHaveAttribute('component-url', /^https:\/\/esm\.sh\/react-countup@/, { timeout: CDN_TIMEOUT });
+  // react-countup renders an empty span server-side and counts up to `end` only once its own React runs.
+  await expect(island.locator('span')).toHaveText('2026', { timeout: CDN_TIMEOUT });
 });

--- a/e2e/pages.spec.ts
+++ b/e2e/pages.spec.ts
@@ -112,6 +112,6 @@ test.describe('react', () => {
     await expect(page.locator('h1')).toHaveText('Islands in the preview');
     await expect(page.locator('.counter strong')).toHaveText('41');
     await expect(page.locator('.greeting h2')).toHaveText('Hello, static React');
-    await expect(page.locator('astro-island:not([ssr])'), 'island hydrated').toHaveCount(1, { timeout: CDN_TIMEOUT });
+    await expect(page.locator('astro-island:not([ssr])'), 'both islands hydrated').toHaveCount(2, { timeout: CDN_TIMEOUT });
   });
 });

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -7,6 +7,7 @@
     "@astrojs/react": "^6.0.5",
     "astro": "^7.3.1",
     "react": "^19.2.8",
+    "react-countup": "^6.5.3",
     "react-dom": "^19.2.8"
   },
   "devDependencies": {

--- a/examples/react/src/pages/index.astro
+++ b/examples/react/src/pages/index.astro
@@ -2,11 +2,14 @@
 import Layout from "../layouts/Layout.astro";
 import Counter from "../components/Counter.tsx";
 import Greeting from "../components/Greeting.tsx";
+import CountUp from "react-countup";
 ---
 <Layout title="Islands">
   <h1>Islands in the preview</h1>
   <p class="lede">The card below is a React component rendered to HTML in your browser, then hydrated with <code>client:load</code>.</p>
   <Counter client:load label="Visitors today" start={41} />
+  <p class="lede">This one comes from npm — <code>react-countup</code>, loaded from the CDN at the version <code>package.json</code> pins — and hydrates the same way.</p>
+  <p class="countup">Signups this year: <CountUp client:load end={2026} duration={0.6} separator="" /></p>
   <Greeting name="static React">
     <p>This one has no <code>client:</code> directive, so it is plain HTML with no JavaScript shipped.</p>
   </Greeting>
@@ -16,6 +19,7 @@ import Greeting from "../components/Greeting.tsx";
   .counter { display: inline-flex; align-items: center; gap: 12px; padding: 14px 18px; border-radius: 14px; background: #141b33; border: 1px solid #26305a; }
   .counter button { width: 32px; height: 32px; border-radius: 50%; border: none; background: #4f6cff; color: white; font-size: 18px; cursor: pointer; }
   .counter strong { min-width: 2ch; text-align: center; font-size: 20px; }
+  .countup span { font-variant-numeric: tabular-nums; font-weight: 700; color: #9ece6a; }
   .greeting { margin-top: 32px; padding: 18px; border-radius: 14px; border: 1px dashed #26305a; }
   .greeting h2 { margin: 0 0 6px; }
 </style>

--- a/src/transform/astro.rs
+++ b/src/transform/astro.rs
@@ -3,10 +3,13 @@ use oxc_allocator::Allocator;
 use oxc_parser::{ParseOptions, Parser};
 use oxc_span::SourceType;
 
+use super::js::SpecRef;
 use super::{BuildError, Diag, json_str};
 
 pub const INTERNAL_URL: &str = "/__sl/astro.js";
 pub const TRANSITIONS_URL: &str = "/__sl/shim/viewtransitions-css.js";
+
+const PATH_ATTRS: [&str; 2] = ["client:component-path", "server:component-path"];
 
 pub enum Script {
     Inline(String),
@@ -19,6 +22,7 @@ pub struct AstroOut {
     pub scripts: Vec<Script>,
     pub warnings: Vec<Diag>,
     pub islands: usize,
+    pub component_paths: Vec<SpecRef>,
 }
 
 pub type Preprocess<'a> = &'a dyn Fn(&str, &str) -> Result<String, String>;
@@ -80,12 +84,28 @@ pub fn compile(path: &str, source: &str, site: Option<&str>, preprocess: Preproc
     for c in r.hydrated_components.iter().chain(&r.client_only_components).chain(&r.server_components) {
         if c.specifier.starts_with('.') {
             let resolved = format!("/{}", crate::resolve::join(dir, &c.specifier));
-            for attr in ["client:component-path", "server:component-path"] {
+            for attr in PATH_ATTRS {
                 code = code.replace(&format!("\"{attr}\": \"{}\"", c.specifier), &format!("\"{attr}\": \"{resolved}\""));
             }
         }
     }
-    Ok(AstroOut { code, css: r.css, scripts, warnings: diags, islands })
+    // A package's URL depends on the tenant's package.json pins, which the cache key does not hash: `serve` resolves these.
+    let mut component_paths = Vec::new();
+    for c in r.hydrated_components.iter().chain(&r.client_only_components).chain(&r.server_components) {
+        if c.specifier.starts_with('.') || c.specifier.starts_with('/') {
+            continue;
+        }
+        for attr in PATH_ATTRS {
+            let prefix = format!("\"{attr}\": \"");
+            for (at, _) in code.match_indices(&format!("{prefix}{}\"", c.specifier)) {
+                let start = at + prefix.len();
+                component_paths.push(SpecRef { start, end: start + c.specifier.len(), spec: c.specifier.clone() });
+            }
+        }
+    }
+    component_paths.sort_by_key(|s| s.start);
+    component_paths.dedup_by_key(|s| s.start);
+    Ok(AstroOut { code, css: r.css, scripts, warnings: diags, islands, component_paths })
 }
 
 fn first_text(diags: &[Diag]) -> String {
@@ -113,4 +133,31 @@ fn convert(diags: &[Diagnostic], file: &str) -> Vec<Diag> {
             }
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AstroOut, compile};
+
+    fn compiled(source: &str) -> AstroOut {
+        compile("src/pages/index.astro", source, None, &|_, src| Ok(src.to_string())).unwrap()
+    }
+
+    #[test]
+    fn package_island_paths_are_left_for_serve_time() {
+        let out = compiled(
+            "---\nimport { Chart } from \"some-widgets\";\nimport Local from \"../components/Local.tsx\";\n---\n<Chart client:load />\n<Local client:load />\n",
+        );
+        assert!(out.code.contains(r#""client:component-path": "/src/components/Local.tsx""#), "{}", out.code);
+        assert!(out.code.contains(r#""client:component-export": "Chart""#), "{}", out.code);
+        let found: Vec<(&str, &str)> = out.component_paths.iter().map(|s| (s.spec.as_str(), &out.code[s.start..s.end])).collect();
+        assert_eq!(found, vec![("some-widgets", "some-widgets")]);
+    }
+
+    #[test]
+    fn a_client_only_package_island_is_recorded_once() {
+        let out = compiled("---\nimport Widget from \"widgets\";\n---\n<Widget client:only=\"react\" />\n<Widget client:load />\n");
+        assert_eq!(out.component_paths.len(), 2, "{:?}", out.component_paths);
+        assert!(out.component_paths.iter().all(|s| &out.code[s.start..s.end] == "widgets"), "{}", out.code);
+    }
 }

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -48,6 +48,7 @@ pub struct Built {
     pub body: String,
     pub content_type: &'static str,
     pub specs: Vec<js::SpecRef>,
+    pub component_paths: Vec<js::SpecRef>,
     pub globs: Vec<glob::GlobRef>,
     pub warnings: Vec<Diag>,
     pub env_banner: bool,
@@ -62,6 +63,7 @@ impl Built {
             body,
             content_type: JS,
             specs: vec![],
+            component_paths: vec![],
             globs: vec![],
             warnings: vec![],
             env_banner: false,
@@ -264,6 +266,7 @@ impl Engine {
                             body: out.code,
                             content_type: JS,
                             specs,
+                            component_paths: out.component_paths,
                             globs,
                             warnings: out.warnings,
                             env_banner: true,
@@ -323,7 +326,7 @@ impl Engine {
     pub fn serve(&self, tenant: &Tenant, path: &str, kind: Kind, resolver: &Resolver) -> Result<(String, &'static str), BuildError> {
         let built = self.build(tenant, path, kind)?;
         let mut edits: Vec<(usize, usize, String)> =
-            built.specs.iter().map(|s| (s.start, s.end, resolver.resolve(path, &s.spec))).collect();
+            built.specs.iter().chain(&built.component_paths).map(|s| (s.start, s.end, resolver.resolve(path, &s.spec))).collect();
         let mut hoisted = String::new();
         for (i, g) in built.globs.iter().enumerate() {
             let expansion = glob::expand(tenant, path, g, i, resolver.version())
@@ -392,7 +395,83 @@ pub fn is_source(path: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::svg_size;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    use super::{Config, Engine, Kind, scss, svg_size};
+    use crate::resolve::Resolver;
+    use crate::store::{Base, Store, Tenant};
+
+    const PAGE: &str = "---\nimport { Chart } from \"some-widgets\";\n---\n<Chart client:load />\n";
+    const PAGE_PATH: &str = "src/pages/index.astro";
+
+    fn tenant(files: &[(&str, &str)]) -> Arc<Tenant> {
+        static N: AtomicUsize = AtomicUsize::new(0);
+        let root = std::env::temp_dir().join(format!("sandbox-lite-test-{}-{}", std::process::id(), N.fetch_add(1, Ordering::Relaxed)));
+        std::fs::create_dir_all(&root).unwrap();
+        let store = Store::new(None, u64::MAX);
+        store.add_base(Base::load("b", &root).unwrap());
+        std::fs::remove_dir(&root).unwrap();
+        let tenant = store.create_tenant("t", "b").unwrap();
+        for (path, body) in files {
+            tenant.write(path, body.as_bytes().to_vec()).unwrap();
+        }
+        tenant
+    }
+
+    fn engine() -> Engine {
+        Engine::new(Config {
+            cdn: "https://esm.sh".into(),
+            cache_bytes: 1 << 20,
+            sass_timeout: Duration::from_millis(scss::DEFAULT_TIMEOUT_MS),
+        })
+    }
+
+    fn served(engine: &Engine, tenant: &Tenant) -> String {
+        engine.serve(tenant, PAGE_PATH, Kind::Module, &Resolver::new(tenant, "https://esm.sh", 7)).unwrap().0
+    }
+
+    #[test]
+    fn a_package_island_path_becomes_the_pinned_cdn_url() {
+        let t = tenant(&[("package.json", r#"{"dependencies":{"some-widgets":"^1.2.3"}}"#), (PAGE_PATH, PAGE)]);
+        let out = served(&engine(), &t);
+        assert!(out.contains(r#""client:component-path": "https://esm.sh/some-widgets@^1.2.3""#), "{out}");
+        assert!(out.contains(r#""client:component-export": "Chart""#), "{out}");
+        assert!(out.contains(r#"import { Chart } from "https://esm.sh/some-widgets@^1.2.3""#), "{out}");
+    }
+
+    #[test]
+    fn a_client_only_package_island_resolves_at_serve_time() {
+        let t = tenant(&[
+            ("package.json", r#"{"dependencies":{"some-widgets":"1.0.0"}}"#),
+            (PAGE_PATH, "---\nimport Widget from \"some-widgets\";\n---\n<Widget client:only=\"react\" />\n"),
+        ]);
+        let out = served(&engine(), &t);
+        assert!(out.contains(r#""client:component-path": "https://esm.sh/some-widgets@1.0.0""#), "{out}");
+        assert!(out.contains(r#""client:component-export": "default""#), "{out}");
+    }
+
+    #[test]
+    fn an_aliased_island_path_becomes_the_tenants_own_module() {
+        let t = tenant(&[
+            ("tsconfig.json", r#"{"compilerOptions":{"baseUrl":".","paths":{"@c/*":["src/components/*"]}}}"#),
+            ("src/components/Card.tsx", "export default () => null;\n"),
+            (PAGE_PATH, "---\nimport Card from \"@c/Card.tsx\";\n---\n<Card client:load />\n"),
+        ]);
+        let out = served(&engine(), &t);
+        assert!(out.contains(r#""client:component-path": "/__sl/m/src/components/Card.tsx?v=7""#), "{out}");
+    }
+
+    #[test]
+    fn one_cached_compile_serves_each_tenant_its_own_pin() {
+        let a = tenant(&[("package.json", r#"{"dependencies":{"some-widgets":"1.0.0"}}"#), (PAGE_PATH, PAGE)]);
+        let b = tenant(&[("package.json", r#"{"dependencies":{"some-widgets":"2.0.0"}}"#), (PAGE_PATH, PAGE)]);
+        let engine = engine();
+        assert!(served(&engine, &a).contains("https://esm.sh/some-widgets@1.0.0"));
+        assert!(served(&engine, &b).contains("https://esm.sh/some-widgets@2.0.0"));
+        assert_eq!(engine.stats().misses, 1, "package.json is not in the cache key, so both tenants share one compile");
+    }
 
     #[test]
     fn svg_size_survives_junk_attributes() {


### PR DESCRIPTION
Closes #9

An island imported from an npm package kept its bare specifier in
`client:component-path`, so `resolveId` in `assets/shell.js` turned it into
`/__sl/m/react-countup` and the browser got a 404. Only relative specifiers
were ever rewritten.

The specifier cannot be rewritten at compile time: what a package resolves to
depends on the tenant's `package.json` pins, and the cache key deliberately
does not hash those, so two tenants with a byte-identical page share one
compiled entry. So this follows the route the import specifiers already take.

`astro::compile` records the byte range of every `client:component-path` /
`server:component-path` it could not make root-absolute, in a new
`Built::component_paths`, and `Engine::serve` runs those through the same
`Resolver` as `Built::specs` on every request. Nothing about
`client:component-export` changes, so named exports keep working, and
`client:only` components are recorded from `client_only_components` alongside
the hydrated ones.

## What the suite asserts

Each row below is a test, so CI is what says it holds:

| written | served | test |
|---|---|---|
| `import { Chart } from "some-widgets"` + `client:load`, pinned `^1.2.3` | `"client:component-path": "https://esm.sh/some-widgets@^1.2.3"`, export `Chart` | `transform::a_package_island_path_becomes_the_pinned_cdn_url` |
| `import Widget from "some-widgets"` + `client:only="react"` | the pinned URL, export `default` | `transform::a_client_only_package_island_resolves_at_serve_time` |
| `import Card from "@c/Card.tsx"` (tsconfig alias) + `client:load` | `/__sl/m/src/components/Card.tsx?v=7` | `transform::an_aliased_island_path_becomes_the_tenants_own_module` |
| a relative import next to a package one | the relative one root-absolute at compile time, the package one left for `serve` | `transform::astro::package_island_paths_are_left_for_serve_time` |

Two more:

- `transform::one_cached_compile_serves_each_tenant_its_own_pin` — two tenants
  pinning different versions of the same package get their own CDN URL out of
  **one** cached compile (`stats().misses == 1`). That is what makes the
  serve-time rewrite necessary rather than merely tidy; a compile-time rewrite
  would hand the second tenant the first one's version.
- `transform::astro::a_client_only_package_island_is_recorded_once` — a
  component used twice records two ranges, not four.

`examples/react` grows a second island, `react-countup` from npm, so the
Playwright job drives it in Chromium: `e2e/hydration.spec.ts` asserts the
island's `component-url` matches `https://esm.sh/react-countup@…` and that the
component actually counts up, and `e2e/pages.spec.ts` now expects two hydrated
islands on that page rather than one.

## Noticed, not fixed

- The compile-time rewrite of relative paths and the new range-recording both
  match on the literal `"client:component-path": "<spec>"`. A page whose
  frontmatter contains that exact text in a string of its own would be
  rewritten too. The pre-existing `code.replace` has the same shape; a
  specifier needing JSON escaping simply fails to match and falls back to
  today's behaviour rather than corrupting the output.
- `examples/react` pins `react-countup` by range, so the e2e job depends on
  esm.sh serving whatever `^6.5.3` currently means.
- `Config { .. }` literals in test fixtures are what broke `main` in 6f71156;
  a `Default` for `Config`, or one test constructor next to it, would make the
  next field addition a non-event. This PR adds one more such literal, in
  `src/transform/mod.rs`'s tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
