### PR TITLE
security: source size cap and a big-stack thread for the parsers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,16 @@ jobs:
           curl -sf -H 'Host: ci.localhost' 'http://127.0.0.1:4399/__sl/m/src/pages/index.astro?v=1' | grep -q createComponent
           curl -sf -H 'Host: ci.localhost' 'http://127.0.0.1:4399/__sl/routes.json' | grep -q '"/blog/\[slug\]"'
           curl -sf -H 'Host: ci.localhost' 'http://127.0.0.1:4399/' | grep -q shell.js
+          # issue #25: deeply nested source must answer rather than abort the daemon
+          python3 -c "print('const x = ' + '['*20000)" > deep.ts
+          python3 -c "print('<style>p{color:red}</style><script>console.log(1)</script>' + '<div>'*1000 + 'x' + '</div>'*1000)" > deep.astro
+          curl -sf -X PUT --data-binary @deep.ts http://127.0.0.1:4399/api/t/ci/file/src/deep.ts
+          curl -sf -X PUT --data-binary @deep.astro http://127.0.0.1:4399/api/t/ci/file/src/deep.astro
+          test 500 = "$(curl -s -o /dev/null -w '%{http_code}' -H 'Host: ci.localhost' 'http://127.0.0.1:4399/__sl/m/src/deep.ts?v=1')"
+          curl -sf -H 'Host: ci.localhost' 'http://127.0.0.1:4399/__sl/m/src/deep.astro?v=1' | grep -q createComponent
+          curl -sf -H 'Host: ci.localhost' 'http://127.0.0.1:4399/__sl/m/src/deep.astro?astro&type=style&index=0' | grep -q __sl_css
+          curl -sf -H 'Host: ci.localhost' 'http://127.0.0.1:4399/__sl/m/src/deep.astro?astro&type=script&index=0' | grep -q console.log
+          test 200 = "$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:4399/health)"
       - run: bench/mem.sh 100 4398
   e2e:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ so it can look at the layout it just changed instead of guessing.
 --no-persist         keep edits in memory only
 --cdn URL            where bare npm imports resolve in the browser (default https://esm.sh)
 --cache-mb N         transform cache budget (default 64)
+--max-source-kb N    largest .astro/.ts/.js/.mdx/.scss file the compilers accept (default 64)
 --sass-timeout-ms N  deadline for one Sass compile (default 5000)
 --model NAME         Claude model for the chat endpoint (default claude-fable-5-1)
 --api-token TOKEN    require `Authorization: Bearer TOKEN` (or `?token=`) on /api/*

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -59,6 +59,35 @@ credentials on the API side.
   that is not a regular file or directory (symbolic links are not followed).
 - **Request bodies** on the editor/API router are capped at 64 MiB
   (`DefaultBodyLimit`). No tenant-host handler reads a request body.
+- **Compiled source** is bounded three ways before it reaches oxc,
+  `astro_codegen`, `satteri-mdxjs` or `grass`, all of which are
+  recursive-descent and so can overflow a thread stack — which aborts the whole
+  daemon, since the release profile sets `panic = "abort"`. The three apply to
+  the extensions those parsers read: `.astro`, `.ts`, `.tsx`, `.jsx`, `.mts`,
+  `.js`, `.mjs`, `.mdx`, `.scss`, `.sass`.
+  - **Size** is capped by `--max-source-kb` (default 64 KiB).
+  - **Nesting** is capped at 2000 (`MAX_NESTING_DEPTH`) — the deepest run of
+    unclosed `(`, `[`, `{` or of markdown blockquote markers, counted on the
+    bytes before any parser sees them.
+  - **Stack**: every compile runs on a thread whose stack is sized from the
+    size cap (`Engine::parser_stack_bytes`, 256 MiB at the default), which
+    covers the recursion the nesting scan does not model — chained unary `-`
+    for oxc, `<<` for `astro_codegen`. Raising `--max-source-kb` raises the
+    stack with it. The reservation is virtual address space; only the pages a
+    compile touches become resident.
+
+  Past either cap the build answers with a compile diagnostic. `.md`, `.css`,
+  `.json`, images and `?raw`/`?url` requests are not capped: none of them
+  recurse over the source.
+
+  Two parsed sources do not reach grass or oxc through `Engine::build`, and get
+  the bounds where they are loaded instead:
+  - `src/content.config.ts`, read by the content route — past the size or the
+    nesting cap it is left unparsed and the collection falls back to the
+    directory layout.
+  - Sass partials, which grass reads itself and compiles on its own thread
+    (see below) rather than on the one `Engine::build` reserved. Each is
+    refused past the nesting cap, and that thread gets a 64 MiB stack.
 - **Host matching** is exact: `a.b.<domain>` and `evil-<domain>` are not tenant
   hosts.
 - **Sass compilation** is bounded (`src/transform/scss.rs`). grass runs

--- a/src/http/preview.rs
+++ b/src/http/preview.rs
@@ -129,8 +129,13 @@ pub async fn content(AxState(st): AxState<State>, Extension(id): Extension<Tenan
     if !name.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_') {
         return err(StatusCode::BAD_REQUEST, "bad collection name");
     }
-    let out =
-        tokio::task::spawn_blocking(move || content::collection_json(&t, &name)).await.unwrap_or_else(|_| content::empty_collection());
+    let st2 = st.clone();
+    let out = tokio::task::spawn_blocking(move || {
+        let max = st2.engine.cfg.max_source_bytes;
+        st2.engine.on_parser_stack(move || content::collection_json(&t, &name, max))
+    })
+    .await;
+    let out = out.ok().and_then(Result::ok).unwrap_or_else(content::empty_collection);
     ([(header::CACHE_CONTROL, "no-cache")], Json(out)).into_response()
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ struct Args {
     domain: String,
     cdn: String,
     cache_mb: usize,
+    max_source_kb: usize,
     sass_timeout_ms: u64,
     model: String,
     api_token: Option<String>,
@@ -31,7 +32,7 @@ struct Args {
 
 fn usage() -> ! {
     eprintln!(
-        "sandbox-lite {}\n\nUsage: sandbox-lite [options]\n       sandbox-lite check [--json] DIR...   compile every source file of an Astro project and print diagnostics + a feature census\n\n  --listen ADDR        bind address (default 127.0.0.1:4321)\n  --domain NAME        preview domain; tenants are served at http://<id>.NAME:PORT/ (default localhost)\n  --bases DIR          directory whose sub-directories are base projects (default ./examples if present)\n  --base NAME=PATH     add one base project (repeatable)\n  --data-dir DIR       where tenant edits are persisted (default ./data)\n  --no-persist         keep tenant edits in memory only\n  --cdn URL            where bare npm imports are fetched from in the browser (default https://esm.sh)\n  --cache-mb N         transform cache budget in MiB (default 64)\n  --sass-timeout-ms N  deadline for one Sass compile, after which the request fails (default 5000)\n  --model NAME         Claude model for the built-in chat (default claude-fable-5-1)\n  --api-token TOKEN    require `Authorization: Bearer TOKEN` (or ?token=) on /api/*\n  --preview-secret S   tenant hosts need a per-tenant token derived from S (the API hands it out)\n  --chrome PATH        chrome or chromium binary for the chat's screenshot tool (default: off)\n  --tenant-quota-mb N  edited files a tenant may hold, in MiB; a write past it is refused with 413 (default 64)\n  --cookie-samesite lax|none\n                       SameSite of the preview cookie; none also sets Secure (default lax)\n\nEnvironment: ANTHROPIC_API_KEY enables the chat endpoint; SANDBOX_LITE_API_TOKEN, SANDBOX_LITE_PREVIEW_SECRET, SANDBOX_LITE_TENANT_QUOTA_MB and SANDBOX_LITE_CHROME are read as defaults for those flags; SANDBOX_LITE_ANTHROPIC_BASE points the chat at another Messages API endpoint (default https://api.anthropic.com).",
+        "sandbox-lite {}\n\nUsage: sandbox-lite [options]\n       sandbox-lite check [--json] DIR...   compile every source file of an Astro project and print diagnostics + a feature census\n\n  --listen ADDR        bind address (default 127.0.0.1:4321)\n  --domain NAME        preview domain; tenants are served at http://<id>.NAME:PORT/ (default localhost)\n  --bases DIR          directory whose sub-directories are base projects (default ./examples if present)\n  --base NAME=PATH     add one base project (repeatable)\n  --data-dir DIR       where tenant edits are persisted (default ./data)\n  --no-persist         keep tenant edits in memory only\n  --cdn URL            where bare npm imports are fetched from in the browser (default https://esm.sh)\n  --cache-mb N         transform cache budget in MiB (default 64)\n  --max-source-kb N    largest .astro/.ts/.js/.mdx/.scss file the compilers accept, in KiB (default 64)\n  --sass-timeout-ms N  deadline for one Sass compile, after which the request fails (default 5000)\n  --model NAME         Claude model for the built-in chat (default claude-fable-5-1)\n  --api-token TOKEN    require `Authorization: Bearer TOKEN` (or ?token=) on /api/*\n  --preview-secret S   tenant hosts need a per-tenant token derived from S (the API hands it out)\n  --chrome PATH        chrome or chromium binary for the chat's screenshot tool (default: off)\n  --tenant-quota-mb N  edited files a tenant may hold, in MiB; a write past it is refused with 413 (default 64)\n  --cookie-samesite lax|none\n                       SameSite of the preview cookie; none also sets Secure (default lax)\n\nEnvironment: ANTHROPIC_API_KEY enables the chat endpoint; SANDBOX_LITE_API_TOKEN, SANDBOX_LITE_PREVIEW_SECRET, SANDBOX_LITE_TENANT_QUOTA_MB and SANDBOX_LITE_CHROME are read as defaults for those flags; SANDBOX_LITE_ANTHROPIC_BASE points the chat at another Messages API endpoint (default https://api.anthropic.com).",
         env!("CARGO_PKG_VERSION")
     );
     std::process::exit(2)
@@ -46,6 +47,7 @@ fn parse_args() -> Args {
         domain: "localhost".into(),
         cdn: "https://esm.sh".into(),
         cache_mb: 64,
+        max_source_kb: 64,
         sass_timeout_ms: transform::scss::DEFAULT_TIMEOUT_MS,
         model: "claude-fable-5-1".into(),
         api_token: std::env::var("SANDBOX_LITE_API_TOKEN").ok().filter(|v| !v.is_empty()),
@@ -73,6 +75,7 @@ fn parse_args() -> Args {
             "--no-persist" => args.data_dir = None,
             "--cdn" => args.cdn = value(),
             "--cache-mb" => args.cache_mb = value().parse().unwrap_or_else(|_| usage()),
+            "--max-source-kb" => args.max_source_kb = value().parse().unwrap_or_else(|_| usage()),
             "--sass-timeout-ms" => args.sass_timeout_ms = value().parse().unwrap_or_else(|_| usage()),
             "--model" => args.model = value(),
             "--api-token" => args.api_token = Some(value()),
@@ -151,6 +154,7 @@ async fn main() {
         engine: transform::Engine::new(transform::Config {
             cdn: args.cdn.clone(),
             cache_bytes: args.cache_mb << 20,
+            max_source_bytes: args.max_source_kb << 10,
             sass_timeout: Duration::from_millis(args.sass_timeout_ms),
         }),
         chats: http::chats::Chats::default(),

--- a/src/proptests.rs
+++ b/src/proptests.rs
@@ -13,7 +13,7 @@ use crate::resolve::{import_map, join, normalize, package_name, strip_jsonc, tsc
 use crate::store::{clean_path, valid_id};
 use crate::transform::content::{parse_markdown, slugify, split_frontmatter, yaml_to_json};
 use crate::transform::css::rewrite_relative;
-use crate::transform::{Kind, glob, js, mdx, svg_size};
+use crate::transform::{Config, Engine, Kind, glob, js, mdx, svg_size};
 
 #[rustfmt::skip]
 const TOKENS: &[&str] = &[
@@ -91,6 +91,13 @@ fn svg() -> impl Strategy<Value = String> {
 fn css() -> impl Strategy<Value = String> {
     (short(), short(), prop::sample::select(QUOTES))
         .prop_map(|(a, b, q)| format!("@import {q}{a}{q}; .x{{background:url({q}{b}{q})}} @import url({a})"))
+}
+
+/// The stack `Engine::build` gives every parser; running one here on the 2 MiB test-thread stack
+/// aborts the whole test binary instead of failing a case.
+fn parser_stack<T: Send>(f: impl FnOnce() -> T + Send) -> T {
+    let engine = Engine::new(Config::default());
+    engine.on_parser_stack(f).expect("compiler thread")
 }
 
 fn assert_inside_tenant(path: &str) -> Result<(), TestCaseError> {
@@ -279,7 +286,8 @@ proptest! {
 
     #[test]
     fn mdx_page_module_is_a_module(src in prop_oneof![input(), markdown(), mdx()]) {
-        if let Ok(code) = mdx::page_module("src/pages/x.mdx", &src) {
+        // Nested blockquotes recurse in the MDX parser, so run it where the daemon runs it.
+        if let Ok(code) = parser_stack(|| mdx::page_module("src/pages/x.mdx", &src)) {
             prop_assert!(js::scan_checked(&code).is_some(), "generated module does not parse:\n{code}");
             prop_assert!(code.contains("\nexport const frontmatter = {"), "no frontmatter export in:\n{code}");
             prop_assert!(code.contains("\n__astro_tag_component__(Content, \"astro:jsx\");\n"), "Content not tagged in:\n{code}");

--- a/src/transform/content.rs
+++ b/src/transform/content.rs
@@ -113,8 +113,8 @@ pub fn slugify(text: &str) -> String {
     out.trim_end_matches('-').to_string()
 }
 
-pub fn collection_json(tenant: &Tenant, name: &str) -> Value {
-    let def = config(tenant).remove(name).unwrap_or_default();
+pub fn collection_json(tenant: &Tenant, name: &str, max_config_bytes: usize) -> Value {
+    let def = config(tenant, max_config_bytes).remove(name).unwrap_or_default();
     let entries = match &def.loader {
         Some(Loader::Glob { patterns, base }) => glob_entries(tenant, name, patterns, base),
         Some(Loader::File { path }) => file_entries(tenant, name, path),
@@ -262,8 +262,17 @@ const CONFIG_PATHS: [&str; 6] = [
     "src/content/config.mjs",
 ];
 
-pub fn config(tenant: &Tenant) -> BTreeMap<String, Definition> {
-    CONFIG_PATHS.iter().find_map(|p| tenant.read_text(p)).map(|src| parse_config(&src)).unwrap_or_default()
+/// The config goes to oxc, which recurses over it. This is the one parsed source the content route
+/// reaches without going through `Engine::build`, so the size and nesting caps are applied here;
+/// past either, it is left unparsed and the collection falls back to the directory layout, as it
+/// does when there is no config at all.
+pub fn config(tenant: &Tenant, max_bytes: usize) -> BTreeMap<String, Definition> {
+    CONFIG_PATHS
+        .iter()
+        .find_map(|p| tenant.read_text(p))
+        .filter(|src| src.len() <= max_bytes && super::nesting_depth(src.as_bytes()) <= super::MAX_NESTING_DEPTH)
+        .map(|src| parse_config(&src))
+        .unwrap_or_default()
 }
 
 pub fn parse_config(source: &str) -> BTreeMap<String, Definition> {

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -7,6 +7,7 @@ pub mod markdown;
 pub mod mdx;
 pub mod scss;
 
+use std::cell::Cell;
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -93,6 +94,80 @@ impl Built {
 
 pub const JS: &str = "text/javascript; charset=utf-8";
 
+/// oxc, astro_codegen, satteri-mdxjs and grass are recursive-descent, so a source byte can cost a
+/// stack frame and a stack overflow aborts the process (`panic = "abort"`). The two shapes measured
+/// past 1 KiB of stack per source byte both nest on characters `nesting_depth` counts, so what is
+/// left for the stack to absorb is the recursion that scan cannot see — chained unary `-` through
+/// oxc and `<<` through astro_codegen, both around 300 bytes per source byte in a debug build. The
+/// stack is sized from the source cap rather than fixed, so raising the cap raises it too.
+const STACK_PER_SOURCE_BYTE: usize = 4000;
+const MIN_PARSER_STACK: usize = 16 << 20;
+
+/// Three orders of magnitude past what hand-written source nests to. Two parsers cost far more than
+/// the rest per level — oxc about 2 KiB and the MDX blockquote reader about 3.7 KiB, and the latter
+/// is also quadratic in time, so 64 KiB of `>` takes a quarter of an hour whether or not the stack
+/// holds. Both recurse on characters a scan can count, so they are bounded before they are called.
+const MAX_NESTING_DEPTH: usize = 2000;
+
+/// How deep the parsers will recurse, counted on the bytes themselves: unclosed `(`, `[` and `{`,
+/// and runs of markdown blockquote markers. It does not skip strings or comments, so a literal full
+/// of brackets reads as nesting — nothing written by hand comes near the limit either way.
+fn nesting_depth(source: &[u8]) -> usize {
+    let (mut open, mut quote, mut max) = (0usize, 0usize, 0usize);
+    for &b in source {
+        match b {
+            b'(' | b'[' | b'{' => open += 1,
+            b')' | b']' | b'}' => open = open.saturating_sub(1),
+            b'>' => quote += 1,
+            b' ' | b'\t' => continue,
+            _ => quote = 0,
+        }
+        max = max.max(open).max(quote);
+    }
+    max
+}
+
+/// Extensions whose module build hands the source to one of those parsers. `md` is out: markdown
+/// never overflowed at any size the cap allows, and long articles are legitimate. `css` and `json`
+/// are out too — they are embedded in a JS module as a string, never parsed.
+fn parses_source(ext: &str) -> bool {
+    matches!(ext, "astro" | "ts" | "tsx" | "jsx" | "mts" | "js" | "mjs" | "mdx" | "scss" | "sass")
+}
+
+thread_local! {
+    static ON_PARSER_STACK: Cell<bool> = const { Cell::new(false) };
+    /// Counted per calling thread so parallel tests cannot see each other's spawns.
+    #[cfg(test)]
+    static SPAWNED: Cell<usize> = const { Cell::new(0) };
+}
+
+/// Runs `f` on a thread with a stack the parsers cannot walk off. The reservation is virtual
+/// address space; only the pages a compile actually touches become resident. A `?type=style` or
+/// `?type=script` build asks for the module first, so the flag keeps that inner build on the stack
+/// this one already reserved instead of reserving a second one.
+fn with_big_stack<T: Send>(stack_bytes: usize, f: impl FnOnce() -> T + Send) -> std::io::Result<T> {
+    if ON_PARSER_STACK.get() {
+        return Ok(f());
+    }
+    std::thread::scope(|scope| {
+        let body = || {
+            ON_PARSER_STACK.set(true);
+            f()
+        };
+        let handle = std::thread::Builder::new().stack_size(stack_bytes).spawn_scoped(scope, body)?;
+        #[cfg(test)]
+        SPAWNED.set(SPAWNED.get() + 1);
+        Ok(handle.join().unwrap_or_else(|payload| std::panic::resume_unwind(payload)))
+    })
+}
+
+fn refused(path: &str, text: String, hint: &str) -> BuildError {
+    BuildError::compile(
+        format!("{path}: {text}"),
+        vec![Diag { severity: "error".into(), text, hint: hint.to_string(), file: path.to_string(), line: 0, column: 0 }],
+    )
+}
+
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Kind {
     Module,
@@ -139,12 +214,18 @@ impl Kind {
 pub struct Config {
     pub cdn: String,
     pub cache_bytes: usize,
+    pub max_source_bytes: usize,
     pub sass_timeout: Duration,
 }
 
 impl Default for Config {
     fn default() -> Config {
-        Config { cdn: "https://esm.sh".into(), cache_bytes: 64 << 20, sass_timeout: Duration::from_millis(scss::DEFAULT_TIMEOUT_MS) }
+        Config {
+            cdn: "https://esm.sh".into(),
+            cache_bytes: 64 << 20,
+            max_source_bytes: 64 << 10,
+            sass_timeout: Duration::from_millis(scss::DEFAULT_TIMEOUT_MS),
+        }
     }
 }
 
@@ -174,6 +255,15 @@ impl Engine {
     pub fn new(cfg: Config) -> Engine {
         let sass = scss::Sass::new(cfg.sass_timeout);
         Engine { cfg, cache: Mutex::new(Cache { map: HashMap::new(), order: VecDeque::new(), bytes: 0, hits: 0, misses: 0 }), sass }
+    }
+
+    pub fn parser_stack_bytes(&self) -> usize {
+        self.cfg.max_source_bytes.saturating_mul(STACK_PER_SOURCE_BYTE).max(MIN_PARSER_STACK)
+    }
+
+    /// For the parsers reached outside `build` — the content config, which oxc walks.
+    pub fn on_parser_stack<T: Send>(&self, f: impl FnOnce() -> T + Send) -> std::io::Result<T> {
+        with_big_stack(self.parser_stack_bytes(), f)
     }
 
     pub fn stats(&self) -> CacheStats {
@@ -233,7 +323,10 @@ impl Engine {
         if let Some(b) = self.cached(key) {
             return Ok(b);
         }
-        let built = Arc::new(self.compile(tenant, path, kind, &data, site.as_deref())?);
+        let compiled = self
+            .on_parser_stack(|| self.compile(tenant, path, kind, &data, site.as_deref()))
+            .map_err(|e| BuildError::compile(format!("{path}: cannot start a compiler thread: {e}"), vec![]))?;
+        let built = Arc::new(compiled?);
         self.insert(key, built.clone());
         Ok(built)
     }
@@ -261,6 +354,18 @@ impl Engine {
             }
             Kind::Module => {
                 let ext = path.rsplit_once('.').map(|(_, e)| e).unwrap_or("").to_ascii_lowercase();
+                if parses_source(&ext) {
+                    let max = self.cfg.max_source_bytes;
+                    if data.len() > max {
+                        let text = format!("file too large to compile: {} KiB, limit {} KiB", data.len() / 1024, max / 1024);
+                        return Err(refused(path, text, "raise --max-source-kb, or split the file"));
+                    }
+                    let depth = nesting_depth(data);
+                    if depth > MAX_NESTING_DEPTH {
+                        let text = format!("source nests {depth} deep, limit {MAX_NESTING_DEPTH}");
+                        return Err(refused(path, text, "unbalanced brackets are the usual cause"));
+                    }
+                }
                 match ext.as_str() {
                     "astro" => {
                         let dir = dirname(path);
@@ -417,7 +522,7 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
-    use super::{Config, Engine, Kind, svg_size};
+    use super::*;
     use crate::resolve::Resolver;
     use crate::store::{Base, Store, Tenant};
 
@@ -444,6 +549,23 @@ mod tests {
 
     fn served(engine: &Engine, tenant: &Tenant) -> String {
         engine.serve(tenant, PAGE_PATH, Kind::Module, &Resolver::new(tenant, "https://esm.sh", 7)).unwrap().0
+    }
+
+    const CAP: usize = 64 << 10;
+
+    fn engine_capped(max_source_bytes: usize) -> Engine {
+        Engine::new(Config { cache_bytes: 8 << 20, max_source_bytes, ..Config::default() })
+    }
+
+    fn tenant_with(path: &str, source: &str) -> Arc<Tenant> {
+        tenant(&[(path, source)])
+    }
+
+    fn build_err(r: Result<Arc<Built>, BuildError>) -> BuildError {
+        match r {
+            Ok(_) => panic!("expected a compile error"),
+            Err(e) => e,
+        }
     }
 
     #[test]
@@ -485,6 +607,118 @@ mod tests {
         assert!(served(&engine, &a).contains("https://esm.sh/some-widgets@1.0.0"));
         assert!(served(&engine, &b).contains("https://esm.sh/some-widgets@2.0.0"));
         assert_eq!(engine.stats().misses, 1, "package.json is not in the cache key, so both tenants share one compile");
+    }
+
+    #[test]
+    fn cap_rejects_oversized_parsed_sources() {
+        let big = format!("export const x = [{}0];\n", "\"x\",".repeat(CAP / 4));
+        let t = tenant_with("src/big.ts", &big);
+        let e = build_err(engine_capped(CAP).build(&t, "src/big.ts", Kind::Module));
+        assert_eq!(e.status, 500);
+        assert!(e.message.contains("file too large to compile"), "{}", e.message);
+        assert_eq!(e.diagnostics.len(), 1);
+    }
+
+    #[test]
+    fn cap_leaves_unparsed_kinds_alone() {
+        let t = tenant_with("src/big.json", &format!("[{}0]", "\"x\",".repeat(CAP / 4)));
+        let e = engine_capped(CAP);
+        assert!(e.build(&t, "src/big.json", Kind::Module).is_ok());
+        assert!(e.build(&t, "src/big.json", Kind::Raw).is_ok());
+        assert!(e.build(&t, "src/big.json", Kind::Url).is_ok());
+    }
+
+    #[test]
+    fn cap_counts_bytes_not_characters() {
+        let source = format!("export const x = \"{}\";\n", "é".repeat(CAP / 2));
+        assert!(source.chars().count() < CAP && source.len() > CAP);
+        let t = tenant_with("src/wide.ts", &source);
+        assert!(engine_capped(CAP).build(&t, "src/wide.ts", Kind::Module).is_err());
+    }
+
+    /// Issue #25: on a default 2 MiB thread every one of these aborts the process. Bracket and
+    /// blockquote nesting is refused by the pre-scan; the shapes it does not model reach the parsers
+    /// on the big stack. Either way the build answers, and the process is alive for the next case.
+    #[test]
+    fn deep_nesting_answers_instead_of_aborting() {
+        for (path, source) in [
+            ("src/brackets.ts", format!("const x = {}1{}", "[".repeat(20_000), "]".repeat(20_000))),
+            ("src/unclosed.ts", format!("const x = {}", "[".repeat(20_000))),
+            ("src/quotes.mdx", ">".repeat(20_000)),
+            ("src/braces.scss", "a{".repeat(20_000)),
+        ] {
+            let t = tenant_with(path, &source);
+            let e = build_err(engine_capped(CAP).build(&t, path, Kind::Module));
+            assert!(e.message.contains("nests"), "{path}: {}", e.message);
+        }
+        for (path, source) in [
+            ("src/unary.ts", "- ".repeat(20_000)),
+            ("src/angles.astro", "<<".repeat(20_000)),
+            ("src/divs.astro", format!("{}x{}", "<div>".repeat(2_000), "</div>".repeat(2_000))),
+            ("src/jsx.mdx", format!("{}x{}", "<a>".repeat(2_000), "</a>".repeat(2_000))),
+        ] {
+            let t = tenant_with(path, &source);
+            if let Err(e) = engine_capped(CAP).build(&t, path, Kind::Module) {
+                assert!(!e.message.contains("too large") && !e.message.contains("nests"), "{path}: {}", e.message);
+            }
+        }
+    }
+
+    #[test]
+    fn nesting_depth_counts_brackets_and_blockquotes() {
+        assert_eq!(nesting_depth(b"const x = [[1], [2]];"), 2);
+        assert_eq!(nesting_depth(b"f(a) f(b) f(c)"), 1);
+        assert_eq!(nesting_depth(b"> > > quoted"), 3);
+        assert_eq!(nesting_depth(b"a >> b >>> c"), 3);
+        assert_eq!(nesting_depth(b"<div><span></span></div>"), 1);
+        assert_eq!(nesting_depth(b"))))"), 0);
+    }
+
+    #[test]
+    fn deeply_nested_astro_compiles() {
+        let source = format!("{}hi{}", "<div>".repeat(1000), "</div>".repeat(1000));
+        let t = tenant_with("src/nested.astro", &source);
+        let built = engine_capped(CAP).build(&t, "src/nested.astro", Kind::Module).unwrap();
+        assert!(built.body.contains("createComponent"));
+    }
+
+    /// `src/content.config.ts` goes to oxc from the content route, which does not go through `build`.
+    #[test]
+    fn a_content_config_past_either_limit_is_not_parsed() {
+        let good = "export const collections = { posts: defineCollection({}) };";
+        let t = tenant_with("src/content.config.ts", good);
+        assert!(!crate::transform::content::config(&t, CAP).is_empty());
+        for source in [&"a".repeat(CAP + 1), &"[".repeat(MAX_NESTING_DEPTH + 1)] {
+            let t = tenant_with("src/content.config.ts", source);
+            assert!(crate::transform::content::config(&t, CAP).is_empty());
+        }
+    }
+
+    #[test]
+    fn parser_stack_grows_with_the_cap() {
+        assert_eq!(engine_capped(CAP).parser_stack_bytes(), CAP * STACK_PER_SOURCE_BYTE);
+        assert_eq!(engine_capped(1).parser_stack_bytes(), MIN_PARSER_STACK);
+        assert_eq!(engine_capped(usize::MAX).parser_stack_bytes(), usize::MAX);
+    }
+
+    /// A `?type=style` build asks for the module first. That inner build must not reserve a second
+    /// big stack on top of the one the outer build is already running on.
+    #[test]
+    fn a_style_build_reserves_one_stack_not_two() {
+        let t = tenant_with("src/styled.astro", "<style>p{color:red}</style><p>hi</p>");
+        let e = engine_capped(CAP);
+        SPAWNED.set(0);
+        e.build(&t, "src/styled.astro", Kind::Style(0)).unwrap();
+        assert_eq!(SPAWNED.get(), 1);
+    }
+
+    #[test]
+    fn a_script_build_reserves_one_stack_not_two() {
+        let t = tenant_with("src/scripted.astro", "<script>console.log(1)</script><p>hi</p>");
+        let e = engine_capped(CAP);
+        SPAWNED.set(0);
+        e.build(&t, "src/scripted.astro", Kind::Script(0)).unwrap();
+        assert_eq!(SPAWNED.get(), 1);
     }
 
     #[test]

--- a/src/transform/scss.rs
+++ b/src/transform/scss.rs
@@ -26,6 +26,11 @@ pub const DEFAULT_TIMEOUT_MS: u64 = 5_000;
 /// pathological, and it is what keeps a tenant from turning distinct runaway sources into threads.
 const MAX_THREADS: usize = 8;
 
+/// The compile runs here rather than on the stack `Engine::build` reserved, so this thread needs
+/// its own. grass costs about 8 KiB per nesting level and the loader refuses anything past
+/// `MAX_NESTING_DEPTH`, which puts the deepest stylesheet it will accept well inside this.
+const STACK: usize = 64 << 20;
+
 fn norm(path: &Path) -> String {
     normalize(&path.to_string_lossy())
 }
@@ -88,6 +93,12 @@ impl grass::Fs for Snapshot {
         let name = norm(path);
         match self.files.get(&name).map(FileData::read) {
             Some(Ok(bytes)) => {
+                let depth = super::nesting_depth(&bytes);
+                if depth > super::MAX_NESTING_DEPTH {
+                    let limit = super::MAX_NESTING_DEPTH;
+                    self.deny(format!("{name} nests {depth} deep, over the {limit} level Sass nesting limit"));
+                    return Ok(Vec::new());
+                }
                 self.read.fetch_add(bytes.len(), Ordering::Relaxed);
                 Ok(bytes.to_vec())
             }
@@ -144,7 +155,12 @@ impl Flights {
             options = options.input_syntax(grass::InputSyntax::Sass);
         }
         let css = match grass::from_string(source, &options) {
-            Ok(css) => css,
+            // A file the limits hid reads as empty, which can still compile. The CSS that comes
+            // back is then not the tenant's stylesheet, so say why rather than serve it.
+            Ok(css) => match fs.refusal() {
+                Some(reason) => return Err(self.refuse(reason)),
+                None => css,
+            },
             Err(e) => return self.failed(fs, e.to_string()),
         };
         if css.len() > MAX_OUTPUT {
@@ -212,6 +228,11 @@ impl Sass {
         if source.len() > MAX_FILE {
             return Err(self.0.refuse(format!("Sass source is {} bytes, over the {MAX_FILE} byte limit", source.len())));
         }
+        let depth = super::nesting_depth(source.as_bytes());
+        if depth > super::MAX_NESTING_DEPTH {
+            let limit = super::MAX_NESTING_DEPTH;
+            return Err(self.0.refuse(format!("Sass source nests {depth} deep, over the {limit} level limit")));
+        }
         let mut h = Vec::with_capacity(source.len() + dir.len() + 2);
         h.push(u8::from(indented));
         h.extend_from_slice(dir.as_bytes());
@@ -249,7 +270,7 @@ impl Sass {
         if start {
             let fs = Snapshot::of(tenant, source.len());
             let (inner, f, dir, source) = (self.0.clone(), flight.clone(), dir.to_string(), source.to_string());
-            let spawned = std::thread::Builder::new().name("sass".into()).spawn(move || {
+            let spawned = std::thread::Builder::new().name("sass".into()).stack_size(STACK).spawn(move || {
                 let out = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| inner.run(&fs, &dir, source, indented)))
                     .unwrap_or_else(|_| inner.failed(&fs, "the Sass compiler panicked".to_string()));
                 inner.finish(key, &f, out);
@@ -357,6 +378,26 @@ mod tests {
         let sass = Sass::new(Duration::from_millis(super::DEFAULT_TIMEOUT_MS));
         let e = sass.compile(&t, "src/styles", "@use 'big';\n.a { color: red }", false).unwrap_err();
         assert!(e.contains("over the") && e.contains("byte Sass file limit"), "{e}");
+    }
+
+    /// Issue #25: `Engine::build` bounds the stylesheet it was asked for, but not the partials
+    /// grass then goes and reads, and grass runs on its own thread rather than the one `build`
+    /// reserved. Deep nesting has to be refused where the file is loaded.
+    #[test]
+    fn refuses_a_deeply_nested_import() {
+        let t = tenant(&[("src/styles/_deep.scss", "a{".repeat(20_000))]);
+        let sass = Sass::new(Duration::from_millis(super::DEFAULT_TIMEOUT_MS));
+        let e = sass.compile(&t, "src/styles", "@use 'deep';\n.a { color: red }", false).unwrap_err();
+        assert!(e.contains("level Sass nesting limit"), "{e}");
+    }
+
+    #[test]
+    fn refuses_a_deeply_nested_source() {
+        let t = tenant(&[]);
+        let sass = Sass::new(Duration::from_millis(super::DEFAULT_TIMEOUT_MS));
+        let e = sass.compile(&t, "src", &"a{".repeat(20_000), false).unwrap_err();
+        assert!(e.contains("over the") && e.contains("level limit"), "{e}");
+        assert_eq!(sass.stats().refused, 1);
     }
 
     #[test]


### PR DESCRIPTION
Closes #25

A tenant could write one pathological source file, request its module, and take
the daemon down for every tenant on it. The compilers — oxc, `astro_codegen`,
`satteri-mdxjs`, grass — are recursive-descent, compilation ran on a tokio
worker with the default 2 MiB stack, and a stack overflow is not a panic, so
`panic = "abort"` aborted the process rather than failing the request.

## What it takes to close it

Three bounds. The per-parser costs were measured by binary-searching the stack a
64 KiB file of each shape needs, in a debug build:

| shape | parser | stack per source byte |
|---|---|---|
| `[` repeated | oxc | **1968 B** (123 MiB at 64 KiB) |
| `>` repeated | satteri-mdxjs | **~3.7 KiB**, and quadratic in time |
| `a{` repeated | grass | ~4 KiB |
| `- ` repeated | oxc | 304 B |
| `<<` repeated | astro_codegen | 304 B |

Every one of those aborts the process on a 2 MiB stack. Regular `.md` does not,
at any size — pulldown-cmark is iterative there, so `.md` stays uncapped.

- **`--max-source-kb`** (default 64) caps what reaches any of those parsers:
  `.astro .ts .tsx .jsx .mts .js .mjs .mdx .scss .sass`.
- **A nesting pre-scan** refuses past 2000 levels of unclosed `([{` or of
  markdown blockquote markers — the two shapes that cost more than a KiB per
  byte. A size cap alone cannot contain the MDX one: 64 KiB of `>` takes about
  a quarter of an hour of CPU whether or not the stack holds, so it has to be
  refused rather than sized for.
- **A big-stack compile thread**, sized from the size cap (256 MiB at the
  default), which absorbs the recursion the scan cannot model — the 304 B/byte
  shapes above. Raising `--max-source-kb` raises the stack with it.

## Two things the obvious version got wrong

**A `?type=style` / `?type=script` request builds the module first.** That inner
`Engine::build` would have reserved a second big stack on top of the one it was
already running on — two threads and two reservations per request. A
thread-local flag keeps the nested build on the stack already reserved.
`a_style_build_reserves_one_stack_not_two` counts the spawns.

**Two parsed sources never reach a parser through `Engine::build`**, so the
stack the build reserves does nothing for them:

- `src/content.config.ts` — the content route (`/__sl/content/:name`) hands it
  to oxc directly on a plain blocking thread. It now gets both caps there and
  runs on the parser stack.
- Sass partials — since #35 grass runs on its own `"sass"` thread, which had the
  default 2 MiB stack, and it reads `@use`d partials itself, past anything
  `Engine::build` inspected. `src/a.scss` of `@use "./deep"` plus a 900 KiB
  `_deep.scss` of `a{` was still a live abort. Each file the loader reads is now
  refused past the nesting cap, and that thread gets a 64 MiB stack.

While fixing that: a file the Sass limits *hide* compiled as if it were empty,
so a compile that succeeded without it returned CSS that was not the tenant's
stylesheet, with the refusal silently dropped. It is now an error.

## Cost: none that is resident

The stacks are virtual address space, not RSS. `bench/mem.sh 100 4398` on CI —
main's last green run against this branch's:

| | main | this branch |
|---|---|---|
| idle daemon | 7276 kB | **7124 kB** |
| after 100 tenants | 14168 kB | **14060 kB** |
| per tenant | 68.9 kB | **69.4 kB** |
| transform cache | 66 kB / 108 entries | 66 kB / 108 entries |

Unchanged within noise: a 256 MiB reservation costs nothing until a compile
touches the pages. Wall time per tenant is too noisy on shared runners to read
anything into — 54, 61 and 79 ms across three runs of the same script.

## Verification

Left to CI on this branch — the reproduction is in the suite, not in a local
transcript:

- `transform::tests::deep_nesting_answers_instead_of_aborting` runs seven shapes
  through `Engine::build`. Four are refused by the pre-scan, three reach the
  parsers on the big stack; every one aborts the test binary without this
  change, so the test passing *is* the process surviving.
- `transform::scss::tests::refuses_a_deeply_nested_import` covers the partial
  `Engine::build` never sees.
- `transform::tests::a_content_config_past_either_limit_is_not_parsed` covers
  the content route.
- `proptests::mdx_page_module_is_a_module` was aborting the whole test binary on
  main — its `long()` strategy generates up to 64 KiB of a repeated token and
  found the MDX blockquote overflow on its own. It now runs the parser where the
  daemon runs it.
- The **CI smoke test** now carries the issue's acceptance verbatim: against a
  running release daemon, PUT a 20,000-deep `.ts` and a 1,000-deep `.astro`,
  request both modules plus `?astro&type=style&index=0` and
  `?astro&type=script&index=0`, and assert `/health` still answers 200.

## Noticed, did not fix

- **MDX blockquote parsing is quadratic in time.** 4000 deep is 3.8 s, 8000 is
  14.5 s, 16000 is 56 s. The nesting cap of 2000 keeps it under a second, so it
  is contained here, but the cost in `satteri-pulldown-cmark` is untouched and
  any other route into it meets the same wall.
- **Nothing caps concurrent compiles.** Each reserves `parser_stack_bytes()` of
  address space and tokio's blocking pool defaults to 512 threads, so the worst
  case is a very large VA reservation. It is not RSS and a failed spawn is
  handled as a 500, but a semaphore around `Engine::build` would be the honest
  bound.
- **The pre-scan does not parse.** It counts brackets inside strings and
  comments as nesting, so a source with a literal 2000 levels deep is refused
  even though no parser would have recursed. Nothing hand-written comes close,
  but generated code with a large nested literal could.
- **`Kind::Script` re-parses inline scripts** with `js::transform` on source
  extracted from the `.astro` file. Bounded by that file's cap today, so it is
  safe, but it is not itself scanned.
- **`src/http/preview.rs::content` swallows a spawn failure** into an empty
  collection, as it already did for a join error. A 500 would be truer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
