### PR TITLE
sfc: strip TypeScript from Vue and Svelte script blocks in the daemon

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -181,7 +181,7 @@ What `compile` does per kind and extension:
 | `.md` | frontmatter + pulldown-cmark HTML, wrapped as a page component that renders through `layout:` when set (`src/transform/markdown.rs`) |
 | `.mdx` | satteri-mdxjs (`src/transform/mdx.rs`): frontmatter split off, headings given ids and collected, JSX compiled against `astro/jsx-runtime`, then wrapped as `@astrojs/mdx` does — `frontmatter`, `file`, `url`, `getHeadings`, a `layout:` wrapper, and a default `Content` export tagged for the `astro:jsx` renderer |
 | `.json` | `export default JSON.parse(…)` |
-| `.vue` `.svelte` | a loader module (`transform::sfc_loader`) that hands the source to `/__sl/shim/vue-loader.js` or `svelte-loader.js`, which compiles it in the browser |
+| `.vue` `.svelte` | a loader module (`transform::sfc_loader`) that hands the source — its `<script lang="ts">` blocks already stripped to JavaScript by `transform::sfc` — to `/__sl/shim/vue-loader.js` or `svelte-loader.js`, which compiles it in the browser |
 | images | `export default { src: "/__sl/raw/…", width, height, format, fsPath }` |
 | `Style(i)` / `Script(i)` | builds the `.astro` module (cached) and returns its i-th CSS block or script as its own module |
 | `Raw` / `Url` | the text as a string export / the `/__sl/raw/` URL as a string export |
@@ -194,6 +194,26 @@ three-line loader that carries the source as a string literal and calls
 `/__sl/shim/vue-loader.js` or `/__sl/shim/svelte-loader.js` with it and with
 `import.meta.url`. The loader runs `@vue/compiler-sfc` or `svelte/compiler` in
 the browser and imports the result as a blob module.
+
+The script the loader receives is always JavaScript. `transform::sfc` finds
+every `<script>` element in the file, and for each one that says `lang="ts"`
+runs its text through the same oxc transform as a `.ts` file — a `.vue` file's
+`<script>` and `<script setup>`, a `.svelte` file's instance and
+`context="module"` blocks, all of them. Only the `lang` attribute is dropped;
+`setup`, `context` and the rest survive byte for byte, and the compiled script
+is padded back to the line count of the block it replaces so the SFC compiler's
+own diagnostics still name the right line of the template below it. A type
+error is reported like any other file's, at its line in the `.vue` or
+`.svelte` file, and `sandbox-lite check` sees it too.
+
+Stripping ahead of `@vue/compiler-sfc` costs the macros that take a type and no
+arguments — `defineProps<Props>()`, `defineEmits`, `defineModel`, `defineSlots`
+and `<script setup generic="…">` — because the compiler reads those types out of
+the source to generate the runtime declaration, and by then they are gone.
+Rather than emit a component with no props, the daemon refuses the file with a
+diagnostic that names the macro and asks for the runtime form. Doing better
+means stripping *after* `compileScript`, which needs a TypeScript transform on
+the browser side of the pipeline.
 
 A blob module has no import map, so the loader rewrites the compiler's output
 before creating the blob: `vue`/`svelte` specifiers become CDN URLs, relative
@@ -439,6 +459,7 @@ src/transform/js.rs    oxc transform and import scanning
 src/transform/css.rs   CSS-as-module, relative URL rewriting
 src/transform/scss.rs  grass over a tenant snapshot, size and time limits, fingerprint
 src/transform/glob.rs  import.meta.glob detection and expansion
