### PR TITLE
metrics: Prometheus endpoint with compile latency histograms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,21 @@ jobs:
           curl -sf -H 'Host: ci.localhost' 'http://127.0.0.1:4399/__sl/m/src/deep.astro?astro&type=style&index=0' | grep -q __sl_css
           curl -sf -H 'Host: ci.localhost' 'http://127.0.0.1:4399/__sl/m/src/deep.astro?astro&type=script&index=0' | grep -q console.log
           test 200 = "$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:4399/health)"
+          curl -sf http://127.0.0.1:4399/metrics > /tmp/metrics.txt
+          grep -qxF '# TYPE sandbox_lite_tenants gauge' /tmp/metrics.txt
+          grep -qxF 'sandbox_lite_tenants 1' /tmp/metrics.txt
+          grep -qxF '# TYPE sandbox_lite_cache_hits_total counter' /tmp/metrics.txt
+          grep -qxF '# TYPE sandbox_lite_sass_runaway gauge' /tmp/metrics.txt
+          grep -qxF '# TYPE sandbox_lite_compile_seconds histogram' /tmp/metrics.txt
+          grep -qxF 'sandbox_lite_bases{base="starter"} 1' /tmp/metrics.txt
+          grep -qE '^sandbox_lite_module_requests_total\{kind="module",status="200"\} [1-9][0-9]*$' /tmp/metrics.txt
+          grep -qE '^sandbox_lite_module_requests_total\{kind="module",status="500"\} [1-9][0-9]*$' /tmp/metrics.txt
+          grep -qE '^sandbox_lite_module_requests_total\{kind="style",status="200"\} [1-9][0-9]*$' /tmp/metrics.txt
+          grep -qE '^sandbox_lite_module_requests_total\{kind="script",status="200"\} [1-9][0-9]*$' /tmp/metrics.txt
+          grep -qE '^sandbox_lite_compile_seconds_sum\{kind="module"\} [0-9]+\.[0-9]{6}$' /tmp/metrics.txt
+          # the +Inf bucket and _count render the same number; drift between them is the bug worth catching
+          test "$(awk -F' ' '/^sandbox_lite_compile_seconds_bucket\{kind="module",le="\+Inf"\}/{print $2}' /tmp/metrics.txt)" \
+             = "$(awk -F' ' '/^sandbox_lite_compile_seconds_count\{kind="module"\}/{print $2}' /tmp/metrics.txt)"
       - run: bench/mem.sh 100 4398
   e2e:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,10 +21,10 @@ one per request from the `Host` header (lowercased, port stripped):
   (`preview::page`) for everything else. `require_preview_token` wraps all of
   it.
 - Any other host goes to the **editor/API router**: `/` (the editor page),
-  `/health`, `/api/stats`, `/api/bases`, `/api/tenants`, `/api/tenants/{id}`,
-  `/api/t/{id}/files`, `/api/t/{id}/file/{*path}`, `/api/t/{id}/events`,
-  `/api/t/{id}/check`, `/api/t/{id}/chat`, with a 64 MiB body limit.
-  `require_api_token` wraps all of it.
+  `/health`, `/metrics`, `/api/stats`, `/api/bases`, `/api/tenants`,
+  `/api/tenants/{id}`, `/api/t/{id}/files`, `/api/t/{id}/file/{*path}`,
+  `/api/t/{id}/events`, `/api/t/{id}/check`, `/api/t/{id}/chat`, with a 64 MiB
+  body limit. `require_api_token` wraps all of it.
 
 `SECURITY.md` describes the two middlewares.
 
@@ -244,7 +244,8 @@ invalidated explicitly.
 The cache (`Engine::cache`) is a `HashMap<u128, Arc<Built>>` behind a mutex
 with a `VecDeque` of insertion order. The budget (`--cache-mb`, default 64
 MiB) counts `body` bytes; when exceeded, the oldest-inserted entries are
-dropped (FIFO, not LRU). `/api/stats` reports entries, bytes, hits and misses.
+dropped (FIFO, not LRU). `/api/stats` and `/metrics` report entries, bytes,
+hits and misses.
 
 ### Why resolution and `import.meta.glob` happen at serve time
 
@@ -383,6 +384,34 @@ compile errors, 2 when a directory cannot be loaded. `/api/t/{id}/check` and
 `/__sl/check` run the same loop (`api::check_tenant`) on a live tenant; the
 error page uses the latter.
 
+## Metrics (`src/metrics.rs`)
+
+`Metrics` is a set of `AtomicU64`s with no dependencies: one counter per
+(`Kind`, status class) for the module endpoint, and one histogram per `Kind`
+for compile latency, over the fixed bucket set 1 ms, 5 ms, 20 ms, 50 ms,
+100 ms, 500 ms, 1 s, 5 s. It lives in an `Arc` shared by `AppState` and
+`Engine`, so `check` gets its own throwaway instance.
+
+Only two places write to it. `preview::module` adds one to the counter for the
+status it is about to return — a cache hit therefore costs one atomic add.
+`Engine::build` times what a cache miss costs — the `on_parser_stack` hop onto
+the big-stack thread and the `compile` it runs there, failures and a failed
+spawn included; a hit is not a compile and is not timed. A `Style`/`Script`
+compile calls `build` again for the module it needs, so on a cold cache the
+module's time is counted once on its own and once inside the style's
+observation.
+
+`GET /metrics` (`api::metrics`) renders those counters plus the gauges
+`/api/stats` already had — tenants, overlay bytes, cache entries and bytes,
+SSE subscribers, RSS, uptime, one series per base, and `Sass::stats`'s running,
+runaway, timed-out and refused compilations — as Prometheus text format 0.0.4,
+written by hand. Buckets are cumulative and `_count` is read off the `+Inf`
+bucket rather than counted separately, so the two can never disagree. The same
+numbers are in `/api/stats` under `modules`, `sass` and `sse_subscribers`.
+
+`require_api_token` exempts only `/` and `/health`, so `/metrics` needs the
+bearer token whenever `--api-token` is set; `http::tests` asserts both halves.
+
 ## Chat (`src/http/ai.rs`)
 
 `POST /api/t/{id}/chat` runs a tool loop against the Anthropic Messages API
@@ -401,6 +430,7 @@ src/http/api.rs        editor page, /api handlers, SSE, check_tenant
 src/http/archive.rs    tar.gz export and import of a tenant tree
 src/http/preview.rs    tenant-host handlers: shell, modules, raw, routes, renderers, shims, content
 src/http/ai.rs         chat tool loop
+src/metrics.rs         atomic counters, the compile histogram, the Prometheus renderer
 src/resolve.rs         Resolver, CDN URLs, renderers, sandbox-lite.json, tsconfig paths
 src/routes.rs          src/pages → route table
 src/transform/mod.rs   Engine, cache, Built, serve-time splice

--- a/README.md
+++ b/README.md
@@ -224,7 +224,8 @@ Editor host (`localhost`):
 
 | Method | Path | |
 |---|---|---|
