### PR TITLE
ops: bound how many compiles run at once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
           grep -qxF '# TYPE sandbox_lite_cache_hits_total counter' /tmp/metrics.txt
           grep -qxF '# TYPE sandbox_lite_sass_runaway gauge' /tmp/metrics.txt
           grep -qxF '# TYPE sandbox_lite_compile_seconds histogram' /tmp/metrics.txt
+          grep -qxF '# TYPE sandbox_lite_compiles_queued gauge' /tmp/metrics.txt
+          # issue #47: the permit count is what bounds concurrent compiles, so it must never render as 0
+          grep -qE '^sandbox_lite_compiles_limit [1-9][0-9]*$' /tmp/metrics.txt
           grep -qxF 'sandbox_lite_bases{base="starter"} 1' /tmp/metrics.txt
           grep -qE '^sandbox_lite_module_requests_total\{kind="module",status="200"\} [1-9][0-9]*$' /tmp/metrics.txt
           grep -qE '^sandbox_lite_module_requests_total\{kind="module",status="500"\} [1-9][0-9]*$' /tmp/metrics.txt

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -267,6 +267,24 @@ MiB) counts `body` bytes; when exceeded, the oldest-inserted entries are
 dropped (FIFO, not LRU). `/api/stats` and `/metrics` report entries, bytes,
 hits and misses.
 
+### How many compiles run at once
+
+A cache miss reserves `parser_stack_bytes()` of stack on a thread of its own,
+and the request that asked for it sits on tokio's blocking pool, which would
+let 512 of those exist together. So a miss takes one of `--max-compiles`
+permits first (default: one per core, never fewer than one). A build that
+finds none free waits five seconds for one and is then refused with 503 rather
+than queueing without end. `/api/stats` reports the permits held, the builds
+waiting, the limit and the refusals under `compiles`; `/metrics` has the same
+four.
+
+Two builds take no permit. A cache hit is not a compile, so a warm daemon
+serving cached modules never queues. And a `?type=style` or `?type=script`
+build asks for the module from inside its own compile: that inner build runs
+under the permit — and on the stack — its parent is already holding, which a
+thread-local marks for each. A second permit there would deadlock as soon as
+the gate was full.
+
 ### Why resolution and `import.meta.glob` happen at serve time
 
 The compiled body contains the specifiers as written — `./Header`,
@@ -423,11 +441,13 @@ observation.
 
 `GET /metrics` (`api::metrics`) renders those counters plus the gauges
 `/api/stats` already had — tenants, overlay bytes, cache entries and bytes,
-SSE subscribers, RSS, uptime, one series per base, and `Sass::stats`'s running,
-runaway, timed-out and refused compilations — as Prometheus text format 0.0.4,
+SSE subscribers, RSS, uptime, one series per base, `Sass::stats`'s running,
+runaway, timed-out and refused compilations, and the compile gate's permits
+held, builds queued, limit and refusals — as Prometheus text format 0.0.4,
 written by hand. Buckets are cumulative and `_count` is read off the `+Inf`
 bucket rather than counted separately, so the two can never disagree. The same
-numbers are in `/api/stats` under `modules`, `sass` and `sse_subscribers`.
+numbers are in `/api/stats` under `modules`, `sass`, `compiles` and
+`sse_subscribers`.
 
 `require_api_token` exempts only `/` and `/health`, so `/metrics` needs the
 bearer token whenever `--api-token` is set; `http::tests` asserts both halves.

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ so it can look at the layout it just changed instead of guessing.
 --cache-mb N         transform cache budget (default 64)
 --max-source-kb N    largest .astro/.ts/.js/.mdx/.scss/.vue/.svelte file the compilers accept (default 64)
 --sass-timeout-ms N  deadline for one Sass compile (default 5000)
