### PR TITLE
preview: run endpoint routes (src/pages/*.ts) in the browser

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -109,8 +109,8 @@ exact.
    static, 1 for `[param]`, 2 for `[...rest]` — compared lexicographically,
    so static routes come before dynamic ones and a route sorts before any
    longer route it is a prefix of; equal keys are ordered by path. The kind is
-   `astro`, `md`, `mdx` or `endpoint`; the shell renders the first three and
-   shows an "unsupported route" page for endpoints.
+   `astro`, `md`, `mdx` or `endpoint`, taken from the last extension only, so
+   `rss.xml.ts` is the endpoint `/rss.xml`.
 4. **Page module.** The shell imports `/__sl/astro.js` and
    `/__sl/m/src/pages/blog/[slug].astro?v=<version>`. `preview::module`
    cleans the path, reads the kind from the query, and on the blocking pool
@@ -142,7 +142,13 @@ exact.
    plus `@astrojs/mdx/server.js`) is registered last; it renders MDX content.
    `container.renderToResponse(mod.default, { request, params, props })`
    produces the HTML.
-8. **Document.** A `3xx` with `Location` becomes `location.replace`.
+   An endpoint route takes the same call with the module itself and
+   `routeType: "endpoint"`, which runs its `GET` (or `ALL`) handler with an
+   `APIContext` — `request`, `params`, `props`, `url`, `site`, `redirect`,
+   `cookies`, `locals`. No renderers are registered for it: nothing renders.
+8. **Document.** A `3xx` with `Location` becomes `location.replace`. A response
+   that is not `text/html` (an endpoint's XML, JSON or text) is shown escaped in
+   a `<pre>` under its status and content-type, JSON pretty-printed.
    Otherwise every CSS string that modules registered in
    `globalThis.__sl_css` becomes a `<style data-sl=key>` (with
    `type="text/tailwindcss"` when it contains `@import "tailwindcss"` or

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ and `.scss` files, compiled in-process) and Tailwind v4 (via its browser
 build); content collections (`getCollection`, `getEntry`, `render`); Markdown
 pages with `layout:`; MDX pages and MDX collection entries (compiled
 in-process with Astro's `satteri-mdxjs`, rendered with Astro's JSX runtime);
+endpoints (`src/pages/rss.xml.ts`, `src/pages/api/*.json.ts`: the `GET` handler
+runs in the browser and its `Response` is shown);
 dynamic routes with `getStaticPaths` and `paginate`;
 `import.meta.glob` (eager and lazy, `import:`/`query:` options); `import.meta.env`
 and `.env` `PUBLIC_*` variables; `tsconfig` path aliases; npm packages from a
@@ -274,7 +276,11 @@ Tenant host (`<id>.<domain>`):
 6. `experimental_AstroContainer.renderToResponse()` produces the HTML;
    `document.write` replaces the shell with it, so scripts, links and relative
    URLs behave like a normal page.
-7. `live.js` holds an `EventSource`; any write to the tenant reloads the page.
+7. A `.ts`/`.js` file under `src/pages` is an endpoint: the same call with
+   `routeType: "endpoint"` runs its `GET` (or `ALL`) handler with an
+   `APIContext`. An HTML response is written as a page; anything else — XML,
+   JSON, plain text — is shown with its status and content-type above the body.
+8. `live.js` holds an `EventSource`; any write to the tenant reloads the page.
 
 Error states are pages too: a compile error, a missing import, a 404 route or
 a failing `getStaticPaths` render an overlay that lists the daemon's
@@ -291,14 +297,14 @@ src/transform/         astro (astro_codegen), js (oxc), css, scss (grass), impor
 src/http/              host-based dispatch, auth, editor API, preview endpoints, Claude chat loop
 src/check.rs           the `check` subcommand
 assets/                shell.html, shell.js, live.js, editor.html, astro.js and astro-jsx.js bundles, astro:* shims
-examples/starter       a framework-free Astro 7 site (Markdown, MDX, content collections); the base used by CI's smoke test and bench/mem.sh
+examples/starter       a framework-free Astro 7 site (Markdown, MDX, content collections, endpoints); the base used by CI's smoke test and bench/mem.sh
 examples/tailwind      Tailwind v4 through its browser build
 examples/react         React islands hydrated with client:load, one local and one imported from npm
 examples/vue           a Vue SFC compiled in the browser and hydrated with client:load
 examples/svelte        the same for a Svelte 5 component
 scripts/build-runtime.sh   regenerates assets/astro.js and assets/astro-jsx.js for a new Astro version
 bench/mem.sh           the memory measurement above
-e2e/                   Playwright suite for the browser side: every example page, live reload, hydration, the error overlay
+e2e/                   Playwright suite for the browser side: every example page, endpoints, live reload, hydration, the error overlay
 ```
 
 ## What the preview does not do
@@ -314,7 +320,9 @@ e2e/                   Playwright suite for the browser side: every example page
   `vue`/`svelte` imports to the CDN and relative ones against the component's
   own URL: `./Other.vue` works, `./other` (no extension) does not, and
   `<script lang="ts">` reaches the browser as TypeScript and fails to parse.
-- **Endpoints.** `src/pages/*.ts` endpoints show an "unsupported route" page.
+- **Non-`GET` requests.** A visitor navigates, so only an endpoint's `GET` (or
+  `ALL`) handler ever runs and the request carries no body. `src/middleware.ts`
+  is not loaded, and `astro:actions` answers `SERVICE_UNAVAILABLE`.
 - **Less/Stylus.** Sass works; other preprocessors are passed through untouched.
 - **`content.config.ts` loaders.** The config is read statically, never
   executed: `glob({ pattern, base })` and `file(path)` with literal arguments

--- a/assets/shell.js
+++ b/assets/shell.js
@@ -108,6 +108,35 @@ function replaceDocument(html) {
   document.close();
 }
 
+function writePage(html) {
+  const extras = headExtras();
+  replaceDocument(injectHead(html, extras.html));
+  if (extras.tailwind) {
+    const s = document.createElement("script");
+    s.src = TAILWIND_CDN;
+    document.head.appendChild(s);
+  }
+}
+
+function prettyJSON(body) {
+  try {
+    return JSON.stringify(JSON.parse(body), null, 2);
+  } catch {
+    return body;
+  }
+}
+
+function showResponse({ component, status, statusText, type, body }) {
+  const text = /\bjson\b/i.test(type) ? prettyJSON(body) : body;
+  replaceDocument(`<!doctype html><html><head><meta charset="utf-8"><title>${esc(component)}</title>
+<style>body{margin:0;background:#1a1b26;color:#c0caf5;font:14px/1.5 ui-monospace,Menlo,monospace;padding:32px}
+h1{color:#7aa2f7;font-size:18px;margin:0 0 4px}p{margin:0 0 12px;color:#565f89}pre{white-space:pre-wrap;background:#16161e;padding:12px;border-radius:6px;overflow:auto}
+b{color:#9ece6a}small{color:#565f89}</style>
+<script type="module" src="/__sl/live.js"></script></head>
+<body><h1>${status} ${esc(statusText || "")}</h1><p>${esc(component)} → <b>${esc(type || "no content-type")}</b></p><pre>${esc(text)}</pre>
+<small>sandbox-lite · tenant ${esc(sl.tenant)} · the page reloads itself when a file changes</small></body></html>`);
+}
+
 function showError({ title, message, stack, diagnostics = [], routes }) {
   const diag = diagnostics
     .map((d) => `<li><b>${esc(d.file)}${d.line ? `:${d.line}:${d.column}` : ""}</b> — ${esc(d.text)}${d.hint ? `<br><i>${esc(d.hint)}</i>` : ""}</li>`)
@@ -127,12 +156,16 @@ async function main() {
   const routes = await fetchJSON(`/__sl/routes.json?v=${V}`);
   const hit = matchRoute(routes, location.pathname);
   if (!hit) return showError({ title: "404 — no matching page", message: `Nothing in src/pages matches ${location.pathname}`, routes });
-  if (hit.route.kind !== "astro" && hit.route.kind !== "md" && hit.route.kind !== "mdx") {
-    return showError({ title: "Unsupported route", message: `${hit.route.component} is a ${hit.route.kind} route. sandbox-lite renders .astro, .md and .mdx pages in the browser; endpoints are not available in the preview.` });
-  }
+  const endpoint = hit.route.kind === "endpoint";
   const astro = await import("/__sl/astro.js");
   const mod = await import(`/__sl/m/${hit.route.component}?v=${V}`);
-  if (typeof mod.default !== "function") throw new Error(`${hit.route.component} has no default export component`);
+  if (endpoint) {
+    if (typeof mod.GET !== "function" && typeof mod.ALL !== "function") {
+      return showError({ title: "Endpoint without a handler", message: `${hit.route.component} exports no GET or ALL function. The preview only issues GET requests.` });
+    }
+  } else if (typeof mod.default !== "function") {
+    throw new Error(`${hit.route.component} has no default export component`);
+  }
   let props = {};
   let params = hit.params;
   if (hit.route.params.length && typeof mod.getStaticPaths === "function") {
@@ -143,24 +176,25 @@ async function main() {
     params = entry.params;
   }
   const container = await astro.experimental_AstroContainer.create({ resolve: resolveId, astroConfig: sl.env.SITE ? { site: sl.env.SITE } : undefined });
-  await addRenderers(container);
-  const res = await container.renderToResponse(mod.default, {
+  // An endpoint renders no components, so the framework renderers are not worth fetching.
+  if (!endpoint) await addRenderers(container);
+  const res = await container.renderToResponse(endpoint ? mod : mod.default, {
     request: new Request(location.href),
     params,
     props,
     partial: false,
-    routeType: "page",
+    routeType: endpoint ? "endpoint" : "page",
   });
   const location_ = res.headers.get("location");
   if (res.status >= 300 && res.status < 400 && location_) return location.replace(location_);
-  const html = await res.text();
-  if (res.status >= 400 && !html.trim()) return showError({ title: `${res.status}`, message: `The page responded with status ${res.status} and no body` });
-  const extras = headExtras();
-  replaceDocument(injectHead(html, extras.html));
-  if (extras.tailwind) {
-    const s = document.createElement("script");
-    s.src = TAILWIND_CDN;
-    document.head.appendChild(s);
+  const type = res.headers.get("content-type") || "";
+  const body = await res.text();
+  if (endpoint && type.split(";")[0].trim().toLowerCase() !== "text/html") {
+    showResponse({ component: hit.route.component, status: res.status, statusText: res.statusText, type, body });
+  } else if (res.status >= 400 && !body.trim()) {
+    return showError({ title: `${res.status}`, message: `The page responded with status ${res.status} and no body` });
+  } else {
+    writePage(body);
   }
   console.debug(`[sandbox-lite] ${hit.route.component} rendered in ${(performance.now() - t0).toFixed(0)} ms`);
 }

--- a/e2e/endpoints.spec.ts
+++ b/e2e/endpoints.spec.ts
@@ -1,0 +1,88 @@
+import { expect, test } from './fixtures';
+
+test.describe('starter endpoints', () => {
+  test('/rss.xml', async ({ daemon, page }) => {
+    const site = await daemon.tenant('starter-rss', 'starter');
+    await page.goto(site.url('/rss.xml'));
+    await expect(page).toHaveTitle('src/pages/rss.xml.ts');
+    await expect(page.locator('h1')).toHaveText('200');
+    await expect(page.locator('p b')).toHaveText('application/xml; charset=utf-8');
+    const body = page.locator('pre');
+    await expect(body).toContainText('<rss version="2.0">');
+    await expect(body).toContainText('<title>Writing journal posts in MDX</title>');
+    await expect(body).toContainText('<title>Why we render previews in the browser</title>');
+    await expect(body).toContainText('<title>Launching the journal</title>');
+    await expect(body, 'the link is absolute, built from the request origin').toContainText(`<link>${site.url('/blog/hello-world')}</link>`);
+  });
+
+  test('/api/products.json', async ({ daemon, page }) => {
+    const site = await daemon.tenant('starter-api', 'starter');
+    await page.goto(site.url('/api/products.json'));
+    await expect(page).toHaveTitle('src/pages/api/products.json.ts');
+    await expect(page.locator('h1')).toHaveText('200');
+    await expect(page.locator('p b')).toHaveText('application/json; charset=utf-8');
+    const body = await page.locator('pre').textContent();
+    expect(JSON.parse(body ?? '')).toEqual([
+      { slug: 'brand-sprint', name: 'Brand sprint', blurb: expect.stringContaining('focused week'), price: '€4,200' },
+      { slug: 'site-refresh', name: 'Site refresh', blurb: expect.stringContaining('rebuilt'), price: '€6,800' },
+      { slug: 'retainer', name: 'Design retainer', blurb: expect.stringContaining('monthly block'), price: '€2,400' },
+    ]);
+  });
+
+  test('a dynamic endpoint gets the props of its getStaticPaths entry', async ({ daemon, page }) => {
+    const site = await daemon.tenant('starter-dynamic', 'starter');
+    await site.write(
+      'src/pages/api/[slug].json.ts',
+      `import { products } from "@/data/products";
+
+export function getStaticPaths() {
+  return products.map((product) => ({ params: { slug: product.slug }, props: { product } }));
+}
+
+export function GET({ params, props }) {
+  return new Response(JSON.stringify({ slug: params.slug, name: props.product.name }), { headers: { "content-type": "application/json" } });
+}
+`,
+    );
+    await page.goto(site.url('/api/site-refresh.json'));
+    await expect(page.locator('h1')).toHaveText('200');
+    const body = await page.locator('pre').textContent();
+    expect(JSON.parse(body ?? '')).toEqual({ slug: 'site-refresh', name: 'Site refresh' });
+  });
+
+  test('an html response is written as a page', async ({ daemon, page }) => {
+    const site = await daemon.tenant('starter-html-endpoint', 'starter');
+    await site.write(
+      'src/pages/api/card.ts',
+      `export function GET() {
+  return new Response("<!doctype html><html><head><title>From an endpoint</title></head><body><h1>Hand-written HTML</h1></body></html>", { headers: { "content-type": "text/html; charset=utf-8" } });
+}
+`,
+    );
+    await page.goto(site.url('/api/card'));
+    await expect(page).toHaveTitle('From an endpoint');
+    await expect(page.locator('h1')).toHaveText('Hand-written HTML');
+  });
+
+  test('a redirecting endpoint sends the browser on', async ({ daemon, page }) => {
+    const site = await daemon.tenant('starter-redirect', 'starter');
+    await site.write(
+      'src/pages/api/latest.ts',
+      `export function GET({ redirect }) {
+  return redirect("/blog/writing-in-mdx", 302);
+}
+`,
+    );
+    await page.goto(site.url('/api/latest'));
+    await expect(page).toHaveURL(site.url('/blog/writing-in-mdx'));
+    await expect(page.locator('h1')).toHaveText('Writing journal posts in MDX');
+  });
+
+  test('an endpoint without a handler says so', async ({ daemon, page }) => {
+    const site = await daemon.tenant('starter-no-handler', 'starter');
+    await site.write('src/pages/api/broken.json.ts', 'export const answer = 42;\n');
+    await page.goto(site.url('/api/broken.json'));
+    await expect(page.locator('h1')).toHaveText('Endpoint without a handler');
+    await expect(page.locator('pre')).toContainText('src/pages/api/broken.json.ts exports no GET or ALL function');
+  });
+});

--- a/examples/starter/src/pages/api/products.json.ts
+++ b/examples/starter/src/pages/api/products.json.ts
@@ -1,0 +1,6 @@
+import { formatPrice, products } from "@/data/products";
+
+export function GET(): Response {
+  const body = products.map((p) => ({ ...p, price: formatPrice(p.price) }));
+  return new Response(JSON.stringify(body, null, 2), { headers: { "content-type": "application/json; charset=utf-8" } });
+}

--- a/examples/starter/src/pages/rss.xml.ts
+++ b/examples/starter/src/pages/rss.xml.ts
@@ -1,0 +1,36 @@
+import type { APIContext } from "astro";
+import { getCollection } from "astro:content";
+
+const ESCAPES: Record<string, string> = { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&apos;" };
+
+function xml(value: string): string {
+  return value.replace(/[&<>"']/g, (c) => ESCAPES[c]);
+}
+
+export async function GET(context: APIContext): Promise<Response> {
+  const base = context.site ?? new URL(context.url.origin);
+  const posts = (await getCollection("posts")).sort((a, b) => new Date(b.data.date).getTime() - new Date(a.data.date).getTime());
+  const items = posts
+    .map((post) => {
+      const link = new URL(`/blog/${post.id}`, base).href;
+      return `    <item>
+      <title>${xml(post.data.title)}</title>
+      <link>${xml(link)}</link>
+      <guid isPermaLink="true">${xml(link)}</guid>
+      <description>${xml(post.data.description)}</description>
+      <pubDate>${new Date(post.data.date).toUTCString()}</pubDate>
+    </item>`;
+    })
+    .join("\n");
+  const body = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Lumen Studio</title>
+    <link>${xml(base.href)}</link>
+    <description>Notes on design, process and the tools we build with.</description>
+${items}
+  </channel>
+</rss>
+`;
+  return new Response(body, { headers: { "content-type": "application/xml; charset=utf-8" } });
+}

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -14,49 +14,51 @@ pub struct Route {
 }
 
 pub fn build(tenant: &Tenant) -> Vec<Route> {
-    let mut routes = Vec::new();
-    for e in tenant.list() {
-        let Some(rest) = e.path.strip_prefix("src/pages/") else { continue };
-        let Some((stem, ext)) = rest.rsplit_once('.') else { continue };
-        let kind = match ext {
-            "astro" => "astro",
-            "md" => "md",
-            "mdx" => "mdx",
-            "ts" | "js" | "mjs" | "mts" => "endpoint",
-            _ => continue,
-        };
-        let mut segs: Vec<&str> = stem.split('/').collect();
-        if segs.iter().any(|s| s.starts_with('_')) {
-            continue;
-        }
-        if segs.last() == Some(&"index") {
-            segs.pop();
-        }
-        let mut params = Vec::new();
-        let mut pattern = String::from("^");
-        let mut key = Vec::new();
-        let mut route = String::new();
-        for seg in &segs {
-            route.push('/');
-            route.push_str(seg);
-            let (re, kind_max, ps) = segment_regex(seg);
-            if seg.starts_with("[...") && seg.ends_with(']') && ps.len() == 1 && kind_max == 2 {
-                pattern.push_str("(?:/(.*?))?");
-            } else {
-                pattern.push('/');
-                pattern.push_str(&re);
-            }
-            key.push(kind_max);
-            params.extend(ps);
-        }
-        if segs.is_empty() {
-            route.push('/');
-        }
-        pattern.push_str("/?$");
-        routes.push(Route { route, component: e.path.clone(), kind, params, pattern, key });
-    }
+    let mut routes: Vec<Route> = tenant.list().iter().filter_map(|e| route(&e.path)).collect();
     routes.sort_by(|a, b| a.key.cmp(&b.key).then(b.key.len().cmp(&a.key.len())).then(a.route.cmp(&b.route)));
     routes
+}
+
+fn route(path: &str) -> Option<Route> {
+    let rest = path.strip_prefix("src/pages/")?;
+    // Only the last dot is the extension: rss.xml.ts is the route /rss.xml.
+    let (stem, ext) = rest.rsplit_once('.')?;
+    let kind = match ext {
+        "astro" => "astro",
+        "md" => "md",
+        "mdx" => "mdx",
+        "ts" | "js" | "mjs" | "mts" => "endpoint",
+        _ => return None,
+    };
+    let mut segs: Vec<&str> = stem.split('/').collect();
+    if segs.iter().any(|s| s.starts_with('_')) {
+        return None;
+    }
+    if segs.last() == Some(&"index") {
+        segs.pop();
+    }
+    let mut params = Vec::new();
+    let mut pattern = String::from("^");
+    let mut key = Vec::new();
+    let mut route = String::new();
+    for seg in &segs {
+        route.push('/');
+        route.push_str(seg);
+        let (re, kind_max, ps) = segment_regex(seg);
+        if seg.starts_with("[...") && seg.ends_with(']') && ps.len() == 1 && kind_max == 2 {
+            pattern.push_str("(?:/(.*?))?");
+        } else {
+            pattern.push('/');
+            pattern.push_str(&re);
+        }
+        key.push(kind_max);
+        params.extend(ps);
+    }
+    if segs.is_empty() {
+        route.push('/');
+    }
+    pattern.push_str("/?$");
+    Some(Route { route, component: path.to_string(), kind, params, pattern, key })
 }
 
 fn segment_regex(seg: &str) -> (String, u8, Vec<String>) {
@@ -108,6 +110,23 @@ fn escape(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn of(path: &str) -> (String, &'static str, String) {
+        let r = route(path).unwrap_or_else(|| panic!("{path} is not a route"));
+        (r.route, r.kind, r.pattern)
+    }
+
+    #[test]
+    fn endpoints_keep_the_extension_the_file_name_carries() {
+        assert_eq!(of("src/pages/rss.xml.ts"), ("/rss.xml".into(), "endpoint", "^/rss\\.xml/?$".into()));
+        assert_eq!(of("src/pages/api/products.json.ts"), ("/api/products.json".into(), "endpoint", "^/api/products\\.json/?$".into()));
+        assert_eq!(of("src/pages/sitemap.js").0, "/sitemap");
+        assert_eq!(of("src/pages/api/index.ts").0, "/api");
+        assert_eq!(of("src/pages/about.astro"), ("/about".into(), "astro", "^/about/?$".into()));
+        assert!(route("src/pages/_helpers.ts").is_none());
+        assert!(route("src/pages/styles.css").is_none());
+        assert!(route("src/data/products.ts").is_none());
+    }
 
     #[test]
     fn segment_patterns() {


### PR DESCRIPTION
Closes #8

`src/pages/rss.xml.ts` and `src/pages/api/products.json.ts` are ordinary Astro
idioms and the preview answered both with an "unsupported route" page. It runs
them now.

## Approach

The Astro container already does this work, so nothing here hand-builds an
`APIContext`: `renderToResponse(mod, { routeType: "endpoint" })` takes the
module itself instead of a component and calls its `GET` (or `ALL`) with the
real context — `request`, `params`, `props`, `url`, `site`, `redirect`,
`cookies`, `locals`. `getStaticPaths` runs on the same path as a page, so a
dynamic endpoint receives the props of its matching entry. No framework
renderers are registered for an endpoint: it renders no components, and
fetching `renderers.json` plus each server module is a round trip for nothing.

The `Response` is then presented rather than assumed to be a page:

- `3xx` with `Location` → `location.replace`, as before.
- `text/html` → written to the document, through the same head injection every
  page gets, so `live.js` and registered CSS still arrive.
- anything else (XML, JSON, plain text) → status, content-type and an escaped
  `<pre>` of the body, JSON pretty-printed. A preview's only verb is a
  navigation, so this is what makes an endpoint inspectable at all.
- a module exporting neither `GET` nor `ALL` → the error overlay saying so,
  rather than the page path's "no default export component".

`src/routes.rs` already read the extension from the last dot; the loop moved
into `fn route(path)` so that rule can be tested one path at a time, and it now
is: `rss.xml.ts` is `/rss.xml` with `^/rss\.xml/?$`, `api/products.json.ts` is
`/api/products.json`, `api/index.ts` is `/api`, `_helpers.ts` and
`src/data/products.ts` are not routes.

`examples/starter` gains `src/pages/rss.xml.ts` (hand-written XML over the
`posts` collection, no `@astrojs/rss` dependency, links built from
`context.site ?? context.url.origin`) and `src/pages/api/products.json.ts`
(the existing `@/data/products` module through the `@/` alias).

## What proves it

Nothing here rests on a claim about a machine you cannot see — the checks on
this PR are the evidence, and the new behaviour is written as tests they run:

- `src/routes.rs`: `endpoints_keep_the_extension_the_file_name_carries` pins
  the file-name rule, including the escaped dot in the pattern and the three
  paths that are not routes.
- `e2e/endpoints.spec.ts` (six specs in the `e2e` job): the starter's
  `/rss.xml` and `/api/products.json` rendered through a real browser, a
  dynamic endpoint receiving its `getStaticPaths` props, an HTML response
  written as a page, a `context.redirect()` that actually navigates, and the
  missing-handler overlay. The suite's `browserLog` fixture fails any of them
  on a console error or a failed request, so a silent regression in the shell
  is a red spec.
- `sandbox-lite check examples/starter` in the `test` job reports
  `endpoints 2`, so the two new files are compiled, not merely present.

## Noticed, did not fix

- **Non-`GET` verbs.** `POST`/`PUT`/`DELETE` handlers are never reached: a
  visitor navigates, so the preview only ever issues a `GET` and the request
  carries no body. Exercising them needs a UI (a form, or a fetch console) this
  PR does not add.
- **`src/middleware.ts` is not loaded.** `astro:middleware` is a shim whose
  `sequence` returns its first argument; an endpoint's `context.locals` is
  therefore always empty. Documented under "What the preview does not do", not
  implemented.
- **The endpoint viewer is not a document.** A JSON or XML response is shown as
  escaped text on an HTML page, so "view source" and a browser's own XML/JSON
  viewer do not apply, and copying the body copies the rendered text. Serving
  the bytes with their real content-type would need the daemon to run the
  handler, which is the whole thing this design avoids.
- **The RSS feed is not linked.** `examples/starter` has `/rss.xml` but no
  `<link rel="alternate">` in `Layout.astro` pointing at it.
- **`getStaticPaths` is not validated for endpoints.** A dynamic endpoint whose
  `getStaticPaths` omits the requested params gets the page path's "404 — no
  static path" overlay, which reads as a page error.
- **`prettyJSON` reformats.** A response whose JSON is deliberately compact or
  ordered a particular way is re-serialized for display; the body a client
  would receive is not shown byte-for-byte.
- **Two green PRs can still merge red.** #35 and #36 were each green alone and
  did not compile merged; a checkout of `main` between #36 and 6f71156 fails
  `cargo test`. CI runs on a PR head, never on the merge result, so the shape
  that caused it is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
