### PR TITLE
preview: accept the token on every request so a framed preview works

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,17 +204,18 @@ and `SANDBOX_LITE_CHATS_PER_TENANT` are read as defaults for those flags, and
 endpoint (default `https://api.anthropic.com`). With a
 preview secret set, `/api/tenants` returns each tenant's `preview_token`;
 `?sl_token=<token>` is accepted on every request, so the token alone opens a
-preview. A top-level navigation is redirected to the clean URL and given the
-`sl_t` cookie; a framed one is served where it is and keeps the token, because
-a browser drops the `SameSite=Lax` cookie on a cross-site frame. The shell
-carries the token on the `/__sl/**` requests it makes, and a request that can
-carry neither — `/favicon.svg` written by hand, an import nothing rewrites — is
-accepted on `Sec-Fetch-Site: same-origin`, which only a document already on
-that host produces. Tokens are per-tenant, so a customer's link does not open
-another customer's preview. `--cookie-samesite none` still exists for an editor
-on another registrable domain that would rather have the cookie, and marks it
-`Secure`, so those previews must be served over HTTPS; framing a preview no
-longer needs it.
+preview, and every response that carries one also sets the `sl_t` cookie. A
+top-level navigation is redirected to the clean URL; a framed one is served
+where it is, keeping the token, because a redirect would drop it from the URL
+before the page had it. With a preview secret the cookie defaults to
+`SameSite=None; Secure` — the only form a browser stores for a cross-site frame
+— which browsers accept over HTTPS and on loopback (`localhost`, `127.0.0.1`
+and `*.localhost`); pass `--cookie-samesite lax` if the previews are same-site
+with the editor. The cookie is what carries the `/favicon.svg` a layout writes
+by hand and the imports inside a compiled module, which no URL rewriting
+reaches. A request with neither a valid token nor the cookie answers `403`,
+always: no request header decides access. Tokens are per-tenant, so a
+customer's link does not open another customer's preview.
 
 In production put the daemon behind a wildcard DNS record (`*.preview.example.com`),
 pass `--domain preview.example.com`, set both secrets, and keep `/` and `/api`

--- a/README.md
+++ b/README.md
@@ -203,13 +203,18 @@ and `SANDBOX_LITE_CHATS_PER_TENANT` are read as defaults for those flags, and
 `SANDBOX_LITE_ANTHROPIC_BASE` points the chat at another Messages API
 endpoint (default `https://api.anthropic.com`). With a
 preview secret set, `/api/tenants` returns each tenant's `preview_token`;
-opening `http://<id>.<domain>/?sl_token=<token>` once sets a cookie for that
-host and redirects to the clean URL. Tokens are per-tenant, so a customer's
-link does not open another customer's preview. The cookie is `SameSite=Lax`,
-which browsers send only on same-site requests: an editor that embeds previews
-from a different registrable domain (`app.example.com` framing
-`acme.preview.example.net`) needs `--cookie-samesite none`, which also marks
-the cookie `Secure`, so those previews must be served over HTTPS.
+`?sl_token=<token>` is accepted on every request, so the token alone opens a
+preview. A top-level navigation is redirected to the clean URL and given the
+`sl_t` cookie; a framed one is served where it is and keeps the token, because
+a browser drops the `SameSite=Lax` cookie on a cross-site frame. The shell
+carries the token on the `/__sl/**` requests it makes, and a request that can
+carry neither — `/favicon.svg` written by hand, an import nothing rewrites — is
+accepted on `Sec-Fetch-Site: same-origin`, which only a document already on
+that host produces. Tokens are per-tenant, so a customer's link does not open
+another customer's preview. `--cookie-samesite none` still exists for an editor
+on another registrable domain that would rather have the cookie, and marks it
+`Secure`, so those previews must be served over HTTPS; framing a preview no
+longer needs it.
 
 In production put the daemon behind a wildcard DNS record (`*.preview.example.com`),
 pass `--domain preview.example.com`, set both secrets, and keep `/` and `/api`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -114,11 +114,16 @@ credentials on the API side.
   that needs the compile in a child process with rlimits.
 - **The preview cookie** (`sl_t`) is set with `Path=/; HttpOnly` and no
   `Domain` attribute, so it is a host-only session cookie for that one tenant
-  host. It is a convenience, not a precondition: it is set only on a top-level
-  navigation that carried the token, and a preview reached any other way works
-  without it. `--cookie-samesite` picks `SameSite=Lax` (the default; `Secure`
-  is added only when the request carried `x-forwarded-proto: https`) or
-  `SameSite=None; Secure`, which browsers store only over HTTPS.
+  host, and its value is the tenant's token. Every response to a request that
+  carried a valid token sets it. `--cookie-samesite` picks `SameSite=Lax`
+  (`Secure` added only when the request carried `x-forwarded-proto: https`) or
+  `SameSite=None; Secure`; with `--preview-secret` the default is `none`,
+  because a browser stores no other form for a cross-site frame and the editor
+  frames its previews from another host. Browsers accept `Secure` over HTTPS
+  and on loopback origins (`localhost`, `127.0.0.1`, `*.localhost`), so the
+  default development setup works; a plain-`http` deployment on a public name
+  cannot hold the cookie, and only requests carrying the token in the URL will
+  be served there.
 - **Connections** that have not delivered a complete request head within 30 s,
   whether newly opened or idle between keep-alive requests, are closed.
 - **Archive imports.** `POST /api/tenants/{id}/import` is on the editor/API
@@ -202,26 +207,35 @@ endpoint, including `/__sl/raw/`, `/__sl/events` and `/__sl/check`.
   is a pure function of the secret and the id: it never expires and cannot be
   revoked for one tenant. Rotating `S` invalidates every tenant's link at once.
 - `GET http://<id>.<domain>/any/path?sl_token=<token>`: a wrong token answers
-  `403`. The right one is served. A top-level navigation — `Sec-Fetch-Dest:
-  document`, which a frame reports as `iframe` — answers `303` to the same path
-  with the parameter removed and sets the `sl_t` cookie described above, so a
-  link a person opens becomes a clean URL; every other request is served where
-  it is, because a browser drops the Lax cookie a cross-site frame would be
-  given and the editor frames its preview from another host. Later requests are
-  accepted when the cookie equals the token, otherwise `403`. Both comparisons,
-  like the API token's, take constant time (`constant_time_eq`).
-- A request carrying neither token nor cookie is still served when it arrives
-  with `Sec-Fetch-Site: same-origin`. Not every subresource can be made to
-  carry the token — `<link href="/favicon.svg">` is written by hand, and a
-  module's own imports are rewritten without one — and only a document already
-  on that tenant host makes a browser send `same-origin`, which opening it
-  needed the token or the cookie for. A client that sends no `Sec-Fetch-*`
-  headers (`curl`, an older browser) is unaffected and still needs one of them.
-- The shell puts the token in `window.__sl.token` so it can carry it on the
-  `/__sl/**` requests it makes. Tenant JavaScript can read it there, which the
+  `403`; the right one is served, and the response sets the `sl_t` cookie
+  described above. A top-level navigation — `Sec-Fetch-Dest: document`, which a
+  frame reports as `iframe` — answers `303` to the same path with the parameter
+  removed, so a link a person opens becomes a clean URL. A frame is served
+  where it is instead: redirecting it would take the token out of the URL
+  before anything on the page had it. `Sec-Fetch-Dest` decides only that, never
+  access; it is a value the client chooses.
+- **A request carrying neither a valid token nor the cookie answers `403`.**
+  Nothing else is accepted — no request header, no referrer, no origin. The two
+  comparisons, like the API token's, take constant time (`constant_time_eq`).
+- What the cookie is for: `<link rel="icon" href="/favicon.svg">` in a layout
+  and the imports inside a compiled module carry no token and nothing can put
+  one there, so the cookie is what serves them. This is why the `SameSite=None;
+  Secure` default matters — it is the only cookie a browser sends from a
+  cross-site frame.
+- The shell also puts the token in `window.__sl.token` and carries it on the
+  `/__sl/**` requests it issues itself, so a browser that will not store the
+  cookie still renders. Tenant JavaScript can read it there, which the
   `HttpOnly` cookie did not allow — but tenant JavaScript already runs on that