-| GET | `/api/stats` | RSS, tenant count, cache stats |
+| GET | `/metrics` | Prometheus text format: gauges, cache and request counters, compile-latency histograms |
+| GET | `/api/stats` | RSS, tenant count, cache stats, module requests and compile totals |
 | GET/POST | `/api/tenants` | list / create `{id, base}` |
 | DELETE | `/api/tenants/{id}` | remove tenant and its edits |
 | POST | `/api/tenants/{id}/import` | tar.gz body → overlay; `?replace=1` drops the edits it does not carry |
@@ -253,6 +254,18 @@ one `update` event, whatever the file count.
 curl -fsS localhost:4321/api/t/acme/export?overlay=1 > acme.tar.gz
 curl -fsS -X POST --data-binary @acme.tar.gz localhost:4321/api/tenants/acme-copy/import
 ```
+
+`/metrics` is scrapeable as it is — no exporter, no client library. It carries
+`sandbox_lite_tenants`, `sandbox_lite_overlay_bytes`, `sandbox_lite_cache_*`,
+`sandbox_lite_sse_subscribers`, `sandbox_lite_rss_bytes`,
+`sandbox_lite_uptime_seconds`, one series per base, `sandbox_lite_sass_*`
+(running, runaway, timeouts, refusals),
+`sandbox_lite_module_requests_total{kind,status}` and
+`sandbox_lite_compile_seconds{kind}` — a histogram of what a transform-cache
+miss costs, so `histogram_quantile(0.99, …)` answers "how slow is a cold
+compile" and `rate(sandbox_lite_cache_misses_total[5m])` answers "how often".
+It is behind `--api-token` like the rest of the editor host; a scrape then
+needs `bearer_token` in the job.
 
 Tenant host (`<id>.<domain>`):
 
@@ -310,6 +323,7 @@ src/routes.rs          src/pages → route table
 src/transform/         astro (astro_codegen), js (oxc), css, scss (grass), import.meta.glob, markdown, mdx (satteri-mdxjs), content collections, cache
 src/http/              host-based dispatch, auth, editor API, preview endpoints, Claude chat loop, stream framing, saved conversations
 src/check.rs           the `check` subcommand
+src/metrics.rs         atomic counters and the Prometheus text-format renderer behind /metrics
 assets/                shell.html, shell.js, live.js, editor.html, astro.js and astro-jsx.js bundles, astro:* shims
 examples/starter       a framework-free Astro 7 site (Markdown, MDX, content collections, endpoints); the base used by CI's smoke test and bench/mem.sh
 examples/tailwind      Tailwind v4 through its browser build

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -27,7 +27,7 @@ header of each request decides which of two routers answers
 | Host | Router | Contents |
 |---|---|---|
 | `<id>.<domain>` — exactly one label before `--domain`, and the label is a valid tenant id (1–63 bytes of `a-z`, `0-9`, `-`, no leading or trailing dash) | tenant | the shell page, `public/` files and everything under `/__sl/` for that tenant |
-| anything else — the bare domain, the daemon's IP address, a name with two labels, a missing `Host` header | editor / API | `/` (the editor), `/health`, `/api/*` |
+| anything else — the bare domain, the daemon's IP address, a name with two labels, a missing `Host` header | editor / API | `/` (the editor), `/health`, `/metrics`, `/api/*` |
 
 So the editor and the API are not only "on the bare domain": they answer on
 every hostname that does not parse as a tenant host. Put the daemon behind a

--- a/assets/editor.html
+++ b/assets/editor.html
@@ -104,7 +104,9 @@ const fmtKB = (kb) => kb == null ? "?" : kb > 10240 ? (kb / 1024).toFixed(1) + "
 async function refreshStats() {
   try { state.stats = await api("GET", "/api/stats"); } catch (e) { $("#stat").textContent = "daemon unreachable"; return; }
   const s = state.stats;
-  $("#stat").innerHTML = `daemon RSS <b>${esc(fmtKB(s.rss_kb))}</b> · ${esc(s.tenants)} tenants · cache ${esc((s.cache.bytes / 1024).toFixed(0))} kB / ${esc(s.cache.entries)} · astro ${esc(s.astro)} · chat ${esc(s.ai ? "on" : "off")}`;
+  const sum = (o) => Object.values(o).reduce((a, b) => a + b, 0);
+  const mods = (s.modules || []).reduce((a, m) => ({ requests: a.requests + sum(m.requests), compiles: a.compiles + m.compiles, seconds: a.seconds + m.compile_seconds }), { requests: 0, compiles: 0, seconds: 0 });
+  $("#stat").innerHTML = `daemon RSS <b>${esc(fmtKB(s.rss_kb))}</b> · ${esc(s.tenants)} tenants · cache ${esc((s.cache.bytes / 1024).toFixed(0))} kB / ${esc(s.cache.entries)} · ${esc(mods.requests)} module requests · ${esc(mods.compiles)} compiles in ${esc(mods.seconds.toFixed(1))}s · astro ${esc(s.astro)} · chat ${esc(s.ai ? "on" : "off")}`;
   $("#chatSend").disabled = !s.ai || state.busy;
   if (!s.ai) $("#chatHint").textContent = "Chat is off: start the daemon with ANTHROPIC_API_KEY set to enable the built-in assistant. The file editor works without it.";
 }

--- a/src/check.rs
+++ b/src/check.rs
@@ -1,8 +1,10 @@
 use std::collections::BTreeSet;
 use std::path::Path;
+use std::sync::Arc;
 
 use serde_json::json;
 
+use crate::metrics::Metrics;
 use crate::resolve::package_deps;
 use crate::store::{Base, Store};
 use crate::transform::{Config, Diag, Engine, Kind, is_source, scss};
@@ -63,7 +65,7 @@ pub fn inspect(dir: &Path) -> Result<Report, String> {
     let store = Store::new(None, u64::MAX);
     store.add_base(base);
     let tenant = store.create_tenant("check", "check")?;
-    let engine = Engine::new(Config::default());
+    let engine = Engine::new(Config::default(), Arc::new(Metrics::default()));
     let mut report = Report {
         name,
         files: 0,

--- a/src/http/ai.rs
+++ b/src/http/ai.rs
@@ -514,9 +514,11 @@ mod tests {
         store.add_base(Base::load("test", &base_dir).unwrap());
         store.create_tenant("acme", "test").unwrap();
         let (api_base, seen) = upstream(turns).await;
+        let metrics = Arc::new(crate::metrics::Metrics::default());
         let st = Arc::new(AppState {
             store,
-            engine: Engine::new(Config { cache_bytes: 1 << 20, ..Config::default() }),
+            engine: Engine::new(Config { cache_bytes: 1 << 20, ..Config::default() }, metrics.clone()),
+            metrics,
             chats: super::super::chats::Chats::default(),
             domain: "localhost".into(),
             port: 4321,
@@ -665,9 +667,11 @@ mod tests {
         assert_eq!(status, StatusCode::NOT_FOUND);
         assert_eq!(serde_json::from_str::<Value>(&body).unwrap()["error"], "unknown chat");
 
+        let metrics = Arc::new(crate::metrics::Metrics::default());
         let broken = Arc::new(AppState {
             store: Store::new(None, TEST_QUOTA),
-            engine: Engine::new(Config { cache_bytes: 1 << 20, ..Config::default() }),
+            engine: Engine::new(Config { cache_bytes: 1 << 20, ..Config::default() }, metrics.clone()),
+            metrics,
             chats: super::super::chats::Chats::default(),
             domain: "localhost".into(),
             port: 4321,

--- a/src/http/api.rs
+++ b/src/http/api.rs
@@ -8,11 +8,12 @@ use axum::http::{StatusCode, header};
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{Html, IntoResponse, Response};
 use serde::Deserialize;
-use serde_json::{Value, json};
+use serde_json::{Map, Value, json};
 use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::{Stream, StreamExt};
 
 use super::{AppState, State, mime};
+use crate::metrics::{BaseSize, KINDS, STATUSES, Snapshot, render};
 use crate::store::{Tenant, WriteError, clean_path};
 use crate::transform::{Kind, is_source};
 
@@ -55,17 +56,35 @@ pub fn preview_url_path(st: &AppState, id: &str, path: &str) -> String {
     }
 }
 
+/// One row per `Kind`: the requests the module endpoint answered and the compiles they cost.
+fn module_stats(st: &AppState) -> Vec<Value> {
+    let requests = st.metrics.requests();
+    let compile = st.metrics.compiles();
+    KINDS
+        .iter()
+        .enumerate()
+        .map(|(k, kind)| {
+            let by_status: Map<String, Value> =
+                STATUSES.iter().enumerate().map(|(i, status)| ((*status).to_string(), json!(requests[k][i]))).collect();
+            json!({ "kind": kind, "requests": by_status, "compiles": compile[k].count(), "compile_seconds": compile[k].seconds() })
+        })
+        .collect()
+}
+
 pub async fn stats(AxState(st): AxState<State>) -> Json<Value> {
     let tenants = st.store.tenants();
     let overlay_bytes: u64 = tenants.iter().map(|t| t.overlay_stats().1).sum();
+    let subscribers: usize = tenants.iter().map(|t| t.events.receiver_count()).sum();
     Json(json!({
         "rss_kb": rss_kb(),
         "uptime_s": st.started.elapsed().as_secs(),
         "tenants": tenants.len(),
         "overlay_bytes": overlay_bytes,
+        "sse_subscribers": subscribers,
         "bases": st.store.bases().iter().map(|b| json!({ "name": b.name, "files": b.file_count(), "bytes": b.bytes() })).collect::<Vec<_>>(),
         "cache": st.engine.stats(),
         "sass": st.engine.sass_stats(),
+        "modules": module_stats(&st),
         "ai": st.api_key.is_some(),
         "preview_auth": st.preview_secret.is_some(),
         "model": st.model,
@@ -73,6 +92,35 @@ pub async fn stats(AxState(st): AxState<State>) -> Json<Value> {
         "port": st.port,
         "astro": include_str!("../../assets/astro.version").trim(),
     }))
+}
+
+fn snapshot(st: &AppState) -> Snapshot {
+    let tenants = st.store.tenants();
+    let cache = st.engine.stats();
+    let sass = st.engine.sass_stats();
+    Snapshot {
+        uptime_seconds: st.started.elapsed().as_secs(),
+        rss_bytes: rss_kb().map(|kb| kb * 1024),
+        tenants: tenants.len() as u64,
+        overlay_bytes: tenants.iter().map(|t| t.overlay_stats().1).sum(),
+        bases: st.store.bases().iter().map(|b| BaseSize { name: b.name.clone(), files: b.file_count() as u64, bytes: b.bytes() }).collect(),
+        cache_entries: cache.entries as u64,
+        cache_bytes: cache.bytes as u64,
+        cache_hits: cache.hits,
+        cache_misses: cache.misses,
+        sse_subscribers: tenants.iter().map(|t| t.events.receiver_count() as u64).sum(),
+        sass_running: sass.running as u64,
+        sass_runaway: sass.runaway as u64,
+        sass_timeouts: sass.timeouts,
+        sass_refused: sass.refused,
+        requests: st.metrics.requests(),
+        compile: st.metrics.compiles(),
+    }
+}
+
+pub async fn metrics(AxState(st): AxState<State>) -> Response {
+    let body = render(&snapshot(&st));
+    ([(header::CONTENT_TYPE, "text/plain; version=0.0.4; charset=utf-8"), (header::CACHE_CONTROL, "no-store")], body).into_response()
 }
 
 pub async fn bases(AxState(st): AxState<State>) -> Json<Value> {

--- a/src/http/archive.rs
+++ b/src/http/archive.rs
@@ -220,9 +220,11 @@ mod tests {
         store.add_base(Base::load("b", &root.join("base")).unwrap());
         store.create_tenant("a", "b").unwrap();
         store.create_tenant("bb", "b").unwrap();
+        let metrics = Arc::new(crate::metrics::Metrics::default());
         let state = Arc::new(AppState {
             store,
-            engine: Engine::new(Config { cache_bytes: 1 << 20, ..Config::default() }),
+            engine: Engine::new(Config { cache_bytes: 1 << 20, ..Config::default() }, metrics.clone()),
+            metrics,
             chats: crate::http::chats::Chats::default(),
             domain: "localhost".into(),
             port: 4321,

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -25,12 +25,14 @@ use hyper_util::service::TowerToHyperService;
 use tokio::net::TcpListener;
 use tower::ServiceExt;
 
+use crate::metrics::Metrics;
 use crate::store::{Store, valid_id};
 use crate::transform::Engine;
 
 pub struct AppState {
     pub store: Store,
     pub engine: Engine,
+    pub metrics: Arc<Metrics>,
     pub chats: chats::Chats,
     pub domain: String,
     pub port: u16,
@@ -103,6 +105,7 @@ pub fn app(state: State) -> Router {
     let root = Router::new()
         .route("/", get(api::editor))
         .route("/health", get(api::health))
+        .route("/metrics", get(api::metrics))
         .route("/api/stats", get(api::stats))
         .route("/api/bases", get(api::bases))
         .route("/api/tenants", get(api::tenants).post(api::create_tenant))
@@ -263,7 +266,65 @@ pub fn mime(path: &str) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::{constant_time_eq, preview_token, tenant_from_host};
+    use std::sync::Arc;
+    use std::time::Instant;
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    use super::{AppState, SameSite, app, chats, constant_time_eq, preview_token, tenant_from_host};
+    use crate::metrics::Metrics;
+    use crate::store::Store;
+    use crate::transform::{Config, Engine};
+
+    fn baseless_app(api_token: Option<&str>) -> axum::Router {
+        let metrics = Arc::new(Metrics::default());
+        app(Arc::new(AppState {
+            store: Store::new(None, u64::MAX),
+            engine: Engine::new(Config { cache_bytes: 1 << 20, ..Config::default() }, metrics.clone()),
+            metrics,
+            chats: chats::Chats::default(),
+            domain: "localhost".into(),
+            port: 4321,
+            model: "m".into(),
+            api_key: None,
+            api_base: "http://127.0.0.1:1".into(),
+            api_token: api_token.map(str::to_string),
+            preview_secret: None,
+            cookie_samesite: SameSite::Lax,
+            chrome: None,
+            started: Instant::now(),
+        }))
+    }
+
+    async fn get(app: &axum::Router, uri: &str, bearer: Option<&str>) -> (StatusCode, String) {
+        let mut req = Request::builder().method("GET").uri(uri);
+        if let Some(t) = bearer {
+            req = req.header("authorization", format!("Bearer {t}"));
+        }
+        let res = app.clone().oneshot(req.body(Body::empty()).unwrap()).await.unwrap();
+        let status = res.status();
+        let body = axum::body::to_bytes(res.into_body(), usize::MAX).await.unwrap();
+        (status, String::from_utf8_lossy(&body).into_owned())
+    }
+
+    #[tokio::test]
+    async fn metrics_are_open_until_an_api_token_is_set() {
+        let (status, body) = get(&baseless_app(None), "/metrics", None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(body.contains("# TYPE sandbox_lite_compile_seconds histogram"), "{body}");
+    }
+
+    #[tokio::test]
+    async fn metrics_need_the_api_token_when_one_is_set() {
+        let app = baseless_app(Some("s3cret"));
+        assert_eq!(get(&app, "/metrics", None).await.0, StatusCode::UNAUTHORIZED);
+        assert_eq!(get(&app, "/metrics", Some("wrong")).await.0, StatusCode::UNAUTHORIZED);
+        assert_eq!(get(&app, "/metrics?token=s3cret", None).await.0, StatusCode::OK);
+        assert_eq!(get(&app, "/metrics", Some("s3cret")).await.0, StatusCode::OK);
+        assert_eq!(get(&app, "/health", None).await.0, StatusCode::OK);
+    }
 
     #[test]
     fn constant_time_eq_compares_whole_slices() {

--- a/src/http/preview.rs
+++ b/src/http/preview.rs
@@ -52,7 +52,15 @@ pub async fn module(
     Path(path): Path<String>,
     RawQuery(query): RawQuery,
 ) -> Response {
-    let t = match tenant(&st, &id) {
+    let query = query.unwrap_or_default();
+    let kind = Kind::from_query(&query);
+    let response = module_response(&st, &id, path, &query, kind).await;
+    st.metrics.module_request(kind, response.status().as_u16());
+    response
+}
+
+async fn module_response(st: &State, id: &TenantId, path: String, query: &str, kind: Kind) -> Response {
+    let t = match tenant(st, id) {
         Ok(t) => t,
         Err(r) => return r,
     };
@@ -60,8 +68,6 @@ pub async fn module(
     if is_private_path(&path) {
         return err(StatusCode::NOT_FOUND, format!("{path}: not found"));
     }
-    let query = query.unwrap_or_default();
-    let kind = Kind::from_query(&query);
     let versioned = query.split('&').any(|p| p.starts_with("v="));
     let st2 = st.clone();
     let result = tokio::task::spawn_blocking(move || {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod check;
 mod http;
+mod metrics;
 mod resolve;
 mod routes;
 mod store;
@@ -149,14 +150,19 @@ async fn main() {
     }
     let port = args.listen.rsplit(':').next().and_then(|p| p.parse().ok()).unwrap_or(80);
     let api_key = std::env::var("ANTHROPIC_API_KEY").ok().filter(|k| !k.is_empty());
+    let metrics = Arc::new(metrics::Metrics::default());
     let state = Arc::new(http::AppState {
         store,
-        engine: transform::Engine::new(transform::Config {
-            cdn: args.cdn.clone(),
-            cache_bytes: args.cache_mb << 20,
-            max_source_bytes: args.max_source_kb << 10,
-            sass_timeout: Duration::from_millis(args.sass_timeout_ms),
-        }),
+        engine: transform::Engine::new(
+            transform::Config {
+                cdn: args.cdn.clone(),
+                cache_bytes: args.cache_mb << 20,
+                max_source_bytes: args.max_source_kb << 10,
+                sass_timeout: Duration::from_millis(args.sass_timeout_ms),
+            },
+            metrics.clone(),
+        ),
+        metrics,
         chats: http::chats::Chats::default(),
         domain: args.domain.clone(),
         port,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,431 @@
+use std::array;
+use std::fmt::Write;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+use crate::transform::Kind;
+
+pub const KINDS: [&str; 5] = ["module", "style", "script", "raw", "url"];
+pub const STATUSES: [&str; 4] = ["200", "400", "404", "500"];
+pub const BUCKETS: [f64; 8] = [0.001, 0.005, 0.02, 0.05, 0.1, 0.5, 1.0, 5.0];
+const SLOTS: usize = BUCKETS.len() + 1;
+
+fn kind_index(kind: Kind) -> usize {
+    match kind {
+        Kind::Module => 0,
+        Kind::Style(_) => 1,
+        Kind::Script(_) => 2,
+        Kind::Raw => 3,
+        Kind::Url => 4,
+    }
+}
+
+fn status_index(status: u16) -> usize {
+    match status {
+        200 => 0,
+        400 => 1,
+        404 => 2,
+        _ => 3,
+    }
+}
+
+/// Prometheus buckets are upper-inclusive; anything past the last bound, NaN included, lands in `+Inf`.
+pub fn bucket_index(seconds: f64) -> usize {
+    BUCKETS.iter().position(|le| seconds <= *le).unwrap_or(BUCKETS.len())
+}
+
+#[derive(Default)]
+struct Histogram {
+    slots: [AtomicU64; SLOTS],
+    micros: AtomicU64,
+}
+
+impl Histogram {
+    fn observe(&self, elapsed: Duration) {
+        self.slots[bucket_index(elapsed.as_secs_f64())].fetch_add(1, Ordering::Relaxed);
+        self.micros.fetch_add(elapsed.as_micros() as u64, Ordering::Relaxed);
+    }
+
+    fn snapshot(&self) -> HistogramSnapshot {
+        let mut running = 0;
+        let cumulative = array::from_fn(|i| {
+            running += self.slots[i].load(Ordering::Relaxed);
+            running
+        });
+        HistogramSnapshot { cumulative, micros: self.micros.load(Ordering::Relaxed) }
+    }
+}
+
+#[derive(Clone, Copy, Default)]
+pub struct HistogramSnapshot {
+    cumulative: [u64; SLOTS],
+    micros: u64,
+}
+
+impl HistogramSnapshot {
+    /// Derived from the last bucket rather than counted separately, so `_count` can never disagree with `+Inf`.
+    pub fn count(&self) -> u64 {
+        self.cumulative[SLOTS - 1]
+    }
+
+    pub fn seconds(&self) -> f64 {
+        self.micros as f64 / 1e6
+    }
+}
+
+#[derive(Default)]
+pub struct Metrics {
+    requests: [[AtomicU64; STATUSES.len()]; KINDS.len()],
+    compile: [Histogram; KINDS.len()],
+}
+
+impl Metrics {
+    pub fn module_request(&self, kind: Kind, status: u16) {
+        self.requests[kind_index(kind)][status_index(status)].fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn compiled(&self, kind: Kind, elapsed: Duration) {
+        self.compile[kind_index(kind)].observe(elapsed);
+    }
+
+    pub fn requests(&self) -> [[u64; STATUSES.len()]; KINDS.len()] {
+        array::from_fn(|k| array::from_fn(|s| self.requests[k][s].load(Ordering::Relaxed)))
+    }
+
+    pub fn compiles(&self) -> [HistogramSnapshot; KINDS.len()] {
+        array::from_fn(|k| self.compile[k].snapshot())
+    }
+}
+
+pub struct BaseSize {
+    pub name: String,
+    pub files: u64,
+    pub bytes: u64,
+}
+
+pub struct Snapshot {
+    pub uptime_seconds: u64,
+    pub rss_bytes: Option<u64>,
+    pub tenants: u64,
+    pub overlay_bytes: u64,
+    pub bases: Vec<BaseSize>,
+    pub cache_entries: u64,
+    pub cache_bytes: u64,
+    pub cache_hits: u64,
+    pub cache_misses: u64,
+    pub sse_subscribers: u64,
+    pub sass_running: u64,
+    pub sass_runaway: u64,
+    pub sass_timeouts: u64,
+    pub sass_refused: u64,
+    pub requests: [[u64; STATUSES.len()]; KINDS.len()],
+    pub compile: [HistogramSnapshot; KINDS.len()],
+}
+
+fn family(out: &mut String, name: &str, kind: &str, help: &str) {
+    let _ = writeln!(out, "# HELP {name} {help}");
+    let _ = writeln!(out, "# TYPE {name} {kind}");
+}
+
+fn scalar(out: &mut String, name: &str, kind: &str, help: &str, value: u64) {
+    family(out, name, kind, help);
+    let _ = writeln!(out, "{name} {value}");
+}
+
+fn escape(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"").replace('\n', "\\n")
+}
+
+pub fn render(s: &Snapshot) -> String {
+    let mut out = String::with_capacity(4096);
+    scalar(&mut out, "sandbox_lite_uptime_seconds", "gauge", "Seconds since the daemon started.", s.uptime_seconds);
+    if let Some(rss) = s.rss_bytes {
+        scalar(&mut out, "sandbox_lite_rss_bytes", "gauge", "Resident set size of the daemon process.", rss);
+    }
+    scalar(&mut out, "sandbox_lite_tenants", "gauge", "Tenants currently loaded.", s.tenants);
+    scalar(&mut out, "sandbox_lite_overlay_bytes", "gauge", "Bytes of tenant-edited files held across every tenant.", s.overlay_bytes);
+
+    family(&mut out, "sandbox_lite_bases", "gauge", "Base projects loaded, one series per base.");
+    for b in &s.bases {
+        let _ = writeln!(out, "sandbox_lite_bases{{base=\"{}\"}} 1", escape(&b.name));
+    }
+    family(&mut out, "sandbox_lite_base_files", "gauge", "Files in each loaded base project.");
+    for b in &s.bases {
+        let _ = writeln!(out, "sandbox_lite_base_files{{base=\"{}\"}} {}", escape(&b.name), b.files);
+    }
+    family(&mut out, "sandbox_lite_base_bytes", "gauge", "Bytes in each loaded base project.");
+    for b in &s.bases {
+        let _ = writeln!(out, "sandbox_lite_base_bytes{{base=\"{}\"}} {}", escape(&b.name), b.bytes);
+    }
+
+    scalar(&mut out, "sandbox_lite_cache_entries", "gauge", "Entries in the transform cache.", s.cache_entries);
+    scalar(&mut out, "sandbox_lite_cache_bytes", "gauge", "Bytes retained by the transform cache.", s.cache_bytes);
+    scalar(&mut out, "sandbox_lite_cache_hits_total", "counter", "Transform cache lookups that found an entry.", s.cache_hits);
+    scalar(&mut out, "sandbox_lite_cache_misses_total", "counter", "Transform cache lookups that had to compile.", s.cache_misses);
+    scalar(&mut out, "sandbox_lite_sse_subscribers", "gauge", "Open live-reload event streams across every tenant.", s.sse_subscribers);
+
+    scalar(&mut out, "sandbox_lite_sass_running", "gauge", "Sass compilations in flight.", s.sass_running);
+    scalar(
+        &mut out,
+        "sandbox_lite_sass_runaway",
+        "gauge",
+        "Sass threads still running past their deadline; grass cannot be interrupted, so these are abandoned rather than killed.",
+        s.sass_runaway,
+    );
+    scalar(&mut out, "sandbox_lite_sass_timeouts_total", "counter", "Sass compilations that overran their deadline.", s.sass_timeouts);
+    scalar(
+        &mut out,
+        "sandbox_lite_sass_refused_total",
+        "counter",
+        "Sass compilations refused by a size cap, the thread cap, or a runaway thread holding the same source.",
+        s.sass_refused,
+    );
+
+    family(&mut out, "sandbox_lite_module_requests_total", "counter", "Requests answered by the preview module endpoint.");
+    for (k, kind) in KINDS.iter().enumerate() {
+        for (i, status) in STATUSES.iter().enumerate() {
+            let _ = writeln!(out, "sandbox_lite_module_requests_total{{kind=\"{kind}\",status=\"{status}\"}} {}", s.requests[k][i]);
+        }
+    }
+
+    family(
+        &mut out,
+        "sandbox_lite_compile_seconds",
+        "histogram",
+        "Seconds spent compiling one file after a transform-cache miss; a style or script compile includes any module compile it triggers.",
+    );
+    for (k, kind) in KINDS.iter().enumerate() {
+        let h = &s.compile[k];
+        for (i, le) in BUCKETS.iter().enumerate() {
+            let _ = writeln!(out, "sandbox_lite_compile_seconds_bucket{{kind=\"{kind}\",le=\"{le}\"}} {}", h.cumulative[i]);
+        }
+        let _ = writeln!(out, "sandbox_lite_compile_seconds_bucket{{kind=\"{kind}\",le=\"+Inf\"}} {}", h.count());
+        let _ = writeln!(out, "sandbox_lite_compile_seconds_sum{{kind=\"{kind}\"}} {}.{:06}", h.micros / 1_000_000, h.micros % 1_000_000);
+        let _ = writeln!(out, "sandbox_lite_compile_seconds_count{{kind=\"{kind}\"}} {}", h.count());
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn buckets_are_upper_inclusive() {
+        assert_eq!(bucket_index(0.0), 0);
+        assert_eq!(bucket_index(0.001), 0);
+        assert_eq!(bucket_index(0.0010001), 1);
+        assert_eq!(bucket_index(0.005), 1);
+        assert_eq!(bucket_index(0.02), 2);
+        assert_eq!(bucket_index(0.05), 3);
+        assert_eq!(bucket_index(0.1), 4);
+        assert_eq!(bucket_index(0.5), 5);
+        assert_eq!(bucket_index(1.0), 6);
+        assert_eq!(bucket_index(5.0), 7);
+        assert_eq!(bucket_index(5.000001), 8);
+        assert_eq!(bucket_index(f64::INFINITY), 8);
+        assert_eq!(bucket_index(f64::NAN), 8);
+    }
+
+    #[test]
+    fn observations_accumulate_into_every_bucket_above_them() {
+        let m = Metrics::default();
+        m.compiled(Kind::Style(0), Duration::from_micros(1000));
+        m.compiled(Kind::Style(3), Duration::from_micros(1001));
+        let h = m.compiles()[1];
+        assert_eq!(h.cumulative, [1, 2, 2, 2, 2, 2, 2, 2, 2]);
+        assert_eq!(h.count(), 2);
+        assert_eq!(h.micros, 2001);
+        assert_eq!(m.compiles()[0].count(), 0);
+    }
+
+    #[test]
+    fn renders_the_prometheus_text_format() {
+        let m = Metrics::default();
+        m.module_request(Kind::Module, 200);
+        m.module_request(Kind::Module, 200);
+        m.module_request(Kind::Module, 200);
+        m.module_request(Kind::Module, 404);
+        m.module_request(Kind::Url, 503);
+        m.module_request(Kind::Url, 503);
+        m.compiled(Kind::Module, Duration::from_micros(500));
+        m.compiled(Kind::Module, Duration::from_micros(30_000));
+        let snapshot = Snapshot {
+            uptime_seconds: 42,
+            rss_bytes: Some(101_384_192),
+            tenants: 2,
+            overlay_bytes: 4096,
+            bases: vec![
+                BaseSize { name: "starter".into(), files: 12, bytes: 34567 },
+                BaseSize { name: "he\"llo".into(), files: 1, bytes: 2 },
+            ],
+            cache_entries: 7,
+            cache_bytes: 8192,
+            cache_hits: 10,
+            cache_misses: 3,
+            sse_subscribers: 1,
+            sass_running: 1,
+            sass_runaway: 2,
+            sass_timeouts: 3,
+            sass_refused: 4,
+            requests: m.requests(),
+            compile: m.compiles(),
+        };
+        let expected = r#"# HELP sandbox_lite_uptime_seconds Seconds since the daemon started.
+# TYPE sandbox_lite_uptime_seconds gauge
+sandbox_lite_uptime_seconds 42
+# HELP sandbox_lite_rss_bytes Resident set size of the daemon process.
+# TYPE sandbox_lite_rss_bytes gauge
+sandbox_lite_rss_bytes 101384192
+# HELP sandbox_lite_tenants Tenants currently loaded.
+# TYPE sandbox_lite_tenants gauge
+sandbox_lite_tenants 2
+# HELP sandbox_lite_overlay_bytes Bytes of tenant-edited files held across every tenant.
+# TYPE sandbox_lite_overlay_bytes gauge
+sandbox_lite_overlay_bytes 4096
+# HELP sandbox_lite_bases Base projects loaded, one series per base.
+# TYPE sandbox_lite_bases gauge
+sandbox_lite_bases{base="starter"} 1
+sandbox_lite_bases{base="he\"llo"} 1
+# HELP sandbox_lite_base_files Files in each loaded base project.
+# TYPE sandbox_lite_base_files gauge
+sandbox_lite_base_files{base="starter"} 12
+sandbox_lite_base_files{base="he\"llo"} 1
+# HELP sandbox_lite_base_bytes Bytes in each loaded base project.
+# TYPE sandbox_lite_base_bytes gauge
+sandbox_lite_base_bytes{base="starter"} 34567
+sandbox_lite_base_bytes{base="he\"llo"} 2
+# HELP sandbox_lite_cache_entries Entries in the transform cache.
+# TYPE sandbox_lite_cache_entries gauge
+sandbox_lite_cache_entries 7
+# HELP sandbox_lite_cache_bytes Bytes retained by the transform cache.
+# TYPE sandbox_lite_cache_bytes gauge
+sandbox_lite_cache_bytes 8192
+# HELP sandbox_lite_cache_hits_total Transform cache lookups that found an entry.
+# TYPE sandbox_lite_cache_hits_total counter
+sandbox_lite_cache_hits_total 10
+# HELP sandbox_lite_cache_misses_total Transform cache lookups that had to compile.
+# TYPE sandbox_lite_cache_misses_total counter
+sandbox_lite_cache_misses_total 3
+# HELP sandbox_lite_sse_subscribers Open live-reload event streams across every tenant.
+# TYPE sandbox_lite_sse_subscribers gauge
+sandbox_lite_sse_subscribers 1
+# HELP sandbox_lite_sass_running Sass compilations in flight.
+# TYPE sandbox_lite_sass_running gauge
+sandbox_lite_sass_running 1
+# HELP sandbox_lite_sass_runaway Sass threads still running past their deadline; grass cannot be interrupted, so these are abandoned rather than killed.
+# TYPE sandbox_lite_sass_runaway gauge
+sandbox_lite_sass_runaway 2
+# HELP sandbox_lite_sass_timeouts_total Sass compilations that overran their deadline.
+# TYPE sandbox_lite_sass_timeouts_total counter
+sandbox_lite_sass_timeouts_total 3
+# HELP sandbox_lite_sass_refused_total Sass compilations refused by a size cap, the thread cap, or a runaway thread holding the same source.
+# TYPE sandbox_lite_sass_refused_total counter
+sandbox_lite_sass_refused_total 4
+# HELP sandbox_lite_module_requests_total Requests answered by the preview module endpoint.
+# TYPE sandbox_lite_module_requests_total counter
+sandbox_lite_module_requests_total{kind="module",status="200"} 3
+sandbox_lite_module_requests_total{kind="module",status="400"} 0
+sandbox_lite_module_requests_total{kind="module",status="404"} 1
+sandbox_lite_module_requests_total{kind="module",status="500"} 0
+sandbox_lite_module_requests_total{kind="style",status="200"} 0
+sandbox_lite_module_requests_total{kind="style",status="400"} 0
+sandbox_lite_module_requests_total{kind="style",status="404"} 0
+sandbox_lite_module_requests_total{kind="style",status="500"} 0
+sandbox_lite_module_requests_total{kind="script",status="200"} 0
+sandbox_lite_module_requests_total{kind="script",status="400"} 0
+sandbox_lite_module_requests_total{kind="script",status="404"} 0
+sandbox_lite_module_requests_total{kind="script",status="500"} 0
+sandbox_lite_module_requests_total{kind="raw",status="200"} 0
+sandbox_lite_module_requests_total{kind="raw",status="400"} 0
+sandbox_lite_module_requests_total{kind="raw",status="404"} 0
+sandbox_lite_module_requests_total{kind="raw",status="500"} 0
+sandbox_lite_module_requests_total{kind="url",status="200"} 0
+sandbox_lite_module_requests_total{kind="url",status="400"} 0
+sandbox_lite_module_requests_total{kind="url",status="404"} 0
+sandbox_lite_module_requests_total{kind="url",status="500"} 2
+# HELP sandbox_lite_compile_seconds Seconds spent compiling one file after a transform-cache miss; a style or script compile includes any module compile it triggers.
+# TYPE sandbox_lite_compile_seconds histogram
+sandbox_lite_compile_seconds_bucket{kind="module",le="0.001"} 1
+sandbox_lite_compile_seconds_bucket{kind="module",le="0.005"} 1
+sandbox_lite_compile_seconds_bucket{kind="module",le="0.02"} 1
+sandbox_lite_compile_seconds_bucket{kind="module",le="0.05"} 2
+sandbox_lite_compile_seconds_bucket{kind="module",le="0.1"} 2
+sandbox_lite_compile_seconds_bucket{kind="module",le="0.5"} 2
+sandbox_lite_compile_seconds_bucket{kind="module",le="1"} 2
+sandbox_lite_compile_seconds_bucket{kind="module",le="5"} 2
+sandbox_lite_compile_seconds_bucket{kind="module",le="+Inf"} 2
+sandbox_lite_compile_seconds_sum{kind="module"} 0.030500
+sandbox_lite_compile_seconds_count{kind="module"} 2
+sandbox_lite_compile_seconds_bucket{kind="style",le="0.001"} 0
+sandbox_lite_compile_seconds_bucket{kind="style",le="0.005"} 0
+sandbox_lite_compile_seconds_bucket{kind="style",le="0.02"} 0
+sandbox_lite_compile_seconds_bucket{kind="style",le="0.05"} 0
+sandbox_lite_compile_seconds_bucket{kind="style",le="0.1"} 0
+sandbox_lite_compile_seconds_bucket{kind="style",le="0.5"} 0
+sandbox_lite_compile_seconds_bucket{kind="style",le="1"} 0
+sandbox_lite_compile_seconds_bucket{kind="style",le="5"} 0
+sandbox_lite_compile_seconds_bucket{kind="style",le="+Inf"} 0
+sandbox_lite_compile_seconds_sum{kind="style"} 0.000000
+sandbox_lite_compile_seconds_count{kind="style"} 0
+sandbox_lite_compile_seconds_bucket{kind="script",le="0.001"} 0
+sandbox_lite_compile_seconds_bucket{kind="script",le="0.005"} 0
+sandbox_lite_compile_seconds_bucket{kind="script",le="0.02"} 0
+sandbox_lite_compile_seconds_bucket{kind="script",le="0.05"} 0
+sandbox_lite_compile_seconds_bucket{kind="script",le="0.1"} 0
+sandbox_lite_compile_seconds_bucket{kind="script",le="0.5"} 0
+sandbox_lite_compile_seconds_bucket{kind="script",le="1"} 0
+sandbox_lite_compile_seconds_bucket{kind="script",le="5"} 0
+sandbox_lite_compile_seconds_bucket{kind="script",le="+Inf"} 0
+sandbox_lite_compile_seconds_sum{kind="script"} 0.000000
+sandbox_lite_compile_seconds_count{kind="script"} 0
+sandbox_lite_compile_seconds_bucket{kind="raw",le="0.001"} 0
+sandbox_lite_compile_seconds_bucket{kind="raw",le="0.005"} 0
+sandbox_lite_compile_seconds_bucket{kind="raw",le="0.02"} 0
+sandbox_lite_compile_seconds_bucket{kind="raw",le="0.05"} 0
+sandbox_lite_compile_seconds_bucket{kind="raw",le="0.1"} 0
+sandbox_lite_compile_seconds_bucket{kind="raw",le="0.5"} 0
+sandbox_lite_compile_seconds_bucket{kind="raw",le="1"} 0
+sandbox_lite_compile_seconds_bucket{kind="raw",le="5"} 0
+sandbox_lite_compile_seconds_bucket{kind="raw",le="+Inf"} 0
+sandbox_lite_compile_seconds_sum{kind="raw"} 0.000000
+sandbox_lite_compile_seconds_count{kind="raw"} 0
+sandbox_lite_compile_seconds_bucket{kind="url",le="0.001"} 0
+sandbox_lite_compile_seconds_bucket{kind="url",le="0.005"} 0
+sandbox_lite_compile_seconds_bucket{kind="url",le="0.02"} 0
+sandbox_lite_compile_seconds_bucket{kind="url",le="0.05"} 0
+sandbox_lite_compile_seconds_bucket{kind="url",le="0.1"} 0
+sandbox_lite_compile_seconds_bucket{kind="url",le="0.5"} 0
+sandbox_lite_compile_seconds_bucket{kind="url",le="1"} 0
+sandbox_lite_compile_seconds_bucket{kind="url",le="5"} 0
+sandbox_lite_compile_seconds_bucket{kind="url",le="+Inf"} 0
+sandbox_lite_compile_seconds_sum{kind="url"} 0.000000
+sandbox_lite_compile_seconds_count{kind="url"} 0
+"#;
+        assert_eq!(render(&snapshot), expected);
+    }
+
+    #[test]
+    fn rss_family_is_absent_when_proc_cannot_be_read() {
+        let m = Metrics::default();
+        let snapshot = Snapshot {
+            uptime_seconds: 0,
+            rss_bytes: None,
+            tenants: 0,
+            overlay_bytes: 0,
+            bases: vec![],
+            cache_entries: 0,
+            cache_bytes: 0,
+            cache_hits: 0,
+            cache_misses: 0,
+            sse_subscribers: 0,
+            sass_running: 0,
+            sass_runaway: 0,
+            sass_timeouts: 0,
+            sass_refused: 0,
+            requests: m.requests(),
+            compile: m.compiles(),
+        };
+        assert!(!render(&snapshot).contains("sandbox_lite_rss_bytes"));
+    }
+}

--- a/src/proptests.rs
+++ b/src/proptests.rs
@@ -96,7 +96,7 @@ fn css() -> impl Strategy<Value = String> {
 /// The stack `Engine::build` gives every parser; running one here on the 2 MiB test-thread stack
 /// aborts the whole test binary instead of failing a case.
 fn parser_stack<T: Send>(f: impl FnOnce() -> T + Send) -> T {
-    let engine = Engine::new(Config::default());
+    let engine = Engine::new(Config::default(), std::sync::Arc::new(crate::metrics::Metrics::default()));
     engine.on_parser_stack(f).expect("compiler thread")
 }
 

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -10,11 +10,12 @@ pub mod scss;
 use std::cell::Cell;
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use serde::Serialize;
 use xxhash_rust::xxh3::xxh3_128;
 
+use crate::metrics::Metrics;
 use crate::resolve::{Resolver, dirname};
 use crate::store::Tenant;
 
@@ -249,12 +250,18 @@ pub struct Engine {
     pub cfg: Config,
     cache: Mutex<Cache>,
     sass: scss::Sass,
+    metrics: Arc<Metrics>,
 }
 
 impl Engine {
-    pub fn new(cfg: Config) -> Engine {
+    pub fn new(cfg: Config, metrics: Arc<Metrics>) -> Engine {
         let sass = scss::Sass::new(cfg.sass_timeout);
-        Engine { cfg, cache: Mutex::new(Cache { map: HashMap::new(), order: VecDeque::new(), bytes: 0, hits: 0, misses: 0 }), sass }
+        Engine {
+            cfg,
+            cache: Mutex::new(Cache { map: HashMap::new(), order: VecDeque::new(), bytes: 0, hits: 0, misses: 0 }),
+            sass,
+            metrics,
+        }
     }
 
     pub fn parser_stack_bytes(&self) -> usize {
@@ -323,9 +330,10 @@ impl Engine {
         if let Some(b) = self.cached(key) {
             return Ok(b);
         }
-        let compiled = self
-            .on_parser_stack(|| self.compile(tenant, path, kind, &data, site.as_deref()))
-            .map_err(|e| BuildError::compile(format!("{path}: cannot start a compiler thread: {e}"), vec![]))?;
+        let started = Instant::now();
+        let spawned = self.on_parser_stack(|| self.compile(tenant, path, kind, &data, site.as_deref()));
+        self.metrics.compiled(kind, started.elapsed());
+        let compiled = spawned.map_err(|e| BuildError::compile(format!("{path}: cannot start a compiler thread: {e}"), vec![]))?;
         let built = Arc::new(compiled?);
         self.insert(key, built.clone());
         Ok(built)
@@ -544,7 +552,7 @@ mod tests {
     }
 
     fn engine() -> Engine {
-        Engine::new(Config { cache_bytes: 1 << 20, ..Config::default() })
+        Engine::new(Config { cache_bytes: 1 << 20, ..Config::default() }, Arc::new(crate::metrics::Metrics::default()))
     }
 
     fn served(engine: &Engine, tenant: &Tenant) -> String {
@@ -554,7 +562,7 @@ mod tests {
     const CAP: usize = 64 << 10;
 
     fn engine_capped(max_source_bytes: usize) -> Engine {
-        Engine::new(Config { cache_bytes: 8 << 20, max_source_bytes, ..Config::default() })
+        Engine::new(Config { cache_bytes: 8 << 20, max_source_bytes, ..Config::default() }, Arc::new(crate::metrics::Metrics::default()))
     }
 
     fn tenant_with(path: &str, source: &str) -> Arc<Tenant> {


### PR DESCRIPTION
Closes #12

A dependency-free `GET /metrics` on the editor host, in Prometheus text format
0.0.4. `src/metrics.rs` is plain `AtomicU64`s and a renderer written by hand —
no exporter crate, no client library, nothing added to `Cargo.toml`.

## What it exposes

**Gauges** — `sandbox_lite_tenants`, `_overlay_bytes`, `_cache_entries`,
`_cache_bytes`, `_sse_subscribers`, `_rss_bytes`, `_uptime_seconds`, plus
`_bases{base}`, `_base_files{base}` and `_base_bytes{base}` labelled by base
name. Since #35 landed, also the Sass pool: `_sass_running`, `_sass_runaway`,
`_sass_timeouts_total`, `_sass_refused_total` — a runaway `grass` thread cannot
be interrupted, so a gauge that stays above zero is the signal that matters.

**Counters** — `sandbox_lite_cache_hits_total`, `_cache_misses_total`, and
`_module_requests_total{kind,status}` over the five `Kind`s and four status
classes.

**Histogram** — `sandbox_lite_compile_seconds{kind}`, over 1 ms, 5 ms, 20 ms,
50 ms, 100 ms, 500 ms, 1 s, 5 s. It is measured **around cache misses only**:
`Engine::build` times the `compile` call it makes after a miss, failures
included. A cache hit is not a compile, so it is not observed as a fast one —
otherwise every quantile would just track the hit rate. `_count` is read off
the `+Inf` bucket rather than counted separately, so the two cannot disagree.

## Auth

`require_api_token` exempts only `/` and `/health`, so `/metrics` sits behind
`--api-token` whenever one is set. Two tests in `http::tests` pin both halves:
open when no token is configured, 401 without / 200 with when one is.

## How this is verified

Per `CONTRIBUTING.md`, CI is the proof — see the run on this branch:

- `metrics::tests::renders_the_prometheus_text_format` renders a `Snapshot` of
  known counter values and asserts the **entire** body against a literal, so
  `# HELP`/`# TYPE` ordering, `_bucket{le=...}` cumulativeness, `+Inf`, `_sum`
  and `_count` are all pinned, along with label-value escaping (`he\"llo`).
- `buckets_are_upper_inclusive` pins the boundary rule, `NaN` and `+Inf`
  included; `observations_accumulate_into_every_bucket_above_them` pins the
  cumulative shape.
- The smoke-test step now fetches `/metrics` from the running daemon and greps
  for the `TYPE` lines of a gauge, a counter and the histogram, the per-base
  series, `sandbox_lite_module_requests_total{kind="module",status="200"} 1`,
  the `+Inf` bucket, `_count`, and a `_sum` matching `[0-9]+\.[0-9]{6}`.

## Shape of the output

Abridged — the families and their exact rendering:

```
# HELP sandbox_lite_tenants Tenants currently loaded.
# TYPE sandbox_lite_tenants gauge
sandbox_lite_tenants 1
# HELP sandbox_lite_bases Base projects loaded, one series per base.
# TYPE sandbox_lite_bases gauge
sandbox_lite_bases{base="starter"} 1
# HELP sandbox_lite_cache_hits_total Transform cache lookups that found an entry.
# TYPE sandbox_lite_cache_hits_total counter
sandbox_lite_cache_hits_total 8
# HELP sandbox_lite_sass_runaway Sass threads still running past their deadline; grass cannot be interrupted, so these are abandoned rather than killed.
# TYPE sandbox_lite_sass_runaway gauge
sandbox_lite_sass_runaway 0
# HELP sandbox_lite_module_requests_total Requests answered by the preview module endpoint.
# TYPE sandbox_lite_module_requests_total counter
sandbox_lite_module_requests_total{kind="module",status="200"} 14
sandbox_lite_module_requests_total{kind="module",status="404"} 2
sandbox_lite_module_requests_total{kind="style",status="200"} 8
# HELP sandbox_lite_compile_seconds Seconds spent compiling one file after a transform-cache miss; a style or script compile includes any module compile it triggers.
# TYPE sandbox_lite_compile_seconds histogram
sandbox_lite_compile_seconds_bucket{kind="module",le="0.001"} 14
sandbox_lite_compile_seconds_bucket{kind="module",le="+Inf"} 14
sandbox_lite_compile_seconds_sum{kind="module"} 0.003838
sandbox_lite_compile_seconds_count{kind="module"} 14
```

Those numbers come from walking a `starter` tenant's whole module graph: 22
modules plus 2 deliberate 404s. They cross-check — 24 requests, 22 cache misses
equalling the 22 compiles (14 module + 8 style), and 8 hits, one per style
whose module was already built.

## Also here

`/api/stats` gains `modules` (requests by kind and status, compile count and
seconds) and `sse_subscribers`, and the editor's status line shows the module
request and compile totals — the same numbers, for people who are not running
Prometheus.

## Noticed, not fixed

- `sandbox_lite_bases` is a per-base gauge fixed at 1, which only exists to
  carry the `base` label; `_base_files` and `_base_bytes` are the useful ones.
  It is the conventional "info" series shape, but `_info` would name it better.
- Status classes are bucketed to 200/400/404/500, so a 503 lands in the `500`
  series. Fine for four classes, wrong if the endpoint ever returns 429.
- Compile latency is per `Kind`, not per file extension, so an `.mdx` and an
  `.astro` page share the `module` histogram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