+src/transform/sfc.rs   TypeScript out of the <script> blocks of a .vue or .svelte file
 src/transform/markdown.rs, content.rs   Markdown pages and collections
 src/transform/mdx.rs   MDX pages and entries through satteri-mdxjs
 src/check.rs           the check subcommand

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ so it can look at the layout it just changed instead of guessing.
 --no-persist         keep edits in memory only
 --cdn URL            where bare npm imports resolve in the browser (default https://esm.sh)
 --cache-mb N         transform cache budget (default 64)
---max-source-kb N    largest .astro/.ts/.js/.mdx/.scss file the compilers accept (default 64)
+--max-source-kb N    largest .astro/.ts/.js/.mdx/.scss/.vue/.svelte file the compilers accept (default 64)
 --sass-timeout-ms N  deadline for one Sass compile (default 5000)
 --model NAME         Claude model for the chat endpoint (default claude-fable-5-1)
 --api-token TOKEN    require `Authorization: Bearer TOKEN` (or `?token=`) on /api/*

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ and `.env` `PUBLIC_*` variables; `tsconfig` path aliases; npm packages from a
 CDN pinned to the versions in `package.json`; React, Preact, Vue and Svelte
 islands (`client:load` and friends hydrate with the framework's own runtime,
 whether the component is a file in `src/` or one imported from a package, and
-`.vue`/`.svelte` single-file components are compiled in the browser);
+`.vue`/`.svelte` single-file components are compiled in the browser, with the
+TypeScript in their `<script>` blocks stripped by the daemon first);
 `<script>` tags, `public/` files and live reload.
 
 ## What it costs
@@ -320,7 +321,7 @@ src/main.rs            CLI, startup
 src/store.rs           base projects, tenant overlays, versions, SSE fan-out, persistence
 src/resolve.rs         import specifier → URL
 src/routes.rs          src/pages → route table
-src/transform/         astro (astro_codegen), js (oxc), css, scss (grass), import.meta.glob, markdown, mdx (satteri-mdxjs), content collections, cache
+src/transform/         astro (astro_codegen), js (oxc), css, scss (grass), sfc (Vue/Svelte script blocks), import.meta.glob, markdown, mdx (satteri-mdxjs), content collections, cache
 src/http/              host-based dispatch, auth, editor API, preview endpoints, Claude chat loop, stream framing, saved conversations
 src/check.rs           the `check` subcommand
 src/metrics.rs         atomic counters and the Prometheus text-format renderer behind /metrics
@@ -328,7 +329,7 @@ assets/                shell.html, shell.js, live.js, editor.html, astro.js and 
 examples/starter       a framework-free Astro 7 site (Markdown, MDX, content collections, endpoints); the base used by CI's smoke test and bench/mem.sh
 examples/tailwind      Tailwind v4 through its browser build
 examples/react         React islands hydrated with client:load, one local and one imported from npm
-examples/vue           a Vue SFC compiled in the browser and hydrated with client:load
+examples/vue           a TypeScript Vue SFC compiled in the browser and hydrated with client:load
 examples/svelte        the same for a Svelte 5 component
 scripts/build-runtime.sh   regenerates assets/astro.js and assets/astro-jsx.js for a new Astro version
 bench/mem.sh           the memory measurement above
@@ -341,13 +342,16 @@ e2e/                   Playwright suite for the browser side: every example page
   framework needs a `server` module exposing `check` and
   `renderToStaticMarkup` (see `assets/shims/renderer-react.js`, 40 lines) and a
   `client` entrypoint, listed under `renderers` in `sandbox-lite.json`.
-- **TypeScript inside a `.vue` or `.svelte` file.** There is no Rust compiler
-  for either format, so the daemon serves the component as a loader module that
-  runs `@vue/compiler-sfc` or `svelte/compiler` in the browser and imports the
-  result as a blob module. A blob has no import map, so the loader rewrites
+- **Type-driven Vue macros.** There is no Rust compiler for `.vue` or
+  `.svelte`, so the daemon serves the component as a loader module that runs
+  `@vue/compiler-sfc` or `svelte/compiler` in the browser and imports the result
+  as a blob module. Every `<script lang="ts">` block is stripped to JavaScript
+  by the daemon before that, which leaves `defineProps<Props>()`,
+  `defineEmits`, `defineModel`, `defineSlots` and `<script setup generic="…">`
+  with no type to compile — they are refused with a diagnostic asking for the
+  runtime form. A blob has no import map either, so the loader rewrites
   `vue`/`svelte` imports to the CDN and relative ones against the component's
-  own URL: `./Other.vue` works, `./other` (no extension) does not, and
-  `<script lang="ts">` reaches the browser as TypeScript and fails to parse.
+  own URL: `./Other.vue` works, `./other` (no extension) does not.
 - **Non-`GET` requests.** A visitor navigates, so only an endpoint's `GET` (or
   `ALL`) handler ever runs and the request carries no body. `src/middleware.ts`
   is not loaded, and `astro:actions` answers `SERVICE_UNAVAILABLE`.

--- a/examples/svelte/src/components/Counter.svelte
+++ b/examples/svelte/src/components/Counter.svelte
@@ -1,7 +1,12 @@
-<script>
-  let { label, start = 0 } = $props();
-  let delta = $state(0);
-  let n = $derived(start + delta);
+<script lang="ts">
+  interface Props {
+    label: string;
+    start?: number;
+  }
+
+  let { label, start = 0 }: Props = $props();
+  let delta: number = $state(0);
+  let n: number = $derived(start + delta);
 </script>
 
 <div class="counter" data-count={n}>

--- a/examples/vue/src/components/Counter.vue
+++ b/examples/vue/src/components/Counter.vue
@@ -1,12 +1,12 @@
-<script setup>
-import { ref } from "vue";
+<script setup lang="ts">
+import { ref, type PropType } from "vue";
 
 const props = defineProps({
-  label: { type: String, required: true },
-  start: { type: Number, default: 0 },
+  label: { type: String as PropType<string>, required: true },
+  start: { type: Number as PropType<number>, default: 0 },
 });
 
-const n = ref(props.start);
+const n = ref<number>(props.start);
 </script>
 
 <template>

--- a/src/transform/js.rs
+++ b/src/transform/js.rs
@@ -5,7 +5,7 @@ use oxc_codegen::Codegen;
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
 use oxc_span::SourceType;
-use oxc_transformer::{TransformOptions, Transformer};
+use oxc_transformer::{TransformOptions, Transformer, TypeScriptOptions};
 
 use super::{BuildError, Diag};
 
@@ -18,16 +18,30 @@ pub struct SpecRef {
 }
 
 pub fn transform(path: &str, source: &str) -> Result<String, BuildError> {
-    let allocator = Allocator::default();
     let source_type = SourceType::from_path(path).unwrap_or_else(|_| SourceType::ts());
+    transform_with(path, source, source_type, &TransformOptions::default())
+}
+
+/// Transforms one `<script>` block of a `.vue` or `.svelte` file.
+///
+/// A binding the template alone uses looks unreferenced here, so an unused import is not dead.
+pub fn transform_sfc_script(path: &str, source: &str) -> Result<String, BuildError> {
+    let options = TransformOptions {
+        typescript: TypeScriptOptions { only_remove_type_imports: true, ..TypeScriptOptions::default() },
+        ..TransformOptions::default()
+    };
+    transform_with(path, source, SourceType::ts(), &options)
+}
+
+fn transform_with(path: &str, source: &str, source_type: SourceType, options: &TransformOptions) -> Result<String, BuildError> {
+    let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source, source_type).parse();
     if !ret.errors.is_empty() {
         return Err(oxc_errors(path, source, &ret.errors));
     }
     let mut program = ret.program;
     let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
-    let options = TransformOptions::default();
-    let out = Transformer::new(&allocator, Path::new(path), &options).build_with_scoping(scoping, &mut program);
+    let out = Transformer::new(&allocator, Path::new(path), options).build_with_scoping(scoping, &mut program);
     if !out.errors.is_empty() {
         return Err(oxc_errors(path, source, &out.errors));
     }

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -6,6 +6,7 @@ pub mod js;
 pub mod markdown;
 pub mod mdx;
 pub mod scss;
+pub mod sfc;
 
 use std::cell::Cell;
 use std::collections::{HashMap, VecDeque};
@@ -419,7 +420,7 @@ impl Engine {
                         })?;
                         Ok(Built::js(css::to_module(path, &compiled, dirname(path))))
                     }
-                    "vue" | "svelte" => Ok(Built::js(sfc_loader(&ext, path, &text()))),
+                    "vue" | "svelte" => Ok(Built::js(sfc_loader(&ext, path, &sfc::strip_types(&ext, path, &text())?))),
                     "json" => Ok(Built::js(format!("export default JSON.parse({});\n", json_str(&text())))),
                     "md" => Ok(Built::scanned(markdown::page_module(path, &text()))),
                     "mdx" => Ok(Built::scanned(mdx::page_module(path, &text())?)),
@@ -475,7 +476,8 @@ impl Engine {
 }
 
 /// No Rust compiler exists for `.vue` or `.svelte`, so the file is served as a module that
-/// compiles its source in the browser and re-exports the component.
+/// compiles its source in the browser and re-exports the component. The source it carries has
+/// been through `sfc::strip_types`, so its `<script>` blocks are JavaScript.
 fn sfc_loader(ext: &str, path: &str, source: &str) -> String {
     format!(
         "import {{ compileComponent }} from \"/__sl/shim/{ext}-loader.js\";\nexport default await compileComponent({}, {}, import.meta.url);\n",

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -129,11 +129,12 @@ fn nesting_depth(source: &[u8]) -> usize {
     max
 }
 
-/// Extensions whose module build hands the source to one of those parsers. `md` is out: markdown
-/// never overflowed at any size the cap allows, and long articles are legitimate. `css` and `json`
-/// are out too — they are embedded in a JS module as a string, never parsed.
+/// Extensions whose module build hands the source to one of those parsers — `.vue` and `.svelte`
+/// among them, since `sfc::strip_types` runs oxc over their `<script lang="ts">` blocks. `md` is
+/// out: markdown never overflowed at any size the cap allows, and long articles are legitimate.
+/// `css` and `json` are out too — they are embedded in a JS module as a string, never parsed.
 fn parses_source(ext: &str) -> bool {
-    matches!(ext, "astro" | "ts" | "tsx" | "jsx" | "mts" | "js" | "mjs" | "mdx" | "scss" | "sass")
+    matches!(ext, "astro" | "ts" | "tsx" | "jsx" | "mts" | "js" | "mjs" | "mdx" | "scss" | "sass" | "vue" | "svelte")
 }
 
 thread_local! {
@@ -656,6 +657,7 @@ mod tests {
             ("src/unclosed.ts", format!("const x = {}", "[".repeat(20_000))),
             ("src/quotes.mdx", ">".repeat(20_000)),
             ("src/braces.scss", "a{".repeat(20_000)),
+            ("src/deep.vue", format!("<script lang=\"ts\">const x = {}</script>\n", "[".repeat(20_000))),
         ] {
             let t = tenant_with(path, &source);
             let e = build_err(engine_capped(CAP).build(&t, path, Kind::Module));

--- a/src/transform/sfc.rs
+++ b/src/transform/sfc.rs
@@ -1,0 +1,399 @@
+//! TypeScript out of the `<script>` blocks of a `.vue` or `.svelte` file.
+//!
+//! The browser compiles the SFC and imports the result as a blob module, so TypeScript anywhere in
+//! the script is a syntax error there: `svelte/compiler` refuses to parse it, and
+//! `@vue/compiler-sfc` copies it into its output untouched. Every block that says `lang="ts"` goes
+//! through the same oxc transform as a `.ts` file, and the block keeps its other attributes.
+
+use std::ops::Range;
+
+use super::{BuildError, Diag, js};
+
+/// A macro whose only argument is a type, so stripping types ahead of `@vue/compiler-sfc` would
+/// leave it with nothing to compile.
+const TYPE_ONLY_MACROS: [&str; 4] = ["defineProps", "defineEmits", "defineModel", "defineSlots"];
+
+struct Attr {
+    name: String,
+    value: String,
+    start: usize,
+    end: usize,
+}
+
+struct Block {
+    attrs: Vec<Attr>,
+    content: Range<usize>,
+}
+
+impl Block {
+    fn attr(&self, name: &str) -> Option<&Attr> {
+        self.attrs.iter().find(|a| a.name == name)
+    }
+}
+
+/// Rewrites every `<script lang="ts">` block of `source` to JavaScript.
+pub fn strip_types(ext: &str, path: &str, source: &str) -> Result<String, BuildError> {
+    let mut edits: Vec<(usize, usize, String)> = Vec::new();
+    for block in blocks(source) {
+        let Some(lang) = block.attr("lang") else { continue };
+        if !matches!(lang.value.trim().to_ascii_lowercase().as_str(), "ts" | "typescript") {
+            continue;
+        }
+        if ext == "vue" {
+            refuse_type_only(path, source, &block)?;
+        }
+        let content = &source[block.content.clone()];
+        // Blank lines instead of the markup above the block, so oxc's diagnostics carry file lines.
+        let padded = format!("{}{content}", "\n".repeat(source[..block.content.start].matches('\n').count()));
+        let code = js::transform_sfc_script(path, &padded)?;
+        let mut start = lang.start;
+        if matches!(source.as_bytes().get(start.wrapping_sub(1)).copied(), Some(b' ' | b'\t')) {
+            start -= 1;
+        }
+        edits.push((start, lang.end, String::new()));
+        edits.push((block.content.start, block.content.end, relined(content, &code)));
+    }
+    if edits.is_empty() {
+        return Ok(source.to_string());
+    }
+    edits.sort_by_key(|e| e.0);
+    let mut out = String::with_capacity(source.len());
+    let mut last = 0usize;
+    for (start, end, replacement) in edits {
+        out.push_str(&source[last..start]);
+        out.push_str(&replacement);
+        last = end;
+    }
+    out.push_str(&source[last..]);
+    Ok(out)
+}
+
+/// The compiled script, on as many lines as the block it replaces, so the SFC compiler's own
+/// diagnostics still point at the right line of the template and the styles below it.
+fn relined(content: &str, code: &str) -> String {
+    let body = content.find(|c: char| !c.is_whitespace()).unwrap_or(content.len());
+    let lead = match content[..body].rfind('\n') {
+        Some(i) => &content[..=i],
+        None => "",
+    };
+    let want = content.matches('\n').count();
+    let have = lead.matches('\n').count() + code.matches('\n').count();
+    format!("{lead}{code}{}", "\n".repeat(want.saturating_sub(have)))
+}
+
+/// `@vue/compiler-sfc` turns a type into a runtime declaration, and it reads that type from the
+/// source we are about to strip. Refuse rather than hand back a component with no props.
+fn refuse_type_only(path: &str, source: &str, block: &Block) -> Result<(), BuildError> {
+    let (offset, text, hint) = if let Some(generic) = block.attr("generic") {
+        (
+            generic.start,
+            "<script setup generic> compiles to TypeScript the browser cannot run".to_string(),
+            "drop the generic attribute: the preview strips types before @vue/compiler-sfc sees them".to_string(),
+        )
+    } else if let Some((offset, macro_name)) = type_only_macro(&source[block.content.clone()]) {
+        (
+            block.content.start + offset,
+            format!("{macro_name}<T>() needs a type the preview has already stripped"),
+            format!("declare them at runtime instead: {}", runtime_form(macro_name)),
+        )
+    } else {
+        return Ok(());
+    };
+    let (line, column) = js::line_col(source, offset);
+    let diag = Diag { severity: "error".into(), text: text.clone(), hint, file: path.to_string(), line, column };
+    Err(BuildError::compile(format!("{path}: {text}"), vec![diag]))
+}
+
+fn runtime_form(macro_name: &str) -> &'static str {
+    match macro_name {
+        "defineProps" => "defineProps({ label: { type: String, required: true } })",
+        "defineEmits" => "defineEmits([\"change\"])",
+        "defineModel" => "defineModel({ type: String })",
+        _ => "defineSlots()",
+    }
+}
+
+/// Offset of the first `defineProps<…>`-style call outside a string or a comment.
+fn type_only_macro(code: &str) -> Option<(usize, &'static str)> {
+    let b = code.as_bytes();
+    let mut i = 0usize;
+    while i < b.len() {
+        match b[i] {
+            b'/' if b.get(i + 1).copied() == Some(b'/') => i = code[i..].find('\n').map(|k| i + k + 1).unwrap_or(b.len()),
+            b'/' if b.get(i + 1).copied() == Some(b'*') => i = code[i + 2..].find("*/").map(|k| i + 4 + k).unwrap_or(b.len()),
+            b'"' | b'\'' | b'`' => i = string_end(code, i),
+            c if is_ident(c) && !c.is_ascii_digit() => {
+                let start = i;
+                while i < b.len() && is_ident(b[i]) {
+                    i += 1;
+                }
+                let word = &code[start..i];
+                let mut j = i;
+                while j < b.len() && b[j].is_ascii_whitespace() {
+                    j += 1;
+                }
+                if b.get(j).copied() == Some(b'<')
+                    && let Some(name) = TYPE_ONLY_MACROS.iter().find(|m| **m == word).copied()
+                {
+                    return Some((start, name));
+                }
+            }
+            _ => i += 1,
+        }
+    }
+    None
+}
+
+fn string_end(code: &str, open: usize) -> usize {
+    let b = code.as_bytes();
+    let quote = b[open];
+    let mut i = open + 1;
+    while i < b.len() {
+        match b[i] {
+            b'\\' => i += 2,
+            c if c == quote => return i + 1,
+            _ => i += 1,
+        }
+    }
+    b.len()
+}
+
+fn is_ident(c: u8) -> bool {
+    c.is_ascii_alphanumeric() || c == b'_' || c == b'$'
+}
+
+/// Every `<script>` element in the file, in source order. A `<script>` nested in markup is one of
+/// them, but only a block that says `lang="ts"` is ever rewritten.
+fn blocks(source: &str) -> Vec<Block> {
+    let mut out = Vec::new();
+    let mut i = 0usize;
+    while let Some(rel) = source[i..].find('<') {
+        let open = i + rel;
+        i = open + 1;
+        if !is_tag(source, i, "script") {
+            continue;
+        }
+        let Some((attrs, content_start, self_closing)) = attributes(source, i + "script".len()) else { break };
+        i = content_start;
+        if self_closing {
+            continue;
+        }
+        let Some((content_end, after)) = close_tag(source, content_start) else { break };
+        out.push(Block { attrs, content: content_start..content_end });
+        i = after;
+    }
+    out
+}
+
+fn is_tag(source: &str, at: usize, name: &str) -> bool {
+    source.get(at..at + name.len()).is_some_and(|s| s.eq_ignore_ascii_case(name))
+        && !source.as_bytes().get(at + name.len()).is_some_and(|c| is_ident(*c) || *c == b'-')
+}
+
+/// The tag's attributes, the offset just past its `>`, and whether it closed itself. Quoted values
+/// are read as such: `generic="T extends Item<string>"` holds a `>` that does not end the tag.
+fn attributes(source: &str, from: usize) -> Option<(Vec<Attr>, usize, bool)> {
+    let b = source.as_bytes();
+    let mut attrs = Vec::new();
+    let mut i = from;
+    loop {
+        while b.get(i).is_some_and(|c| c.is_ascii_whitespace()) {
+            i += 1;
+        }
+        match b.get(i).copied()? {
+            b'>' => return Some((attrs, i + 1, false)),
+            b'/' if b.get(i + 1).copied() == Some(b'>') => return Some((attrs, i + 2, true)),
+            b'/' => {
+                i += 1;
+                continue;
+            }
+            _ => {}
+        }
+        let name_start = i;
+        while b.get(i).is_some_and(|c| !c.is_ascii_whitespace() && !matches!(*c, b'=' | b'>' | b'/')) {
+            i += 1;
+        }
+        if i == name_start {
+            return None;
+        }
+        let name = source[name_start..i].to_ascii_lowercase();
+        let mut end = i;
+        let mut value = String::new();
+        let mut j = i;
+        while b.get(j).is_some_and(|c| c.is_ascii_whitespace()) {
+            j += 1;
+        }
+        if b.get(j).copied() == Some(b'=') {
+            j += 1;
+            while b.get(j).is_some_and(|c| c.is_ascii_whitespace()) {
+                j += 1;
+            }
+            match b.get(j).copied() {
+                Some(quote @ (b'"' | b'\'')) => {
+                    let start = j + 1;
+                    let close = start + source[start..].find(quote as char)?;
+                    value = source[start..close].to_string();
+                    end = close + 1;
+                }
+                Some(_) => {
+                    let start = j;
+                    while b.get(j).is_some_and(|c| !c.is_ascii_whitespace() && *c != b'>') {
+                        j += 1;
+                    }
+                    value = source[start..j].to_string();
+                    end = j;
+                }
+                None => return None,
+            }
+            i = end;
+        }
+        attrs.push(Attr { name, value, start: name_start, end });
+    }
+}
+
+/// Start of `</script>` and the offset just past it. A script's text ends at the first one of
+/// these, which is why `</script>` cannot appear inside a script anywhere.
+fn close_tag(source: &str, from: usize) -> Option<(usize, usize)> {
+    let mut i = from;
+    loop {
+        let open = i + source[i..].find('<')?;
+        if source[open + 1..].starts_with('/') && is_tag(source, open + 2, "script") {
+            let end = open + source[open..].find('>')? + 1;
+            return Some((open, end));
+        }
+        i = open + 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_types;
+
+    const VUE: &str = r#"<script setup lang="ts">
+import { ref, type PropType } from "vue";
+import Badge from "./Badge.vue";
+
+interface Row {
+  id: number;
+}
+
+const props = defineProps({
+  rows: { type: Array as PropType<Row[]>, required: true },
+});
+
+const open = ref<boolean>(false);
+</script>
+
+<template>
+  <Badge v-if="open" :count="props.rows.length" />
+</template>
+
+<style>
+.badge {
+  color: red;
+}
+</style>
+"#;
+
+    const SVELTE: &str = r#"<script context="module" lang="ts">
+  export const kind: string = "counter";
+</script>
+
+<script lang="ts">
+  interface Props {
+    label: string;
+    start?: number;
+  }
+
+  let { label, start = 0 }: Props = $props();
+  let delta: number = $state(0);
+</script>
+
+<h1>{label}{start}{delta}</h1>
+"#;
+
+    fn line_of(source: &str, needle: &str) -> usize {
+        source[..source.find(needle).unwrap_or_else(|| panic!("{needle} missing from\n{source}"))].matches('\n').count() + 1
+    }
+
+    #[test]
+    fn a_vue_script_setup_block_loses_its_types_and_keeps_its_attributes() {
+        let out = strip_types("vue", "src/components/Table.vue", VUE).unwrap();
+        assert!(out.contains("<script setup>"), "{out}");
+        assert!(!out.contains("lang="), "{out}");
+        assert!(!out.contains("interface Row"), "{out}");
+        assert!(!out.contains("PropType"), "{out}");
+        assert!(out.contains("ref(false)"), "{out}");
+        assert!(out.contains("type: Array,"), "{out}");
+        assert!(out.contains("<template>"), "the markup is untouched: {out}");
+        assert!(out.contains("color: red;"), "the styles are untouched: {out}");
+    }
+
+    #[test]
+    fn an_import_only_the_template_uses_survives() {
+        let out = strip_types("vue", "src/components/Table.vue", VUE).unwrap();
+        assert!(out.contains(r#"import Badge from "./Badge.vue""#), "{out}");
+    }
+
+    #[test]
+    fn both_svelte_script_blocks_are_stripped() {
+        let out = strip_types("svelte", "src/components/Counter.svelte", SVELTE).unwrap();
+        assert!(out.contains(r#"<script context="module">"#), "{out}");
+        assert!(out.contains("<script>\n"), "{out}");
+        assert!(!out.contains("lang="), "{out}");
+        assert!(!out.contains("interface Props"), "{out}");
+        assert!(out.contains("export const kind = \"counter\""), "{out}");
+        assert!(out.contains("let { label, start = 0 } = $props()"), "{out}");
+        assert!(out.contains("let delta = $state(0)"), "{out}");
+    }
+
+    #[test]
+    fn the_markup_below_a_block_keeps_its_line_numbers() {
+        for (ext, source, needle) in [("vue", VUE, "<style>"), ("svelte", SVELTE, "<h1>")] {
+            let out = strip_types(ext, "src/components/C.vue", source).unwrap();
+            assert_eq!(line_of(&out, needle), line_of(source, needle), "{ext}:\n{out}");
+        }
+    }
+
+    #[test]
+    fn a_block_without_lang_is_left_alone() {
+        let source = "<script setup>\nconst n = 1 as const;\n</script>\n";
+        assert_eq!(strip_types("vue", "src/components/C.vue", source).unwrap(), source);
+    }
+
+    #[test]
+    fn a_type_error_is_reported_at_its_line_in_the_file() {
+        let source = "<template>\n  <p>hi</p>\n</template>\n\n<script setup lang=\"ts\">\nconst n: number = ;\n</script>\n";
+        let err = strip_types("vue", "src/components/C.vue", source).unwrap_err();
+        assert_eq!(err.diagnostics[0].file, "src/components/C.vue");
+        assert_eq!(err.diagnostics[0].line, 6, "{:?}", err.diagnostics);
+    }
+
+    #[test]
+    fn a_type_only_vue_macro_is_refused_by_name() {
+        let source = "<script setup lang=\"ts\">\ninterface Props { n: number }\nconst props = defineProps<Props>();\n</script>\n";
+        let err = strip_types("vue", "src/components/C.vue", source).unwrap_err();
+        assert!(err.message.contains("defineProps<T>()"), "{}", err.message);
+        assert_eq!(err.diagnostics[0].line, 3);
+        assert!(err.diagnostics[0].hint.contains("defineProps({"), "{:?}", err.diagnostics);
+    }
+
+    #[test]
+    fn a_generic_vue_component_is_refused() {
+        let source = "<script setup lang=\"ts\" generic=\"T extends Item<string>\">\nconst n = 1;\n</script>\n";
+        let err = strip_types("vue", "src/components/C.vue", source).unwrap_err();
+        assert!(err.message.contains("generic"), "{}", err.message);
+    }
+
+    #[test]
+    fn a_macro_named_in_a_comment_is_not_a_refusal() {
+        let source = "<script setup lang=\"ts\">\n// defineProps<Props>() is not supported\nconst n: number = 1;\n</script>\n";
+        assert!(strip_types("vue", "src/components/C.vue", source).is_ok());
+    }
+
+    #[test]
+    fn a_svelte_type_annotation_is_not_a_vue_macro() {
+        let source = "<script lang=\"ts\">\n  let props: Props<number> = $props();\n</script>\n";
+        assert!(strip_types("svelte", "src/components/C.svelte", source).is_ok());
+    }
+}


### PR DESCRIPTION
Closes #42

`<script setup lang="ts">` in a `.vue` file and `<script lang="ts">` in a `.svelte` file reached the browser as TypeScript. `svelte/compiler` refuses to parse it and `@vue/compiler-sfc` copies it into its output untouched, so the blob module the loader imports was a syntax error. Astro's own TypeScript templates for both frameworks hit it on the first component.

## What changed

`src/transform/sfc.rs` (new) finds every `<script>` element in the file and runs each one that says `lang="ts"` through the same oxc transform as a `.ts` file, before `sfc_loader` embeds the source. This is the daemon option from the issue: no extra CDN weight on a path that already fetches a megabyte of `svelte/compiler`, and diagnostics come out of the same code as every other file — `sandbox-lite check` now reports type errors in an SFC too.

- **Every block.** A `.vue` file's `<script>` and `<script setup>`, a `.svelte` file's instance and `context="module"` blocks. Attribute parsing is quote-aware, so `generic="T extends Item<string>"` does not end the tag early; only `lang` is dropped, everything else survives byte for byte.
- **Offsets.** The compiled script is padded back to the line count of the block it replaces, so `</script>`, the template and the styles keep their line numbers and the SFC compiler's own diagnostics still point at the right line. Going into oxc, the block is prefixed with the blank lines above it, so a type error is reported at its line *in the `.vue` file*.
- **Unused imports stay.** `only_remove_type_imports` is on for this path (`js::transform_sfc_script`): a binding only the template mentions looks unreferenced to oxc, and eliding `import Icon from "./Icon.svelte"` would silently break the component.
- **Refusals over broken output.** `@vue/compiler-sfc` reads the type out of `defineProps<Props>()` to generate the runtime declaration, and stripping first takes it away. Those macros — `defineProps`, `defineEmits`, `defineModel`, `defineSlots` — and `<script setup generic="…">` are refused with a diagnostic naming the macro, its line, and the runtime form to use, instead of serving a component with no props.
- **The caps from #43 now cover SFCs.** Stripping means oxc parses `.vue` and `.svelte` source, so they join `parses_source`; without that a component whose script nests 20,000 brackets deep walks off the stack and aborts the daemon. A `.vue` case was added to `deep_nesting_answers_instead_of_aborting`, and `--max-source-kb` now applies to these two extensions (a >64 KiB SFC that used to be served is now refused).

`examples/vue/src/components/Counter.vue` and `examples/svelte/src/components/Counter.svelte` are TypeScript now — typed props (`PropType<string>` on the Vue side, an `interface Props` annotation on `$props()` on the Svelte side) and a typed local each — so the existing hydration specs exercise the new path end to end. Eleven unit tests in `sfc.rs` cover the extraction for both formats: attributes kept, both Svelte blocks, template-only imports, line numbers below the block, a block without `lang` left byte-identical, error lines, and each refusal.

## CI

Green on [run 34056545945](https://github.com/productdevbook/sandbox-lite/actions/runs/34056545945) for `21593af`: `test` (fmt, clippy `-D warnings`, `cargo test`, release build, `check` over every example base, smoke test, `bench/mem.sh`) and `e2e` (Playwright in Chromium — the Vue and Svelte hydration specs are the proof the TypeScript components still hydrate and click).

## Noticed, did not fix

- **Vue's type-driven macros are refused, not supported.** `defineProps<Props>()` is the dominant Vue + TS idiom, and this PR turns a browser syntax error into a clear daemon diagnostic rather than making it work. The fix is to strip *after* `compileScript` instead of before: either the loader posts the compiled script back to the daemon for one more oxc pass (a small `POST` route, one extra request on a path that already fetches a megabyte), or a TypeScript transform ships to the browser. The first keeps oxc as the only TypeScript implementation in the project and is what I would do next.
- **`lang="tsx"` / `lang="jsx"` blocks pass through untouched**, as they do today, and still fail in the browser. Handling them means choosing a JSX pragma, and Vue's JSX is not React's — worth doing deliberately rather than as a side effect of this change.
- **Comments in a script block are dropped**, because oxc's codegen re-prints the AST. Nothing reads them in the browser, but a `// @ts-expect-error` or a license header disappears from the compiled script.
- **Line numbers *inside* a block still shift.** Only the block's total line count is restored; the code within it is re-printed. A source map from oxc, carried through the loader into the blob, would fix that and give browser stack traces that name the `.vue` file.
- **A `<script>` nested in markup is treated like a top-level block.** One inside a Vue `<template>` or a Svelte `<svelte:head>` with `lang="ts"` would be transformed, where Vue and Svelte would treat it as markup. Nothing that works today changes, and modelling top-level blocks properly means parsing the template.
- **No browser-level test of a refusal.** The `defineProps<T>()` diagnostic is covered by a unit test; an error-overlay spec would prove the message reaches the person editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