-  host, with the cookie attached to every request it makes, so the token gives
+  host with the cookie attached to every request it makes, so the token gives
   it nothing it did not have.
+- **Where the token in a URL ends up.** Every preview-host response carries
+  `Referrer-Policy: no-referrer` and the shell repeats it in a `<meta>`, so a
+  tenant page never names its own URL to `esm.sh` or any other third party. The
+  residue that cannot be removed: a token that reached the browser as a URL is
+  in that browser's history, and in the access log of any proxy in front of the
+  daemon. Since a token is a pure function of the secret and the tenant id, it
+  never expires and cannot be revoked for one tenant — rotating `S` is the only
+  way to invalidate one, and it invalidates every tenant's link at once.
 - `/api/tenants` returns each tenant's `preview_token` and a ready-made
   `preview` link, so anyone with API access can open every preview.
 - The `preview` link the API builds is

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -114,11 +114,11 @@ credentials on the API side.
   that needs the compile in a child process with rlimits.
 - **The preview cookie** (`sl_t`) is set with `Path=/; HttpOnly` and no
   `Domain` attribute, so it is a host-only session cookie for that one tenant
-  host. `--cookie-samesite` picks `SameSite=Lax` (the default; `Secure` is
-  added only when the request carried `x-forwarded-proto: https`) or
-  `SameSite=None; Secure`, which an editor on another registrable domain needs
-  before a framed preview will carry the cookie, and which browsers store only
-  over HTTPS.
+  host. It is a convenience, not a precondition: it is set only on a top-level
+  navigation that carried the token, and a preview reached any other way works
+  without it. `--cookie-samesite` picks `SameSite=Lax` (the default; `Secure`
+  is added only when the request carried `x-forwarded-proto: https`) or
+  `SameSite=None; Secure`, which browsers store only over HTTPS.
 - **Connections** that have not delivered a complete request head within 30 s,
   whether newly opened or idle between keep-alive requests, are closed.
 - **Archive imports.** `POST /api/tenants/{id}/import` is on the editor/API
@@ -202,10 +202,26 @@ endpoint, including `/__sl/raw/`, `/__sl/events` and `/__sl/check`.
   is a pure function of the secret and the id: it never expires and cannot be
   revoked for one tenant. Rotating `S` invalidates every tenant's link at once.
 - `GET http://<id>.<domain>/any/path?sl_token=<token>`: a wrong token answers
-  `403`; the right one answers `303` to the same path with the parameter
-  removed and sets the `sl_t` cookie described above. Later requests are
-  accepted when the cookie equals the token, otherwise `403`. Both
-  comparisons, like the API token's, take constant time (`constant_time_eq`).
+  `403`. The right one is served. A top-level navigation — `Sec-Fetch-Dest:
+  document`, which a frame reports as `iframe` — answers `303` to the same path
+  with the parameter removed and sets the `sl_t` cookie described above, so a
+  link a person opens becomes a clean URL; every other request is served where
+  it is, because a browser drops the Lax cookie a cross-site frame would be
+  given and the editor frames its preview from another host. Later requests are
+  accepted when the cookie equals the token, otherwise `403`. Both comparisons,
+  like the API token's, take constant time (`constant_time_eq`).
+- A request carrying neither token nor cookie is still served when it arrives
+  with `Sec-Fetch-Site: same-origin`. Not every subresource can be made to
+  carry the token — `<link href="/favicon.svg">` is written by hand, and a
+  module's own imports are rewritten without one — and only a document already
+  on that tenant host makes a browser send `same-origin`, which opening it
+  needed the token or the cookie for. A client that sends no `Sec-Fetch-*`
+  headers (`curl`, an older browser) is unaffected and still needs one of them.
+- The shell puts the token in `window.__sl.token` so it can carry it on the
+  `/__sl/**` requests it makes. Tenant JavaScript can read it there, which the
+  `HttpOnly` cookie did not allow — but tenant JavaScript already runs on that
+  host, with the cookie attached to every request it makes, so the token gives
+  it nothing it did not have.
 - `/api/tenants` returns each tenant's `preview_token` and a ready-made
   `preview` link, so anyone with API access can open every preview.
 - The `preview` link the API builds is

--- a/assets/live.js
+++ b/assets/live.js
@@ -3,7 +3,7 @@
   if (new URLSearchParams(location.search).has("sl_shot")) return;
   const prev = window.__sl_es;
   if (prev && prev.readyState !== EventSource.CLOSED) return;
-  const es = new EventSource("/__sl/events");
+  const es = new EventSource((globalThis.__sl_url || ((u) => u))("/__sl/events"));
   window.__sl_es = es;
 
   const reload = () => location.reload();

--- a/assets/live.js
+++ b/assets/live.js
@@ -3,7 +3,8 @@
   if (new URLSearchParams(location.search).has("sl_shot")) return;
   const prev = window.__sl_es;
   if (prev && prev.readyState !== EventSource.CLOSED) return;
-  const es = new EventSource((globalThis.__sl_url || ((u) => u))("/__sl/events"));
+  const slUrl = globalThis.__sl_url || ((u) => u);
+  const es = new EventSource(slUrl("/__sl/events"));
   window.__sl_es = es;
 
   const reload = () => location.reload();
@@ -19,7 +20,7 @@
   }
 
   async function fetchCss(el, url) {
-    const mod = await import(url);
+    const mod = await import(slUrl(url));
     if (typeof mod.default !== "string") throw new Error(`${url} exported no CSS`);
     put(el, mod.default);
   }

--- a/assets/shell.html
+++ b/assets/shell.html
@@ -4,9 +4,11 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>preview</title>
-<script>window.__sl = { tenant: "%TENANT%", version: %VERSION%, assets: "%ASSETS%", env: %ENV% }; globalThis.__sl_env = window.__sl.env;</script>
-<script type="module" src="/__sl/live.js"></script>
-<script type="module" src="/__sl/shell.js"></script>
+<script>window.__sl = { tenant: "%TENANT%", version: %VERSION%, assets: "%ASSETS%", token: "%TOKEN%", env: %ENV% }; globalThis.__sl_env = window.__sl.env;
+// A framed preview is cross-site and never gets the cookie, so every /__sl/ URL this page builds carries the token.
+globalThis.__sl_url = (u) => (window.__sl.token && typeof u === "string" && u.startsWith("/") ? `${u}${u.includes("?") ? "&" : "?"}sl_token=${window.__sl.token}` : u);</script>
+<script type="module" src="/__sl/live.js%TOKENQ%"></script>
+<script type="module" src="/__sl/shell.js%TOKENQ%"></script>
 </head>
 <body></body>
 </html>

--- a/assets/shell.html
+++ b/assets/shell.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="referrer" content="no-referrer">
 <title>preview</title>
 <script>window.__sl = { tenant: "%TENANT%", version: %VERSION%, assets: "%ASSETS%", token: "%TOKEN%", env: %ENV% }; globalThis.__sl_env = window.__sl.env;
 // A framed preview is cross-site and never gets the cookie, so every /__sl/ URL this page builds carries the token.

--- a/assets/shell.js
+++ b/assets/shell.js
@@ -1,5 +1,6 @@
 const sl = window.__sl;
 const V = sl.version;
+const slUrl = globalThis.__sl_url || ((u) => u);
 const registry = (globalThis.__sl_css ||= new Map());
 const TAILWIND_CDN = "https://cdn.jsdelivr.net/npm/@tailwindcss/browser@4";
 
@@ -8,7 +9,7 @@ function esc(s) {
 }
 
 async function fetchJSON(url) {
-  const r = await fetch(url);
+  const r = await fetch(slUrl(url));
   if (!r.ok) throw new Error(`${url} answered ${r.status}`);
   return r.json();
 }