+--max-compiles N     compiles that may run at once (default: one per core)
 --model NAME         Claude model for the chat endpoint (default claude-fable-5-1)
 --api-token TOKEN    require `Authorization: Bearer TOKEN` (or `?token=`) on /api/*
 --preview-secret S   tenant hosts require a per-tenant token derived from S
@@ -179,9 +180,10 @@ so it can look at the layout it just changed instead of guessing.
 ```
 
 `SANDBOX_LITE_API_TOKEN`, `SANDBOX_LITE_PREVIEW_SECRET`,
-`SANDBOX_LITE_TENANT_QUOTA_MB` and `SANDBOX_LITE_CHROME` are read as defaults
-for those flags, and `SANDBOX_LITE_ANTHROPIC_BASE` points the chat at another
-Messages API endpoint (default `https://api.anthropic.com`). With a
+`SANDBOX_LITE_TENANT_QUOTA_MB`, `SANDBOX_LITE_MAX_COMPILES` and
+`SANDBOX_LITE_CHROME` are read as defaults for those flags, and
+`SANDBOX_LITE_ANTHROPIC_BASE` points the chat at another Messages API
+endpoint (default `https://api.anthropic.com`). With a
 preview secret set, `/api/tenants` returns each tenant's `preview_token`;
 opening `http://<id>.<domain>/?sl_token=<token>` once sets a cookie for that
 host and redirects to the clean URL. Tokens are per-tenant, so a customer's

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -88,6 +88,12 @@ credentials on the API side.
   - Sass partials, which grass reads itself and compiles on its own thread
     (see below) rather than on the one `Engine::build` reserved. Each is
     refused past the nesting cap, and that thread gets a 64 MiB stack.
+- **Concurrent compiles** are capped by `--max-compiles` (default: one per
+  core). Each compile holds a stack reservation of its own, so without the cap
+  the only ceiling on how many exist together is tokio's blocking pool of 512
+  threads. A build that waits more than five seconds for a permit is refused
+  with 503. A cache hit takes no permit, and the module build a `?type=style`
+  request makes from inside its own compile runs under its parent's.
 - **Host matching** is exact: `a.b.<domain>` and `evil-<domain>` are not tenant
   hosts.
 - **Sass compilation** is bounded (`src/transform/scss.rs`). grass runs

--- a/src/http/api.rs
+++ b/src/http/api.rs
@@ -84,6 +84,7 @@ pub async fn stats(AxState(st): AxState<State>) -> Json<Value> {
         "bases": st.store.bases().iter().map(|b| json!({ "name": b.name, "files": b.file_count(), "bytes": b.bytes() })).collect::<Vec<_>>(),
         "cache": st.engine.stats(),
         "sass": st.engine.sass_stats(),
+        "compiles": st.engine.compile_stats(),
         "modules": module_stats(&st),
         "ai": st.api_key.is_some(),
         "preview_auth": st.preview_secret.is_some(),
@@ -98,6 +99,7 @@ fn snapshot(st: &AppState) -> Snapshot {
     let tenants = st.store.tenants();
     let cache = st.engine.stats();
     let sass = st.engine.sass_stats();
+    let compiles = st.engine.compile_stats();
     Snapshot {
         uptime_seconds: st.started.elapsed().as_secs(),
         rss_bytes: rss_kb().map(|kb| kb * 1024),
@@ -113,6 +115,10 @@ fn snapshot(st: &AppState) -> Snapshot {
         sass_runaway: sass.runaway as u64,
         sass_timeouts: sass.timeouts,
         sass_refused: sass.refused,
+        compiles_running: compiles.running as u64,
+        compiles_queued: compiles.queued as u64,
+        compiles_limit: compiles.limit as u64,
+        compiles_refused: compiles.refused,
         requests: st.metrics.requests(),
         compile: st.metrics.compiles(),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,7 @@ struct Args {
     cache_mb: usize,
     max_source_kb: usize,
     sass_timeout_ms: u64,
+    max_compiles: usize,
     model: String,
     api_token: Option<String>,
     preview_secret: Option<String>,
@@ -33,7 +34,7 @@ struct Args {
 
 fn usage() -> ! {
     eprintln!(
-        "sandbox-lite {}\n\nUsage: sandbox-lite [options]\n       sandbox-lite check [--json] DIR...   compile every source file of an Astro project and print diagnostics + a feature census\n\n  --listen ADDR        bind address (default 127.0.0.1:4321)\n  --domain NAME        preview domain; tenants are served at http://<id>.NAME:PORT/ (default localhost)\n  --bases DIR          directory whose sub-directories are base projects (default ./examples if present)\n  --base NAME=PATH     add one base project (repeatable)\n  --data-dir DIR       where tenant edits are persisted (default ./data)\n  --no-persist         keep tenant edits in memory only\n  --cdn URL            where bare npm imports are fetched from in the browser (default https://esm.sh)\n  --cache-mb N         transform cache budget in MiB (default 64)\n  --max-source-kb N    largest .astro/.ts/.js/.mdx/.scss file the compilers accept, in KiB (default 64)\n  --sass-timeout-ms N  deadline for one Sass compile, after which the request fails (default 5000)\n  --model NAME         Claude model for the built-in chat (default claude-fable-5-1)\n  --api-token TOKEN    require `Authorization: Bearer TOKEN` (or ?token=) on /api/*\n  --preview-secret S   tenant hosts need a per-tenant token derived from S (the API hands it out)\n  --chrome PATH        chrome or chromium binary for the chat's screenshot tool (default: off)\n  --tenant-quota-mb N  edited files a tenant may hold, in MiB; a write past it is refused with 413 (default 64)\n  --cookie-samesite lax|none\n                       SameSite of the preview cookie; none also sets Secure (default lax)\n\nEnvironment: ANTHROPIC_API_KEY enables the chat endpoint; SANDBOX_LITE_API_TOKEN, SANDBOX_LITE_PREVIEW_SECRET, SANDBOX_LITE_TENANT_QUOTA_MB and SANDBOX_LITE_CHROME are read as defaults for those flags; SANDBOX_LITE_ANTHROPIC_BASE points the chat at another Messages API endpoint (default https://api.anthropic.com).",
+        "sandbox-lite {}\n\nUsage: sandbox-lite [options]\n       sandbox-lite check [--json] DIR...   compile every source file of an Astro project and print diagnostics + a feature census\n\n  --listen ADDR        bind address (default 127.0.0.1:4321)\n  --domain NAME        preview domain; tenants are served at http://<id>.NAME:PORT/ (default localhost)\n  --bases DIR          directory whose sub-directories are base projects (default ./examples if present)\n  --base NAME=PATH     add one base project (repeatable)\n  --data-dir DIR       where tenant edits are persisted (default ./data)\n  --no-persist         keep tenant edits in memory only\n  --cdn URL            where bare npm imports are fetched from in the browser (default https://esm.sh)\n  --cache-mb N         transform cache budget in MiB (default 64)\n  --max-source-kb N    largest .astro/.ts/.js/.mdx/.scss file the compilers accept, in KiB (default 64)\n  --sass-timeout-ms N  deadline for one Sass compile, after which the request fails (default 5000)\n  --max-compiles N     compiles that may run at once; one that waits too long for a slot is refused with 503 (default: one per core)\n  --model NAME         Claude model for the built-in chat (default claude-fable-5-1)\n  --api-token TOKEN    require `Authorization: Bearer TOKEN` (or ?token=) on /api/*\n  --preview-secret S   tenant hosts need a per-tenant token derived from S (the API hands it out)\n  --chrome PATH        chrome or chromium binary for the chat's screenshot tool (default: off)\n  --tenant-quota-mb N  edited files a tenant may hold, in MiB; a write past it is refused with 413 (default 64)\n  --cookie-samesite lax|none\n                       SameSite of the preview cookie; none also sets Secure (default lax)\n\nEnvironment: ANTHROPIC_API_KEY enables the chat endpoint; SANDBOX_LITE_API_TOKEN, SANDBOX_LITE_PREVIEW_SECRET, SANDBOX_LITE_TENANT_QUOTA_MB, SANDBOX_LITE_MAX_COMPILES and SANDBOX_LITE_CHROME are read as defaults for those flags; SANDBOX_LITE_ANTHROPIC_BASE points the chat at another Messages API endpoint (default https://api.anthropic.com).",
         env!("CARGO_PKG_VERSION")
     );
     std::process::exit(2)
@@ -50,6 +51,10 @@ fn parse_args() -> Args {
         cache_mb: 64,
         max_source_kb: 64,
         sass_timeout_ms: transform::scss::DEFAULT_TIMEOUT_MS,
+        max_compiles: std::env::var("SANDBOX_LITE_MAX_COMPILES")
+            .ok()
+            .filter(|v| !v.is_empty())
+            .map_or_else(transform::default_max_compiles, |v| v.parse().unwrap_or_else(|_| usage())),
         model: "claude-fable-5-1".into(),
         api_token: std::env::var("SANDBOX_LITE_API_TOKEN").ok().filter(|v| !v.is_empty()),
         preview_secret: std::env::var("SANDBOX_LITE_PREVIEW_SECRET").ok().filter(|v| !v.is_empty()),
@@ -78,6 +83,7 @@ fn parse_args() -> Args {
             "--cache-mb" => args.cache_mb = value().parse().unwrap_or_else(|_| usage()),
             "--max-source-kb" => args.max_source_kb = value().parse().unwrap_or_else(|_| usage()),
             "--sass-timeout-ms" => args.sass_timeout_ms = value().parse().unwrap_or_else(|_| usage()),
+            "--max-compiles" => args.max_compiles = value().parse().unwrap_or_else(|_| usage()),
             "--model" => args.model = value(),
             "--api-token" => args.api_token = Some(value()),
             "--preview-secret" => args.preview_secret = Some(value()),
@@ -159,6 +165,7 @@ async fn main() {
                 cache_bytes: args.cache_mb << 20,
                 max_source_bytes: args.max_source_kb << 10,
                 sass_timeout: Duration::from_millis(args.sass_timeout_ms),
+                max_compiles: args.max_compiles,
             },
             metrics.clone(),
         ),

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -118,6 +118,10 @@ pub struct Snapshot {
     pub sass_runaway: u64,
     pub sass_timeouts: u64,
     pub sass_refused: u64,
+    pub compiles_running: u64,
+    pub compiles_queued: u64,
+    pub compiles_limit: u64,
+    pub compiles_refused: u64,
     pub requests: [[u64; STATUSES.len()]; KINDS.len()],
     pub compile: [HistogramSnapshot; KINDS.len()],
 }
@@ -179,6 +183,17 @@ pub fn render(s: &Snapshot) -> String {
         "counter",
         "Sass compilations refused by a size cap, the thread cap, or a runaway thread holding the same source.",
         s.sass_refused,
+    );
+
+    scalar(&mut out, "sandbox_lite_compiles_running", "gauge", "Compiles holding a permit.", s.compiles_running);
+    scalar(&mut out, "sandbox_lite_compiles_queued", "gauge", "Compiles waiting for a permit.", s.compiles_queued);
+    scalar(&mut out, "sandbox_lite_compiles_limit", "gauge", "Compiles that may run at once (--max-compiles).", s.compiles_limit);
+    scalar(
+        &mut out,
+        "sandbox_lite_compiles_refused_total",
+        "counter",
+        "Compiles refused with 503 after waiting for a permit.",
+        s.compiles_refused,
     );
 
     family(&mut out, "sandbox_lite_module_requests_total", "counter", "Requests answered by the preview module endpoint.");
@@ -268,6 +283,10 @@ mod tests {
             sass_runaway: 2,
             sass_timeouts: 3,
             sass_refused: 4,
+            compiles_running: 2,
+            compiles_queued: 5,
+            compiles_limit: 8,
+            compiles_refused: 6,
             requests: m.requests(),
             compile: m.compiles(),
         };
@@ -322,6 +341,18 @@ sandbox_lite_sass_timeouts_total 3
 # HELP sandbox_lite_sass_refused_total Sass compilations refused by a size cap, the thread cap, or a runaway thread holding the same source.
 # TYPE sandbox_lite_sass_refused_total counter
 sandbox_lite_sass_refused_total 4
+# HELP sandbox_lite_compiles_running Compiles holding a permit.
+# TYPE sandbox_lite_compiles_running gauge
+sandbox_lite_compiles_running 2
+# HELP sandbox_lite_compiles_queued Compiles waiting for a permit.
+# TYPE sandbox_lite_compiles_queued gauge
+sandbox_lite_compiles_queued 5
+# HELP sandbox_lite_compiles_limit Compiles that may run at once (--max-compiles).
+# TYPE sandbox_lite_compiles_limit gauge
+sandbox_lite_compiles_limit 8
+# HELP sandbox_lite_compiles_refused_total Compiles refused with 503 after waiting for a permit.
+# TYPE sandbox_lite_compiles_refused_total counter
+sandbox_lite_compiles_refused_total 6
 # HELP sandbox_lite_module_requests_total Requests answered by the preview module endpoint.
 # TYPE sandbox_lite_module_requests_total counter
 sandbox_lite_module_requests_total{kind="module",status="200"} 3
@@ -423,6 +454,10 @@ sandbox_lite_compile_seconds_count{kind="url"} 0
             sass_runaway: 0,
             sass_timeouts: 0,
             sass_refused: 0,
+            compiles_running: 0,
+            compiles_queued: 0,
+            compiles_limit: 1,
+            compiles_refused: 0,
             requests: m.requests(),
             compile: m.compiles(),
         };

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -10,7 +10,8 @@ pub mod sfc;
 
 use std::cell::Cell;
 use std::collections::{HashMap, VecDeque};
-use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
 use std::time::{Duration, Instant};
 
 use serde::Serialize;
@@ -44,6 +45,10 @@ impl BuildError {
 
     pub fn compile(message: String, diagnostics: Vec<Diag>) -> BuildError {
         BuildError { status: 500, message, diagnostics }
+    }
+
+    pub fn busy(message: String) -> BuildError {
+        BuildError { status: 503, message, diagnostics: vec![] }
     }
 }
 
@@ -139,6 +144,9 @@ fn parses_source(ext: &str) -> bool {
 
 thread_local! {
     static ON_PARSER_STACK: Cell<bool> = const { Cell::new(false) };
+    /// Set while a compile that holds a permit runs, so the module build a `Style`/`Script` compile
+    /// makes from inside it does not queue for a second one.
+    static COMPILING: Cell<bool> = const { Cell::new(false) };
     /// Counted per calling thread so parallel tests cannot see each other's spawns.
     #[cfg(test)]
     static SPAWNED: Cell<usize> = const { Cell::new(0) };
@@ -219,6 +227,7 @@ pub struct Config {
     pub cache_bytes: usize,
     pub max_source_bytes: usize,
     pub sass_timeout: Duration,
+    pub max_compiles: usize,
 }
 
 impl Default for Config {
@@ -228,6 +237,7 @@ impl Default for Config {
             cache_bytes: 64 << 20,
             max_source_bytes: 64 << 10,
             sass_timeout: Duration::from_millis(scss::DEFAULT_TIMEOUT_MS),
+            max_compiles: default_max_compiles(),
         }
     }
 }
@@ -248,20 +258,126 @@ struct Cache {
     misses: u64,
 }
 
+/// How long a compile waits for a permit before its request is refused. Long enough to absorb the
+/// burst of module requests one page load makes, short enough that a saturated daemon says so
+/// instead of holding the connection open.
+const COMPILE_QUEUE_WAIT: Duration = Duration::from_secs(5);
+
+/// Compiles that may run at once when nothing says otherwise. A compile is CPU-bound and holds a
+/// `parser_stack_bytes()` reservation while it runs, so more of them than cores buys queueing.
+pub fn default_max_compiles() -> usize {
+    std::thread::available_parallelism().map_or(4, |n| n.get())
+}
+
+#[derive(Serialize, Clone, Copy)]
+pub struct CompileStats {
+    pub running: usize,
+    pub queued: usize,
+    pub limit: usize,
+    pub refused: u64,
+}
+
+#[derive(Default)]
+struct GateState {
+    running: usize,
+    queued: usize,
+}
+
+/// One permit per compile that may run at once. Every cache miss reserves `parser_stack_bytes()` of
+/// address space on a thread of its own and tokio's blocking pool would let 512 of those exist
+/// together, so without this the ceiling is the OS rather than a decision.
+struct Gate {
+    limit: usize,
+    wait: Duration,
+    state: Mutex<GateState>,
+    free: Condvar,
+    refused: AtomicU64,
+}
+
+struct Permit<'a>(&'a Gate);
+
+impl Drop for Permit<'_> {
+    fn drop(&mut self) {
+        let mut state = self.0.state.lock().unwrap();
+        state.running -= 1;
+        drop(state);
+        self.0.free.notify_one();
+    }
+}
+
+impl Gate {
+    fn new(limit: usize, wait: Duration) -> Gate {
+        Gate { limit, wait, state: Mutex::new(GateState::default()), free: Condvar::new(), refused: AtomicU64::new(0) }
+    }
+
+    fn stats(&self) -> CompileStats {
+        let state = self.state.lock().unwrap();
+        CompileStats { running: state.running, queued: state.queued, limit: self.limit, refused: self.refused.load(Ordering::Relaxed) }
+    }
+
+    /// `None` when this thread is already compiling under a permit: a `?type=style` build asks for
+    /// the module from inside `compile`, and a second permit would deadlock once the gate is full.
+    fn enter(&self) -> Result<Option<Permit<'_>>, String> {
+        if COMPILING.get() {
+            return Ok(None);
+        }
+        let mut state = self.state.lock().unwrap();
+        if state.running >= self.limit {
+            let deadline = Instant::now() + self.wait;
+            state.queued += 1;
+            loop {
+                let Some(left) = deadline.checked_duration_since(Instant::now()) else {
+                    state.queued -= 1;
+                    drop(state);
+                    self.refused.fetch_add(1, Ordering::Relaxed);
+                    let (n, ms) = (self.limit, self.wait.as_millis());
+                    return Err(format!("{n} compiles are already running and this one waited {ms} ms for a slot"));
+                };
+                state = self.free.wait_timeout(state, left).unwrap().0;
+                if state.running < self.limit {
+                    state.queued -= 1;
+                    break;
+                }
+            }
+        }
+        state.running += 1;
+        Ok(Some(Permit(self)))
+    }
+}
+
+/// Marks the thread running a permitted compile, and restores the flag on the way out so a thread
+/// that builds again afterwards queues for a permit of its own.
+struct Compiling(bool);
+
+impl Compiling {
+    fn enter() -> Compiling {
+        Compiling(COMPILING.replace(true))
+    }
+}
+
+impl Drop for Compiling {
+    fn drop(&mut self) {
+        COMPILING.set(self.0);
+    }
+}
+
 pub struct Engine {
     pub cfg: Config,
     cache: Mutex<Cache>,
     sass: scss::Sass,
+    gate: Gate,
     metrics: Arc<Metrics>,
 }
 
 impl Engine {
     pub fn new(cfg: Config, metrics: Arc<Metrics>) -> Engine {
         let sass = scss::Sass::new(cfg.sass_timeout);
+        let gate = Gate::new(cfg.max_compiles.max(1), COMPILE_QUEUE_WAIT);
         Engine {
             cfg,
             cache: Mutex::new(Cache { map: HashMap::new(), order: VecDeque::new(), bytes: 0, hits: 0, misses: 0 }),
             sass,
+            gate,
             metrics,
         }
     }
@@ -282,6 +398,10 @@ impl Engine {
 
     pub fn sass_stats(&self) -> scss::SassStats {
         self.sass.stats()
+    }
+
+    pub fn compile_stats(&self) -> CompileStats {
+        self.gate.stats()
     }
 
     fn cached(&self, key: u128) -> Option<Arc<Built>> {
@@ -332,8 +452,12 @@ impl Engine {
         if let Some(b) = self.cached(key) {
             return Ok(b);
         }
+        let _permit = self.gate.enter().map_err(|e| BuildError::busy(format!("{path}: {e}")))?;
         let started = Instant::now();
-        let spawned = self.on_parser_stack(|| self.compile(tenant, path, kind, &data, site.as_deref()));
+        let spawned = self.on_parser_stack(|| {
+            let _compiling = Compiling::enter();
+            self.compile(tenant, path, kind, &data, site.as_deref())
+        });
         self.metrics.compiled(kind, started.elapsed());
         let compiled = spawned.map_err(|e| BuildError::compile(format!("{path}: cannot start a compiler thread: {e}"), vec![]))?;
         let built = Arc::new(compiled?);
@@ -565,11 +689,20 @@ mod tests {
     const CAP: usize = 64 << 10;
 
     fn engine_capped(max_source_bytes: usize) -> Engine {
-        Engine::new(Config { cache_bytes: 8 << 20, max_source_bytes, ..Config::default() }, Arc::new(crate::metrics::Metrics::default()))
+        Engine::new(capped(max_source_bytes), Arc::new(crate::metrics::Metrics::default()))
     }
 
     fn tenant_with(path: &str, source: &str) -> Arc<Tenant> {
         tenant(&[(path, source)])
+    }
+
+    /// The queue deadline is not a flag, so tests reach past `Engine::new` to shorten it.
+    fn engine_gated(cfg: Config, limit: usize, wait: Duration) -> Engine {
+        Engine { gate: Gate::new(limit, wait), ..Engine::new(cfg, Arc::new(crate::metrics::Metrics::default())) }
+    }
+
+    fn capped(max_source_bytes: usize) -> Config {
+        Config { cache_bytes: 8 << 20, max_source_bytes, ..Config::default() }
     }
 
     fn build_err(r: Result<Arc<Built>, BuildError>) -> BuildError {
@@ -731,6 +864,64 @@ mod tests {
         SPAWNED.set(0);
         e.build(&t, "src/scripted.astro", Kind::Script(0)).unwrap();
         assert_eq!(SPAWNED.get(), 1);
+    }
+
+    /// Issue #47: every compile reserves a stack of its own on a thread of its own, and tokio's
+    /// blocking pool would let 512 of those exist together. Three concurrent compiles, two permits:
+    /// the third waits for a slot and is refused at the deadline instead of reserving a third stack.
+    #[test]
+    fn concurrent_compiles_reserve_no_more_stacks_than_permits() {
+        let bomb = |n: u32| format!("@for $i from 1 through {n} {{ .a-#{{$i}} {{ color: red }} }}");
+        let (a, b, c) = (bomb(200_000), bomb(200_001), bomb(200_002));
+        let t = tenant(&[("src/a.scss", a.as_str()), ("src/b.scss", b.as_str()), ("src/c.scss", c.as_str())]);
+        let cfg = Config { sass_timeout: Duration::from_secs(2), ..capped(CAP) };
+        let engine = engine_gated(cfg, 2, Duration::from_millis(50));
+        std::thread::scope(|scope| {
+            let busy = ["src/a.scss", "src/b.scss"].map(|path| {
+                let (engine, t) = (&engine, &t);
+                scope.spawn(move || {
+                    SPAWNED.set(0);
+                    let _ = engine.build(t, path, Kind::Module);
+                    SPAWNED.get()
+                })
+            });
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while engine.compile_stats().running < 2 && Instant::now() < deadline {
+                std::thread::yield_now();
+            }
+            SPAWNED.set(0);
+            let e = build_err(engine.build(&t, "src/c.scss", Kind::Module));
+            assert_eq!(e.status, 503, "{}", e.message);
+            assert_eq!(SPAWNED.get(), 0, "a refused compile reserves no stack");
+            let stats = engine.compile_stats();
+            assert_eq!((stats.limit, stats.queued, stats.refused), (2, 0, 1));
+            let stacks: usize = busy.into_iter().map(|h| h.join().unwrap()).sum();
+            assert_eq!(stacks, 2, "three concurrent compiles, two stacks");
+        });
+    }
+
+    /// A `?type=style` build compiles the module from inside its own compile. That inner build runs
+    /// under the permit its parent holds; asking for a second would never be answered.
+    #[test]
+    fn a_nested_build_takes_no_second_permit() {
+        let t = tenant_with("src/styled.astro", "<style>p{color:red}</style><script>console.log(1)</script><p>hi</p>");
+        for kind in [Kind::Style(0), Kind::Script(0)] {
+            let engine = engine_gated(capped(CAP), 1, Duration::from_millis(50));
+            engine.build(&t, "src/styled.astro", kind).unwrap();
+            let stats = engine.compile_stats();
+            assert_eq!((stats.running, stats.refused), (0, 0));
+        }
+    }
+
+    /// A warm daemon serving cached modules must not queue: only a miss is a compile.
+    #[test]
+    fn a_cache_hit_takes_no_permit() {
+        let t = tenant(&[("src/hit.ts", "export const x = 1;\n"), ("src/miss.ts", "export const y = 2;\n")]);
+        let engine = engine_gated(capped(CAP), 1, Duration::from_millis(50));
+        engine.build(&t, "src/hit.ts", Kind::Module).unwrap();
+        let closed = Engine { gate: Gate::new(0, Duration::from_millis(50)), ..engine };
+        assert!(closed.build(&t, "src/hit.ts", Kind::Module).is_ok());
+        assert_eq!(build_err(closed.build(&t, "src/miss.ts", Kind::Module)).status, 503);
     }
 
     #[test]


### PR DESCRIPTION
Closes #47

Every `Engine::build` that misses the transform cache reserves
`parser_stack_bytes()` of stack on a thread of its own, and the request holding
it sits on tokio's blocking pool, which defaults to 512 threads. Address space
is not RSS and a failed spawn answers 500, so nothing was broken — but this was
the one place the daemon's cost was bounded by the OS rather than by a decision.

## What changed

- **A gate around the compile.** A cache miss takes one of `--max-compiles`
  permits before it reserves a stack (default: one per core via
  `available_parallelism`, `SANDBOX_LITE_MAX_COMPILES` as an env default in the
  style of the other flags, clamped to at least one). The gate is a
  `Mutex`/`Condvar` pair — `Engine::build` is synchronous and is called from the
  `check` CLI as well as from `spawn_blocking`, so a tokio semaphore would not
  do.
- **A bounded wait, not a queue.** A build that finds no permit free waits five
  seconds (`COMPILE_QUEUE_WAIT`) and is then refused with `BuildError::busy`,
  which `preview::build_error` renders as 503.
- **Counts.** `/api/stats` gains `compiles`: permits held, builds queued, the
  limit and the refusals — the shape of the `sass` block PR #35 added.
  `/metrics` renders `sandbox_lite_compiles_running`, `_queued`, `_limit` and
  `sandbox_lite_compiles_refused_total` next to the Sass counters, and the smoke
  test asserts the limit never renders as 0.

## The two ways this could have gone wrong

- **Re-entrancy (#43).** A `?type=style` or `?type=script` build compiles the
  module from inside its own compile. That inner build takes no second permit —
  it runs under its parent's, marked by a thread-local the way the big stack
  already is — because a second one would deadlock the moment the gate filled.
  `a_nested_build_takes_no_second_permit` builds both kinds through a gate of
  one permit; without the marker it answers 503 rather than hanging, so the test
  fails loudly.
- **Cache hits.** The permit is taken after the cache lookup, so a warm daemon
  serving cached modules never queues. `a_cache_hit_takes_no_permit` moves a
  warm cache behind a gate of zero permits: the cached module still answers, a
  different file gets 503.

## The test the issue asked for

`concurrent_compiles_reserve_no_more_stacks_than_permits` gives an engine two
permits and starts three concurrent compiles of Sass sources slow enough to hold
their permits. Each worker reports the big stacks its own build reserved (the
`SPAWNED` thread-local #43 added, which is counted per calling thread so
parallel tests cannot see each other's spawns); the third build is refused with
503, reserves none, and the two workers report two stacks between them. Three
concurrent compiles, two stacks.

## Noticed, did not fix

- `metrics::status_index` buckets any status that is not 200/400/404 into the
  `"500"` label, so a 503 is counted as a 500 in
  `sandbox_lite_module_requests_total`. That was already true of the 503s the
  metrics test itself feeds in; the refusal counter is the exact signal for now.
- A build that waits and then gets a permit does not re-check the cache, so a
  burst on one cold module can compile it more than once. Re-reading the cache
  after the wait would double-count hits and misses, so it wants its own change.
- The 503 carries no `Retry-After`.
- `check_tenant` builds every source file in turn, each taking its own permit,
  so `/__sl/check` on a saturated daemon can wait the deadline once per file.
  The error page fetches `/__sl/check` when a module fails, which is where that
  would first be felt.

CI: https://github.com/productdevbook/sandbox-lite/actions/runs/34057046378 — fmt, clippy `-D warnings`, tests, release build, `sandbox-lite check`, smoke test, `bench/mem.sh` and Playwright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