@@ -64,21 +65,22 @@ function paginate(route) {
 }
 
 function resolveId(id) {
-  if (/^(https?:)?\/\//.test(id) || id.startsWith("/__sl/")) return id;
-  if (id.startsWith("astro:")) return `/__sl/shim/astro-${id.slice(6).replace(/\.js$/, "").replace(/\//g, "-")}.js`;
+  if (/^(https?:)?\/\//.test(id)) return id;
+  if (id.startsWith("/__sl/")) return slUrl(id);
+  if (id.startsWith("astro:")) return slUrl(`/__sl/shim/astro-${id.slice(6).replace(/\.js$/, "").replace(/\//g, "-")}.js`);
   const clean = id.startsWith("/") ? id.slice(1) : id;
-  return `/__sl/m/${clean}${clean.includes("?") ? "&" : "?"}v=${V}`;
+  return slUrl(`/__sl/m/${clean}${clean.includes("?") ? "&" : "?"}v=${V}`);
 }
 
 async function addRenderers(container) {
   const renderers = await fetchJSON(`/__sl/renderers.json?v=${V}`);
   for (const r of renderers) {
-    const mod = await import(r.server);
+    const mod = await import(slUrl(r.server));
     container.addServerRenderer({ name: r.name, renderer: mod.default });
-    if (r.client) container.addClientRenderer({ name: r.name, entrypoint: r.client });
+    if (r.client) container.addClientRenderer({ name: r.name, entrypoint: slUrl(r.client) });
   }
   // Last, so framework renderers get to claim their components first, as in Astro.
-  const jsx = await import("/__sl/shim/astro-jsx-runtime.js");
+  const jsx = await import(slUrl("/__sl/shim/astro-jsx-runtime.js"));
   container.addServerRenderer({ name: "astro:jsx", renderer: jsx.default });
 }
 
@@ -90,7 +92,7 @@ function headExtras() {
     tailwind ||= tw;
     blocks.push(`<style${tw ? ' type="text/tailwindcss"' : ""} data-sl="${esc(key)}">\n${css}\n</style>`);
   }
-  blocks.push(`<script type="module" src="/__sl/live.js"></script>`);
+  blocks.push(`<script type="module" src="${esc(slUrl("/__sl/live.js"))}"></script>`);
   return { html: blocks.join("\n"), tailwind };
 }
 
@@ -133,7 +135,7 @@ function showResponse({ component, status, statusText, type, body }) {
 <style>body{margin:0;background:#1a1b26;color:#c0caf5;font:14px/1.5 ui-monospace,Menlo,monospace;padding:32px}
 h1{color:#7aa2f7;font-size:18px;margin:0 0 4px}p{margin:0 0 12px;color:#565f89}pre{white-space:pre-wrap;background:#16161e;padding:12px;border-radius:6px;overflow:auto}
 b{color:#9ece6a}small{color:#565f89}</style>
-<script type="module" src="/__sl/live.js"></script></head>
+<script type="module" src="${esc(slUrl("/__sl/live.js"))}"></script></head>
 <body data-sl-overlay><h1>${status} ${esc(statusText || "")}</h1><p>${esc(component)} → <b>${esc(type || "no content-type")}</b></p><pre>${esc(text)}</pre>
 <small>sandbox-lite · tenant ${esc(sl.tenant)} · the page reloads itself when a file changes</small></body></html>`);
 }
@@ -147,7 +149,7 @@ function showError({ title, message, stack, diagnostics = [], routes }) {
 <style>body{margin:0;background:#1a1b26;color:#c0caf5;font:14px/1.5 ui-monospace,Menlo,monospace;padding:32px}
 h1{color:#f7768e;font-size:18px;margin:0 0 12px}pre{white-space:pre-wrap;background:#16161e;padding:12px;border-radius:6px;overflow:auto}
 ul{padding-left:18px}b{color:#7aa2f7}i{color:#9ece6a}a{color:#7dcfff}small{color:#565f89}</style>
-<script type="module" src="/__sl/live.js"></script></head>
+<script type="module" src="${esc(slUrl("/__sl/live.js"))}"></script></head>
 <body data-sl-overlay><h1>${esc(title)}</h1><pre>${esc(message || "")}</pre>${diag ? `<ul>${diag}</ul>` : ""}${stack ? `<pre>${esc(stack)}</pre>` : ""}${list}
 <small>sandbox-lite · tenant ${esc(sl.tenant)} · the page reloads itself when a file changes</small></body></html>`);
 }
@@ -158,8 +160,8 @@ async function main() {
   const hit = matchRoute(routes, location.pathname);
   if (!hit) return showError({ title: "404 — no matching page", message: `Nothing in src/pages matches ${location.pathname}`, routes });
   const endpoint = hit.route.kind === "endpoint";
-  const astro = await import("/__sl/astro.js");
-  const mod = await import(`/__sl/m/${hit.route.component}?v=${V}`);
+  const astro = await import(slUrl("/__sl/astro.js"));
+  const mod = await import(slUrl(`/__sl/m/${hit.route.component}?v=${V}`));
   if (endpoint) {
     if (typeof mod.GET !== "function" && typeof mod.ALL !== "function") {
       return showError({ title: "Endpoint without a handler", message: `${hit.route.component} exports no GET or ALL function. The preview only issues GET requests.` });
@@ -179,8 +181,11 @@ async function main() {
   const container = await astro.experimental_AstroContainer.create({ resolve: resolveId, astroConfig: sl.env.SITE ? { site: sl.env.SITE } : undefined });
   // An endpoint renders no components, so the framework renderers are not worth fetching.
   if (!endpoint) await addRenderers(container);
+  // the token is the daemon's, not the page's: Astro.url must not show it
+  const pageUrl = new URL(location.href);
+  pageUrl.searchParams.delete("sl_token");
   const res = await container.renderToResponse(endpoint ? mod : mod.default, {
-    request: new Request(location.href),
+    request: new Request(pageUrl.href),
     params,
     props,
     partial: false,

--- a/assets/shims/astro-content.js
+++ b/assets/shims/astro-content.js
@@ -1,6 +1,8 @@
 import { createComponent, render as renderTemplate, unescapeHTML } from "/__sl/astro.js";
 import { z } from "/__sl/shim/zod.js";
 
+const slUrl = globalThis.__sl_url || ((u) => u);
+
 const cache = new Map();
 
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}(?:[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:Z|[+-]\d{2}:?\d{2})?)?$/;
@@ -30,7 +32,7 @@ function reviveFields(data, paths) {
 
 function load(name) {
   if (!cache.has(name)) {
-    cache.set(name, fetch(`/__sl/content/${encodeURIComponent(name)}?v=${globalThis.__sl?.version ?? ""}`).then(async (r) => {
+    cache.set(name, fetch(slUrl(`/__sl/content/${encodeURIComponent(name)}?v=${globalThis.__sl?.version ?? ""}`)).then(async (r) => {
       if (!r.ok) throw new Error(`content collection '${name}' is not available (${r.status})`);
       const { entries, dates } = await r.json();
       for (const e of entries) e.data = dates ? reviveFields(e.data, dates) : reviveDates(e.data);
@@ -59,7 +61,7 @@ export async function getLiveEntry() { return { entry: undefined }; }
 
 export async function render(entry) {
   if (!entry?.rendered && entry?.filePath?.endsWith(".mdx")) {
-    const mod = await import(`/__sl/m/${entry.filePath}?v=${globalThis.__sl?.version ?? ""}`);
+    const mod = await import(slUrl(`/__sl/m/${entry.filePath}?v=${globalThis.__sl?.version ?? ""}`));
     return { Content: mod.Content, headings: mod.getHeadings(), remarkPluginFrontmatter: mod.frontmatter };
   }
   const html = entry?.rendered?.html ?? "";

--- a/e2e/daemon.ts
+++ b/e2e/daemon.ts
@@ -73,9 +73,9 @@ export class Daemon {
   }
 }
 
-export async function startDaemon(): Promise<Daemon> {
+export async function startDaemon(extra: string[] = []): Promise<Daemon> {
   const port = await freePort();
-  const args = ['--listen', `127.0.0.1:${port}`, '--bases', path.join(root, 'examples'), '--no-persist'];
+  const args = ['--listen', `127.0.0.1:${port}`, '--bases', path.join(root, 'examples'), '--no-persist', ...extra];
   const child = spawn(binary, args, { stdio: ['ignore', 'ignore', 'pipe'] });
   let stderr = '';
   child.stderr!.on('data', (chunk) => (stderr += chunk));

--- a/e2e/daemon.ts
+++ b/e2e/daemon.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess } from 'node:child_process';
+import http from 'node:http';
 import { createServer, type AddressInfo } from 'node:net';
 import path from 'node:path';
 
@@ -71,6 +72,18 @@ export class Daemon {
     await Promise.race([exited, sleep(2000)]);
     if (this.child.exitCode === null) this.child.kill('SIGKILL');
   }
+}
+
+/// A client with no cookie jar and full control of its headers, which a browser deliberately is not.
+export function rawGet(port: number, host: string, path: string, headers: Record<string, string> = {}): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const req = http.request({ host: '127.0.0.1', port, path, method: 'GET', headers: { host, ...headers } }, (res) => {
+      res.resume();
+      res.on('end', () => resolve(res.statusCode ?? 0));
+    });
+    req.on('error', reject);
+    req.end();
+  });
 }
 
 export async function startDaemon(extra: string[] = []): Promise<Daemon> {

--- a/e2e/preview-token.spec.ts
+++ b/e2e/preview-token.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from './fixtures';
-import { type Daemon, startDaemon } from './daemon';
+import { type Daemon, rawGet, startDaemon } from './daemon';
 
-// --preview-secret with the default Lax cookie: the editor is on 127.0.0.1 and the preview on
-// <id>.localhost, so the frame is cross-site and the cookie never reaches it.
+// --preview-secret and no --cookie-samesite override: the editor is on 127.0.0.1 and the preview
+// on <id>.localhost, so the frame really is cross-site and a Lax cookie would never reach it.
 test.describe('preview token', () => {
   let daemon: Daemon;
   let token: string;
@@ -20,26 +20,40 @@ test.describe('preview token', () => {
   });
 
   test('the editor frames a preview that renders', async ({ page }) => {
+    // Nothing can put a token on `<link rel="icon" href="/favicon.svg">` in the layout, nor on the
+    // imports inside a compiled module, so these are what prove the cookie reached the frame.
+    const origin = `http://framed.localhost:${daemon.port}/`;
+    const tokenless: string[] = [];
+    page.on('response', (r) => {
+      if (r.url().startsWith(origin) && !r.url().includes('sl_token')) tokenless.push(`${r.status()} ${r.url()}`);
+    });
+
     await page.goto(`${daemon.api}/`);
     const frame = page.frameLocator('#frame');
     await expect(frame.locator('h1')).toHaveText('Design that ships.');
     await expect(frame.locator('.card')).toHaveCount(3);
     await expect(frame.locator('footer')).toContainText('rendered live by Astro');
+
+    expect(tokenless.length, 'the frame fetched subresources with no token on the URL').toBeGreaterThan(0);
+    expect(tokenless.filter((r) => Number(r.split(' ')[0]) >= 400), 'and every one of them was served').toEqual([]);
+
     // Served where it is rather than redirected, so the frame still holds the token it was opened with.
-    const framed = page.frames().find((f) => f.url().startsWith(`http://framed.localhost:${daemon.port}/`));
+    const framed = page.frames().find((f) => f.url().startsWith(origin));
     expect(framed?.url()).toContain(`sl_token=${token}`);
   });
 
-  test('a request with neither token nor cookie is refused', async ({ browser }) => {
-    const context = await browser.newContext();
-    const page = await context.newPage();
-    const root = await page.goto(`http://framed.localhost:${daemon.port}/`);
-    expect(root?.status()).toBe(403);
-    const module = await page.goto(`http://framed.localhost:${daemon.port}/__sl/m/src/pages/index.astro?v=1`);
-    expect(module?.status()).toBe(403);
-    const wrong = await page.goto(`http://framed.localhost:${daemon.port}/?sl_token=${'0'.repeat(32)}`);
-    expect(wrong?.status()).toBe(403);
-    await context.close();
+  // Sec-Fetch-* is chosen by the client, so claiming same-origin must buy nothing.
+  test('a request with neither token nor cookie is refused, whatever it claims to be', async () => {
+    const get = (path: string, headers?: Record<string, string>) => rawGet(daemon.port, 'framed.localhost', path, headers);
+    const sameOrigin = { 'sec-fetch-site': 'same-origin', 'sec-fetch-dest': 'empty' };
+
+    expect(await get('/')).toBe(403);
+    expect(await get('/favicon.svg', sameOrigin)).toBe(403);
+    expect(await get('/__sl/raw/.env', sameOrigin)).toBe(403);
+    expect(await get('/__sl/m/src/pages/index.astro?v=1', sameOrigin)).toBe(403);
+    expect(await get(`/?sl_token=${'0'.repeat(32)}`)).toBe(403);
+    // A client with no cookie jar still gets in on the token alone.
+    expect(await get(`/__sl/routes.json?sl_token=${token}`)).toBe(200);
   });
 
   test('a top-level navigation with the token still lands on the clean URL', async ({ browser }) => {

--- a/e2e/preview-token.spec.ts
+++ b/e2e/preview-token.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from './fixtures';
+import { type Daemon, startDaemon } from './daemon';
+
+// --preview-secret with the default Lax cookie: the editor is on 127.0.0.1 and the preview on
+// <id>.localhost, so the frame is cross-site and the cookie never reaches it.
+test.describe('preview token', () => {
+  let daemon: Daemon;
+  let token: string;
+
+  test.beforeAll(async () => {
+    daemon = await startDaemon(['--preview-secret', 'e2e-preview-secret']);
+    await daemon.tenant('framed', 'starter');
+    const tenants = (await fetch(`${daemon.api}/api/tenants`).then((r) => r.json())) as { id: string; preview_token: string }[];
+    token = tenants.find((t) => t.id === 'framed')!.preview_token;
+    expect(token).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  test.afterAll(async () => {
+    await daemon?.stop();
+  });
+
+  test('the editor frames a preview that renders', async ({ page }) => {
+    await page.goto(`${daemon.api}/`);
+    const frame = page.frameLocator('#frame');
+    await expect(frame.locator('h1')).toHaveText('Design that ships.');
+    await expect(frame.locator('.card')).toHaveCount(3);
+    await expect(frame.locator('footer')).toContainText('rendered live by Astro');
+    // Served where it is rather than redirected, so the frame still holds the token it was opened with.
+    const framed = page.frames().find((f) => f.url().startsWith(`http://framed.localhost:${daemon.port}/`));
+    expect(framed?.url()).toContain(`sl_token=${token}`);
+  });
+
+  test('a request with neither token nor cookie is refused', async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    const root = await page.goto(`http://framed.localhost:${daemon.port}/`);
+    expect(root?.status()).toBe(403);
+    const module = await page.goto(`http://framed.localhost:${daemon.port}/__sl/m/src/pages/index.astro?v=1`);
+    expect(module?.status()).toBe(403);
+    const wrong = await page.goto(`http://framed.localhost:${daemon.port}/?sl_token=${'0'.repeat(32)}`);
+    expect(wrong?.status()).toBe(403);
+    await context.close();
+  });
+
+  test('a top-level navigation with the token still lands on the clean URL', async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    await page.goto(`http://framed.localhost:${daemon.port}/about?sl_token=${token}`);
+    await expect(page).toHaveURL(`http://framed.localhost:${daemon.port}/about`);
+    await expect(page.locator('h1')).toHaveText('About the studio');
+    await context.close();
+  });
+});

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -195,6 +195,10 @@ pub fn preview_token(secret: &str, tenant: &str) -> String {
 
 const PREVIEW_COOKIE: &str = "sl_t";
 
+fn header_is(req: &Request, name: &str, value: &str) -> bool {
+    req.headers().get(name).is_some_and(|h| h.as_bytes() == value.as_bytes())
+}
+
 async fn require_preview_token(AxState(st): AxState<State>, req: Request, next: Next) -> Response {
     let Some(secret) = &st.preview_secret else { return next.run(req).await };
     let Some(TenantId(id)) = req.extensions().get::<TenantId>().cloned() else { return next.run(req).await };
@@ -202,6 +206,13 @@ async fn require_preview_token(AxState(st): AxState<State>, req: Request, next: 
     if let Some(token) = query_param(req.uri(), "sl_token") {
         if !constant_time_eq(token.as_bytes(), expected.as_bytes()) {
             return (StatusCode::FORBIDDEN, "wrong preview token\n").into_response();
+        }
+        // A framed preview is a cross-site navigation, and a browser drops the Lax cookie a
+        // redirect would set. Only a top-level navigation (`Sec-Fetch-Dest: document`, which an
+        // iframe reports as `iframe`) is sent to the clean URL; everything else is served where
+        // it is, so the token alone is enough.
+        if !header_is(&req, "sec-fetch-dest", "document") {
+            return next.run(req).await;
         }
         let rest: Vec<&str> = req.uri().query().unwrap_or("").split('&').filter(|p| !p.starts_with("sl_token=")).collect();
         let location = if rest.is_empty() { req.uri().path().to_string() } else { format!("{}?{}", req.uri().path(), rest.join("&")) };
@@ -223,6 +234,12 @@ async fn require_preview_token(AxState(st): AxState<State>, req: Request, next: 
         .filter_map(|c| c.trim().strip_prefix(PREVIEW_COOKIE).and_then(|r| r.strip_prefix('=')))
         .any(|given| constant_time_eq(given.as_bytes(), expected.as_bytes()));
     if has_cookie {
+        return next.run(req).await;
+    }
+    // A page can reference `/favicon.svg` or import a module whose own imports nothing rewrites,
+    // so not every subresource can carry the token. `same-origin` is only sent for a request a
+    // document on this tenant host made, and opening that document needed the token.
+    if header_is(&req, "sec-fetch-site", "same-origin") {
         return next.run(req).await;
     }
     (StatusCode::FORBIDDEN, "this preview needs a token: open it from the editor\n").into_response()
@@ -271,7 +288,7 @@ mod tests {
     use std::time::Instant;
 
     use axum::body::Body;
-    use axum::http::{Request, StatusCode};
+    use axum::http::{Request, StatusCode, header::LOCATION};
     use tower::ServiceExt;
 
     use super::{AppState, SameSite, app, chats, constant_time_eq, preview_token, tenant_from_host};
@@ -279,7 +296,7 @@ mod tests {
     use crate::store::Store;
     use crate::transform::{Config, Engine};
 
-    fn baseless_app(api_token: Option<&str>) -> axum::Router {
+    fn baseless_app(api_token: Option<&str>, preview_secret: Option<&str>) -> axum::Router {
         let metrics = Arc::new(Metrics::default());
         app(Arc::new(AppState {
             store: Store::new(None, u64::MAX),
@@ -292,7 +309,7 @@ mod tests {
             api_key: None,
             api_base: "http://127.0.0.1:1".into(),
             api_token: api_token.map(str::to_string),
-            preview_secret: None,
+            preview_secret: preview_secret.map(str::to_string),
             cookie_samesite: SameSite::Lax,
             chrome: None,
             shots: super::ai::Shots::default(),
@@ -313,14 +330,14 @@ mod tests {
 
     #[tokio::test]
     async fn metrics_are_open_until_an_api_token_is_set() {
-        let (status, body) = get(&baseless_app(None), "/metrics", None).await;
+        let (status, body) = get(&baseless_app(None, None), "/metrics", None).await;
         assert_eq!(status, StatusCode::OK);
         assert!(body.contains("# TYPE sandbox_lite_compile_seconds histogram"), "{body}");
     }
 
     #[tokio::test]
     async fn metrics_need_the_api_token_when_one_is_set() {
-        let app = baseless_app(Some("s3cret"));
+        let app = baseless_app(Some("s3cret"), None);
         assert_eq!(get(&app, "/metrics", None).await.0, StatusCode::UNAUTHORIZED);
         assert_eq!(get(&app, "/metrics", Some("wrong")).await.0, StatusCode::UNAUTHORIZED);
         assert_eq!(get(&app, "/metrics?token=s3cret", None).await.0, StatusCode::OK);
@@ -345,6 +362,48 @@ mod tests {
         assert_ne!(preview_token("s", "acme"), preview_token("s", "bakery"));
         assert_ne!(preview_token("s", "acme"), preview_token("t", "acme"));
         assert_eq!(preview_token("s", "acme").len(), 32);
+    }
+
+    /// No base and no tenant, so a request the middleware lets through reaches a handler that
+    /// answers `404` — which is what tells it apart from the `403` the middleware writes itself.
+    async fn preview_get(uri: &str, headers: &[(&str, &str)]) -> (StatusCode, Option<String>) {
+        let mut req = Request::builder().method("GET").uri(uri).header("host", "acme.localhost");
+        for (name, value) in headers {
+            req = req.header(*name, *value);
+        }
+        let res = baseless_app(None, Some("s")).oneshot(req.body(Body::empty()).unwrap()).await.unwrap();
+        let location = res.headers().get(LOCATION).and_then(|h| h.to_str().ok()).map(|s| s.to_string());
+        (res.status(), location)
+    }
+
+    #[tokio::test]
+    async fn a_valid_token_is_served_and_only_a_document_navigation_is_redirected() {
+        let token = preview_token("s", "acme");
+        let framed = format!("/?sl_token={token}");
+
+        assert_eq!(preview_get(&framed, &[("sec-fetch-dest", "iframe"), ("sec-fetch-site", "cross-site")]).await.0, StatusCode::NOT_FOUND);
+        assert_eq!(
+            preview_get(&format!("/__sl/routes.json?sl_token={token}"), &[("sec-fetch-dest", "empty")]).await.0,
+            StatusCode::NOT_FOUND
+        );
+        assert_eq!(preview_get(&framed, &[]).await.0, StatusCode::NOT_FOUND);
+
+        let (status, location) = preview_get(&format!("/about?sl_token={token}&x=1"), &[("sec-fetch-dest", "document")]).await;
+        assert_eq!(status, StatusCode::SEE_OTHER);
+        assert_eq!(location.as_deref(), Some("/about?x=1"));
+    }
+
+    #[tokio::test]
+    async fn a_request_without_a_token_needs_the_cookie_or_a_same_origin_initiator() {
+        let token = preview_token("s", "acme");
+
+        assert_eq!(preview_get("/", &[]).await.0, StatusCode::FORBIDDEN);
+        assert_eq!(preview_get("/?sl_token=nope", &[]).await.0, StatusCode::FORBIDDEN);
+        assert_eq!(preview_get("/favicon.svg", &[("sec-fetch-site", "cross-site")]).await.0, StatusCode::FORBIDDEN);
+        assert_eq!(preview_get("/favicon.svg", &[("sec-fetch-site", "none")]).await.0, StatusCode::FORBIDDEN);
+
+        assert_eq!(preview_get("/favicon.svg", &[("sec-fetch-site", "same-origin")]).await.0, StatusCode::NOT_FOUND);
+        assert_eq!(preview_get("/", &[("cookie", &format!("sl_t={token}"))]).await.0, StatusCode::NOT_FOUND);
     }
 
     #[test]

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -14,7 +14,7 @@ use std::time::{Duration, Instant};
 use axum::Router;
 use axum::extract::{DefaultBodyLimit, Request, State as AxState};
 use axum::http::header::{AUTHORIZATION, COOKIE, HOST, LOCATION, SET_COOKIE};
-use axum::http::{StatusCode, Uri};
+use axum::http::{HeaderValue, StatusCode, Uri};
 use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, post};
@@ -53,6 +53,15 @@ pub type State = Arc<AppState>;
 pub enum SameSite {
     Lax,
     None,
+}
+
+impl SameSite {
+    /// A framed preview is cross-site, so a browser never stores or sends a Lax cookie there.
+    /// With a preview secret the cookie is only worth anything as `SameSite=None; Secure`,
+    /// which browsers accept on HTTPS and on loopback.
+    pub fn default_for(preview_secret: Option<&str>) -> SameSite {
+        if preview_secret.is_some() { SameSite::None } else { SameSite::Lax }
+    }
 }
 
 impl std::str::FromStr for SameSite {
@@ -138,6 +147,7 @@ pub fn app(state: State) -> Router {
         .route("/__sl/missing.js", get(preview::missing))
         .fallback(preview::page)
         .layer(middleware::from_fn_with_state(state.clone(), require_preview_token))
+        .layer(middleware::from_fn(no_referrer))
         .with_state(state.clone());
     let domain = state.domain.clone();
     Router::new().fallback(move |req: Request| {
@@ -207,15 +217,6 @@ async fn require_preview_token(AxState(st): AxState<State>, req: Request, next: 
         if !constant_time_eq(token.as_bytes(), expected.as_bytes()) {
             return (StatusCode::FORBIDDEN, "wrong preview token\n").into_response();
         }
-        // A framed preview is a cross-site navigation, and a browser drops the Lax cookie a
-        // redirect would set. Only a top-level navigation (`Sec-Fetch-Dest: document`, which an
-        // iframe reports as `iframe`) is sent to the clean URL; everything else is served where
-        // it is, so the token alone is enough.
-        if !header_is(&req, "sec-fetch-dest", "document") {
-            return next.run(req).await;
-        }
-        let rest: Vec<&str> = req.uri().query().unwrap_or("").split('&').filter(|p| !p.starts_with("sl_token=")).collect();
-        let location = if rest.is_empty() { req.uri().path().to_string() } else { format!("{}?{}", req.uri().path(), rest.join("&")) };
         let forwarded_https = req.headers().get("x-forwarded-proto").and_then(|h| h.to_str().ok()) == Some("https");
         let attributes = match st.cookie_samesite {
             SameSite::Lax if forwarded_https => "SameSite=Lax; Secure",
@@ -223,6 +224,18 @@ async fn require_preview_token(AxState(st): AxState<State>, req: Request, next: 
             SameSite::None => "SameSite=None; Secure",
         };
         let cookie = format!("{PREVIEW_COOKIE}={expected}; Path=/; HttpOnly; {attributes}");
+        // A frame reports `iframe` here and a top-level navigation `document`. Only the top-level
+        // one is sent to the clean URL — a frame's redirect would lose the token from the URL
+        // before anything on the page had it — so the rest are served where they are.
+        if !header_is(&req, "sec-fetch-dest", "document") {
+            let mut res = next.run(req).await;
+            if let Ok(value) = cookie.parse() {
+                res.headers_mut().append(SET_COOKIE, value);
+            }
+            return res;
+        }
+        let rest: Vec<&str> = req.uri().query().unwrap_or("").split('&').filter(|p| !p.starts_with("sl_token=")).collect();
+        let location = if rest.is_empty() { req.uri().path().to_string() } else { format!("{}?{}", req.uri().path(), rest.join("&")) };
         return (StatusCode::SEE_OTHER, [(LOCATION, location), (SET_COOKIE, cookie)]).into_response();
     }
     let has_cookie = req
@@ -236,13 +249,15 @@ async fn require_preview_token(AxState(st): AxState<State>, req: Request, next: 
     if has_cookie {
         return next.run(req).await;
     }
-    // A page can reference `/favicon.svg` or import a module whose own imports nothing rewrites,
-    // so not every subresource can carry the token. `same-origin` is only sent for a request a
-    // document on this tenant host made, and opening that document needed the token.
-    if header_is(&req, "sec-fetch-site", "same-origin") {
-        return next.run(req).await;
-    }
     (StatusCode::FORBIDDEN, "this preview needs a token: open it from the editor\n").into_response()
+}
+
+/// The token rides in query strings, so a preview host must never name one to a third party —
+/// `esm.sh` would otherwise read it out of the `Referer` on every bare import.
+async fn no_referrer(req: Request, next: Next) -> Response {
+    let mut res = next.run(req).await;
+    res.headers_mut().insert("referrer-policy", HeaderValue::from_static("no-referrer"));
+    res
 }
 
 pub fn tenant_from_host(host: &str, domain: &str) -> Option<String> {
@@ -288,7 +303,8 @@ mod tests {
     use std::time::Instant;
 
     use axum::body::Body;
-    use axum::http::{Request, StatusCode, header::LOCATION};
+    use axum::http::header::{LOCATION, SET_COOKIE};
+    use axum::http::{HeaderName, Request, StatusCode};
     use tower::ServiceExt;
 
     use super::{AppState, SameSite, app, chats, constant_time_eq, preview_token, tenant_from_host};
@@ -310,7 +326,7 @@ mod tests {
             api_base: "http://127.0.0.1:1".into(),
             api_token: api_token.map(str::to_string),
             preview_secret: preview_secret.map(str::to_string),
-            cookie_samesite: SameSite::Lax,
+            cookie_samesite: SameSite::default_for(preview_secret),
             chrome: None,
             shots: super::ai::Shots::default(),
             started: Instant::now(),
@@ -366,14 +382,14 @@ mod tests {
 
     /// No base and no tenant, so a request the middleware lets through reaches a handler that
     /// answers `404` — which is what tells it apart from the `403` the middleware writes itself.
-    async fn preview_get(uri: &str, headers: &[(&str, &str)]) -> (StatusCode, Option<String>) {
+    async fn preview_get(uri: &str, headers: &[(&str, &str)]) -> (StatusCode, Option<String>, Option<String>) {
         let mut req = Request::builder().method("GET").uri(uri).header("host", "acme.localhost");
         for (name, value) in headers {
             req = req.header(*name, *value);
         }
         let res = baseless_app(None, Some("s")).oneshot(req.body(Body::empty()).unwrap()).await.unwrap();
-        let location = res.headers().get(LOCATION).and_then(|h| h.to_str().ok()).map(|s| s.to_string());
-        (res.status(), location)
+        let header = |name: HeaderName| res.headers().get(name).and_then(|h| h.to_str().ok()).map(|s| s.to_string());
+        (res.status(), header(LOCATION), header(SET_COOKIE))
     }
 
     #[tokio::test]
@@ -381,29 +397,46 @@ mod tests {
         let token = preview_token("s", "acme");
         let framed = format!("/?sl_token={token}");
 
-        assert_eq!(preview_get(&framed, &[("sec-fetch-dest", "iframe"), ("sec-fetch-site", "cross-site")]).await.0, StatusCode::NOT_FOUND);
+        let (status, _, cookie) = preview_get(&framed, &[("sec-fetch-dest", "iframe"), ("sec-fetch-site", "cross-site")]).await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(cookie.as_deref(), Some(format!("sl_t={token}; Path=/; HttpOnly; SameSite=None; Secure").as_str()));
         assert_eq!(
             preview_get(&format!("/__sl/routes.json?sl_token={token}"), &[("sec-fetch-dest", "empty")]).await.0,
             StatusCode::NOT_FOUND
         );
         assert_eq!(preview_get(&framed, &[]).await.0, StatusCode::NOT_FOUND);
 
-        let (status, location) = preview_get(&format!("/about?sl_token={token}&x=1"), &[("sec-fetch-dest", "document")]).await;
+        let (status, location, cookie) = preview_get(&format!("/about?sl_token={token}&x=1"), &[("sec-fetch-dest", "document")]).await;
         assert_eq!(status, StatusCode::SEE_OTHER);
         assert_eq!(location.as_deref(), Some("/about?x=1"));
+        assert!(cookie.is_some_and(|c| c.contains(&token)), "the redirect sets the cookie");
     }
 
+    /// `Sec-Fetch-*` is chosen by the client, so it decides presentation and never access:
+    /// `curl -H 'Sec-Fetch-Site: same-origin'` must not reach a tenant's files.
     #[tokio::test]
-    async fn a_request_without_a_token_needs_the_cookie_or_a_same_origin_initiator() {
+    async fn a_request_without_a_token_or_the_cookie_is_refused_whatever_it_claims() {
         let token = preview_token("s", "acme");
 
         assert_eq!(preview_get("/", &[]).await.0, StatusCode::FORBIDDEN);
         assert_eq!(preview_get("/?sl_token=nope", &[]).await.0, StatusCode::FORBIDDEN);
+        assert_eq!(preview_get("/favicon.svg", &[("sec-fetch-site", "same-origin")]).await.0, StatusCode::FORBIDDEN);
+        assert_eq!(
+            preview_get("/__sl/raw/.env", &[("sec-fetch-site", "same-origin"), ("sec-fetch-dest", "empty")]).await.0,
+            StatusCode::FORBIDDEN
+        );
         assert_eq!(preview_get("/favicon.svg", &[("sec-fetch-site", "cross-site")]).await.0, StatusCode::FORBIDDEN);
-        assert_eq!(preview_get("/favicon.svg", &[("sec-fetch-site", "none")]).await.0, StatusCode::FORBIDDEN);
 
-        assert_eq!(preview_get("/favicon.svg", &[("sec-fetch-site", "same-origin")]).await.0, StatusCode::NOT_FOUND);
         assert_eq!(preview_get("/", &[("cookie", &format!("sl_t={token}"))]).await.0, StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn every_preview_response_forbids_a_referrer() {
+        let app = baseless_app(None, Some("s"));
+        let req = Request::builder().method("GET").uri("/").header("host", "acme.localhost");
+        let res = app.oneshot(req.body(Body::empty()).unwrap()).await.unwrap();
+        assert_eq!(res.status(), StatusCode::FORBIDDEN);
+        assert_eq!(res.headers().get("referrer-policy").unwrap(), "no-referrer");
     }
 
     #[test]

--- a/src/http/preview.rs
+++ b/src/http/preview.rs
@@ -287,10 +287,14 @@ pub async fn page(AxState(st): AxState<State>, Extension(id): Extension<TenantId
         }
     }
     let env = Value::Object(env_map(&t)).to_string().replace('<', "\\u003c");
+    let token = st.preview_secret.as_deref().map(|s| super::preview_token(s, &t.id)).unwrap_or_default();
+    let token_query = if token.is_empty() { String::new() } else { format!("?sl_token={token}") };
     let html = SHELL_HTML
         .replace("%TENANT%", &t.id)
         .replace("%VERSION%", &t.version().to_string())
         .replace("%ASSETS%", asset_version())
+        .replace("%TOKENQ%", &token_query)
+        .replace("%TOKEN%", &token)
         .replace("%ENV%", &env);
     ([(header::CACHE_CONTROL, "no-store")], Html(html)).into_response()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ struct Args {
     api_token: Option<String>,
     preview_secret: Option<String>,
     tenant_quota_mb: u64,
-    cookie_samesite: http::SameSite,
+    cookie_samesite: Option<http::SameSite>,
     chrome: Option<PathBuf>,
     chrome_jobs: usize,
     chat_window: usize,
@@ -37,7 +37,7 @@ struct Args {
 
 fn usage() -> ! {
     eprintln!(
-        "sandbox-lite {}\n\nUsage: sandbox-lite [options]\n       sandbox-lite check [--json] DIR...   compile every source file of an Astro project and print diagnostics + a feature census\n\n  --listen ADDR        bind address (default 127.0.0.1:4321)\n  --domain NAME        preview domain; tenants are served at http://<id>.NAME:PORT/ (default localhost)\n  --bases DIR          directory whose sub-directories are base projects (default ./examples if present)\n  --base NAME=PATH     add one base project (repeatable)\n  --data-dir DIR       where tenant edits are persisted (default ./data)\n  --no-persist         keep tenant edits in memory only\n  --cdn URL            where bare npm imports are fetched from in the browser (default https://esm.sh)\n  --cache-mb N         transform cache budget in MiB (default 64)\n  --max-source-kb N    largest .astro/.ts/.js/.mdx/.scss file the compilers accept, in KiB (default 64)\n  --sass-timeout-ms N  deadline for one Sass compile, after which the request fails (default 5000)\n  --max-compiles N     compiles that may run at once; one that waits too long for a slot is refused with 503 (default: one per core)\n  --model NAME         Claude model for the built-in chat (default claude-fable-5-1)\n  --api-token TOKEN    require `Authorization: Bearer TOKEN` (or ?token=) on /api/*\n  --preview-secret S   tenant hosts need a per-tenant token derived from S (the API hands it out)\n  --chrome PATH        chrome or chromium binary for the chat's screenshot tool (default: off)\n  --chrome-jobs N      screenshots that may run at once; a call that waits longer than 10s is told the tool is busy (default {})\n  --chat-window N      turns of a conversation replayed to the model in full; older ones are folded into a stored summary (default {})\n  --chats-per-tenant N conversations a tenant may keep; saving past it drops the least recently updated (default {})\n  --tenant-quota-mb N  edited files a tenant may hold, in MiB; a write past it is refused with 413 (default 64)\n  --cookie-samesite lax|none\n                       SameSite of the preview cookie; none also sets Secure (default lax)\n\nEnvironment: ANTHROPIC_API_KEY enables the chat endpoint; SANDBOX_LITE_API_TOKEN, SANDBOX_LITE_PREVIEW_SECRET, SANDBOX_LITE_TENANT_QUOTA_MB, SANDBOX_LITE_MAX_COMPILES, SANDBOX_LITE_CHROME, SANDBOX_LITE_CHROME_JOBS, SANDBOX_LITE_CHAT_WINDOW and SANDBOX_LITE_CHATS_PER_TENANT are read as defaults for those flags; SANDBOX_LITE_ANTHROPIC_BASE points the chat at another Messages API endpoint (default https://api.anthropic.com).",
+        "sandbox-lite {}\n\nUsage: sandbox-lite [options]\n       sandbox-lite check [--json] DIR...   compile every source file of an Astro project and print diagnostics + a feature census\n\n  --listen ADDR        bind address (default 127.0.0.1:4321)\n  --domain NAME        preview domain; tenants are served at http://<id>.NAME:PORT/ (default localhost)\n  --bases DIR          directory whose sub-directories are base projects (default ./examples if present)\n  --base NAME=PATH     add one base project (repeatable)\n  --data-dir DIR       where tenant edits are persisted (default ./data)\n  --no-persist         keep tenant edits in memory only\n  --cdn URL            where bare npm imports are fetched from in the browser (default https://esm.sh)\n  --cache-mb N         transform cache budget in MiB (default 64)\n  --max-source-kb N    largest .astro/.ts/.js/.mdx/.scss file the compilers accept, in KiB (default 64)\n  --sass-timeout-ms N  deadline for one Sass compile, after which the request fails (default 5000)\n  --max-compiles N     compiles that may run at once; one that waits too long for a slot is refused with 503 (default: one per core)\n  --model NAME         Claude model for the built-in chat (default claude-fable-5-1)\n  --api-token TOKEN    require `Authorization: Bearer TOKEN` (or ?token=) on /api/*\n  --preview-secret S   tenant hosts need a per-tenant token derived from S (the API hands it out)\n  --chrome PATH        chrome or chromium binary for the chat's screenshot tool (default: off)\n  --chrome-jobs N      screenshots that may run at once; a call that waits longer than 10s is told the tool is busy (default {})\n  --chat-window N      turns of a conversation replayed to the model in full; older ones are folded into a stored summary (default {})\n  --chats-per-tenant N conversations a tenant may keep; saving past it drops the least recently updated (default {})\n  --tenant-quota-mb N  edited files a tenant may hold, in MiB; a write past it is refused with 413 (default 64)\n  --cookie-samesite lax|none\n                       SameSite of the preview cookie; none also sets Secure. With --preview-secret the\n                       default is none, because a framed preview is cross-site and a browser\n                       drops a Lax cookie there; otherwise lax\n\nEnvironment: ANTHROPIC_API_KEY enables the chat endpoint; SANDBOX_LITE_API_TOKEN, SANDBOX_LITE_PREVIEW_SECRET, SANDBOX_LITE_TENANT_QUOTA_MB, SANDBOX_LITE_MAX_COMPILES, SANDBOX_LITE_CHROME, SANDBOX_LITE_CHROME_JOBS, SANDBOX_LITE_CHAT_WINDOW and SANDBOX_LITE_CHATS_PER_TENANT are read as defaults for those flags; SANDBOX_LITE_ANTHROPIC_BASE points the chat at another Messages API endpoint (default https://api.anthropic.com).",
         env!("CARGO_PKG_VERSION"),
         http::ai::DEFAULT_CHROME_JOBS,
         http::chats::DEFAULT_WINDOW_TURNS,
@@ -72,7 +72,7 @@ fn parse_args() -> Args {
             .ok()
             .filter(|v| !v.is_empty())
             .map_or(64, |v| v.parse().unwrap_or_else(|_| usage())),
-        cookie_samesite: http::SameSite::Lax,
+        cookie_samesite: None,
         chrome: std::env::var("SANDBOX_LITE_CHROME").ok().filter(|v| !v.is_empty()).map(PathBuf::from),
         chrome_jobs: env_usize("SANDBOX_LITE_CHROME_JOBS", http::ai::DEFAULT_CHROME_JOBS),
         chat_window: env_usize("SANDBOX_LITE_CHAT_WINDOW", http::chats::DEFAULT_WINDOW_TURNS),
@@ -101,7 +101,7 @@ fn parse_args() -> Args {
             "--api-token" => args.api_token = Some(value()),
             "--preview-secret" => args.preview_secret = Some(value()),
             "--tenant-quota-mb" => args.tenant_quota_mb = value().parse().unwrap_or_else(|_| usage()),
-            "--cookie-samesite" => args.cookie_samesite = value().parse().unwrap_or_else(|_| usage()),
+            "--cookie-samesite" => args.cookie_samesite = Some(value().parse().unwrap_or_else(|_| usage())),
             "--chrome" => args.chrome = Some(PathBuf::from(value())),
             "--chrome-jobs" => args.chrome_jobs = value().parse().unwrap_or_else(|_| usage()),
             "--chat-window" => args.chat_window = value().parse().unwrap_or_else(|_| usage()),
@@ -197,7 +197,7 @@ async fn main() {
             .unwrap_or_else(|| "https://api.anthropic.com".to_string()),
         api_token: args.api_token.clone(),
         preview_secret: args.preview_secret.clone(),
-        cookie_samesite: args.cookie_samesite,
+        cookie_samesite: args.cookie_samesite.unwrap_or(http::SameSite::default_for(args.preview_secret.as_deref())),
         chrome: args.chrome.clone(),
         shots: http::ai::Shots::new(args.chrome_jobs),
         started: Instant::now(),


### PR DESCRIPTION
Closes #44

## The bug

The editor is served from the bare domain and a preview from `<id>.<domain>`, so
the preview iframe is a **cross-site** frame. `require_preview_token` answered
`303` to the clean URL and set `sl_t` with `SameSite=Lax` — and a browser
neither stores nor sends a Lax cookie on a cross-site *iframe* navigation, only
on a top-level one. Every request the frame made after that redirect arrived
without the cookie and answered `403`, so `--preview-secret` — the one flag that
protects previews — broke the editor.

## The fix

**A valid `?sl_token=` is served, wherever it appears.** Only a top-level
navigation is redirected to the clean URL — `Sec-Fetch-Dest: document`, which a
frame reports as `iframe`. A frame is served where it is, because a redirect
would take the token out of the URL before anything on the page had it.
`Sec-Fetch-Dest` decides that and nothing else; it is a value the client
chooses, so it never decides access.

**The cookie is made to work in the frame, which is what it was for.** Every
response to a request that carried a valid token sets `sl_t`, not just the
redirect, and with `--preview-secret` the cookie now defaults to
`SameSite=None; Secure` — the only form a browser stores for a cross-site
frame. Browsers accept `Secure` over HTTPS and on loopback origins (`localhost`,
`127.0.0.1`, `*.localhost`), so development and production both work.
`--cookie-samesite lax` remains as the override for previews served same-site
with the editor. This matters because `<link rel="icon" href="/favicon.svg">` in
a layout and the imports inside a compiled module carry no token and nothing can
put one there — the cookie is what serves them.

**A request with neither a valid token nor the cookie answers `403`, always.**
No request header, referrer or origin is consulted.

**The shell carries the token on what it issues itself**, so a client that will
not store the cookie still renders: `preview::page` puts it in
`window.__sl.token` with a `globalThis.__sl_url` helper beside it, and
`shell.js`, `live.js` (including the CSS hot-swap's module imports) and the
`astro:content` shim thread it through
`resolveId`, the entry module import, `astro.js`, the shim imports,
`routes.json`, `renderers.json`, `content/*`, `check` and the SSE stream.
`shell.js` strips `sl_token` from the URL it hands the Astro container, so the
daemon's token never shows up in `Astro.url`.

**Tokens in URLs no longer leak through `Referer`.** Every preview-host response
carries `Referrer-Policy: no-referrer` and the shell repeats it in a `<meta>`,
so a bare import never hands `esm.sh` the tenant's token.

`editor.html` already built the iframe URL from `preview_token`; it is unchanged.

## Tests

- `src/http/mod.rs`, four `#[tokio::test]`s through `app()`: a valid token is
  served for an `iframe` dest with `SameSite=None; Secure` on the cookie and
  `303`s (parameter stripped, cookie set) for a `document` dest; a request with
  no token and no cookie is `403` for `/`, for a wrong token, and for
  `/favicon.svg` and `/__sl/raw/.env` **even when it claims
  `Sec-Fetch-Site: same-origin`**; every preview response carries
  `Referrer-Policy: no-referrer`.
- `e2e/preview-token.spec.ts`: starts the daemon with `--preview-secret` and no
  `--cookie-samesite` override, opens the editor on `127.0.0.1` (the preview is
  on `framed.localhost`, so the frame really is cross-site), asserts the framed
  page rendered — heading, three cards, footer — and then asserts the thing that
  reasoning cannot settle: the frame fetched subresources whose URLs carry **no**
  token, and every one of them was served. A raw `node:http` client (no cookie
  jar, full control of its headers) gets `403` on `/`, on `/favicon.svg` and
  `/__sl/raw/.env` while claiming `Sec-Fetch-Site: same-origin`, and on a wrong
  token — and `200` on `/__sl/routes.json?sl_token=…`. A top-level navigation
  with the token still lands on the clean URL and renders.
- `e2e/daemon.ts`: `startDaemon` takes extra daemon flags; `rawGet` is the
  header-controlling client the spoofing test needs.

Verified by CI on this branch — run
https://github.com/productdevbook/sandbox-lite/actions/runs/34058823333
(`cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test`,
`node tests/editor-escaping.mjs`, release build, `sandbox-lite check`, the
daemon smoke test, `bench/mem.sh` and the Playwright suite). Nothing was run
locally.

## Noticed, did not fix

- **A plain-`http` deployment on a public hostname cannot hold the cookie.**
  `Secure` is accepted on HTTPS and on loopback, nowhere else, so such a
  deployment falls back to the shell-emitted tokens only, and a hand-written
  `/favicon.svg` will `403` there. Documented in `SECURITY.md`; the answer is
  TLS, which the deployment checklist already asks for.
- **`Resolver` still emits tokenless `/__sl/**` URLs.** Every import inside a
  compiled module, the `/__sl/raw/` asset URLs from `transform/mod.rs` and
  `transform/css.rs`, the `import.meta.glob` URLs and the `/__sl/astro.js`
  baked into the Astro compiler output ride on the cookie. Threading a token
  through them is possible for the import specifiers (`serve()` already
  rewrites those per request) but not for the `/__sl/raw/` literals, which are
  baked into a transform cache keyed by file content and shared across tenants
  — a per-tenant token cannot go in there without making the cache per-tenant.
- **The token is now readable by tenant JavaScript** at `window.__sl.token`,
  which the `HttpOnly` cookie did not allow. Noted in `SECURITY.md`: tenant
  JavaScript already runs on that host with the cookie on every request it
  makes, so it gains nothing.
- **A token that reached a browser as a URL stays in history and in any proxy
  access log** in front of the daemon, and a token never expires and cannot be
  revoked for a single tenant. Both written up in `SECURITY.md`.
- **`preview_url_path` still hands out `http://` links on the listen port**
  whatever proxy is in front — unchanged, already documented.
- **The editor prompts for the API token but never for a preview token**, so an
  operator opening a preview link by hand after rotating the secret just gets
  `403`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
