### PR TITLE
preview: swap CSS in place instead of reloading

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,10 +47,16 @@ same base share the base's memory; a tenant costs its overlay.
 Each tenant has a **version**, a `u64` of milliseconds since the epoch at
 creation. `write` and `delete` call `bump`, which sets it to
 `max(now, previous + 1)` — strictly increasing — and sends
-`{"type":"update"|"delete","path":…,"version":N}` on the tenant's
+`{"type":"update"|"delete","path":…,"kind":…,"version":N}` on the tenant's
 `tokio::sync::broadcast` channel (64 slots). Both SSE endpoints
 (`/api/t/{id}/events`, `/__sl/events`) subscribe to that channel and open with
 an `event: hello` carrying the current version.
+
+The `kind` is what the preview does with the event — `css`, `style` or
+`module`, in `UpdateKind`. `Tenant::write` takes it from the caller rather than
+deciding: `UpdateKind::from_path` is the whole answer for a stylesheet, but
+`style` takes a compile to prove, and that is `Engine::update_kind`'s job
+(`src/transform/mod.rs`). See "CSS without a reload" below.
 
 `write_many` is the batch form used by an import: it settles the whole
 resulting overlay under one lock — the removals, the tombstones and every file
@@ -154,10 +160,12 @@ exact.
    `type="text/tailwindcss"` when it contains `@import "tailwindcss"` or
    `@tailwind`), `live.js` is appended, the block is injected before
    `</head>`, and `document.write` replaces the shell. If Tailwind was seen,
-   its browser build is loaded from jsDelivr.
+   its browser build is loaded from jsDelivr. The `data-sl` key is what lets a
+   later CSS write find the block again — see "CSS without a reload".
 9. **Errors.** Any exception fetches `/__sl/check` and renders an error page
    with the daemon's diagnostics; a missing route lists the routes. Error
-   pages also load `live.js`, so they reload when the file is fixed.
+   pages also load `live.js`, so they reload when the file is fixed; their
+   `<body data-sl-overlay>` is how `live.js` knows not to swap CSS into them.
 
 The editor (`assets/editor.html`) is the other client: it embeds the preview
 in an `<iframe>` and edits files through `/api/t/{id}/file/{path}`.
@@ -259,7 +267,9 @@ Not in the key: the tenant id, the version, the CDN, `package.json`,
 `tsconfig.json`, and the tenant's other files except through the fingerprint.
 So the cache is content-addressed: two tenants with byte-identical files share
 one entry, and a changed file simply hashes to a new key — nothing is
-invalidated explicitly.
+invalidated explicitly. That is also why `build_bytes` can build a source the
+tenant does not hold yet: classifying a write compiles the incoming bytes, and
+the entry it leaves is the one the next module request would have paid for.
 
 The cache (`Engine::cache`) is a `HashMap<u128, Arc<Built>>` behind a mutex
 with a `VecDeque` of insertion order. The budget (`--cache-mb`, default 64
@@ -375,15 +385,56 @@ The version does three jobs:
   browser fetches fresh; the old URLs stay in its cache harmlessly. The daemon
   does not read the value of `v` — it only checks that the parameter is
   present — and always serves the file's current content.
-- **Reload.** `live.js` reloads the page on any `update`/`delete` event, and
-  on the `hello` event when the daemon's version is higher than the one baked
-  into the shell — which covers an edit that landed between the shell and the
-  `EventSource` connecting, and a daemon restart, since restored tenants get a
-  fresh version.
+- **Reload.** `live.js` reloads the page on any `update`/`delete` event it
+  cannot answer by swapping CSS, and on the `hello` event when the daemon's
+  version is higher than the one baked into the shell — which covers an edit
+  that landed between the shell and the `EventSource` connecting, and a daemon
+  restart, since restored tenants get a fresh version. A swap sets
+  `window.__sl.version` to the version it applied, so a later reconnect does
+  not read the page as stale.
 - **Editor refresh.** The editor subscribes to `/api/t/{id}/events` to reload
   its file list and the open file.
 
 The transform cache never sees the version; it is content-addressed.
+
+## CSS without a reload
+
+An `update` event carries a `kind`, and `live.js` swaps rather than reloads for
+two of them.
+
+- **`css`** — a `.css`, `.scss` or `.sass` write. The path is the key the CSS
+  module registered, so `<style data-sl="src/styles/global.css">` is re-imported
+  from `/__sl/m/<path>?v=<new version>` and its text replaced. A stylesheet the
+  page reaches through another sheet's `@import` — `global.css` pulls in
+  `tokens.css` that way — has no block of its own; the importing block's
+  `/__sl/raw/<path>` URL gets a fresh `?v=` instead, which is what makes the
+  browser fetch the file again.
+- **`style`** — an `.astro` write whose compiled JS is byte-identical to the
+  last build of that file, so only its `<style>` blocks moved. Each block is
+  keyed `<file>?<index>` and re-imported from
+  `?astro&type=style&index=<i>&lang.css`.
+- Anything else reloads: a `module` kind, a `delete`, a `write_many`'s empty
+  path, a `kind` the client does not know, a page showing the error overlay
+  (`<body data-sl-overlay>`), a block the page does not have, or a failed swap.
+
+`Engine::update_kind` decides. It compares the JS the incoming bytes compile to
+against `last_js`, a bounded `(tenant, path) → fingerprint` map that every
+module build of an `.astro` file writes — `Tenant::write` must stay cheap, and
+only a build can prove the JS is unchanged. Three consequences worth knowing:
+the fingerprint covers the module body *and* the hoisted `<script>` sources,
+which the body only names by index, so editing a `<script>` reloads; the map is
+written only for content the tenant holds, so a write that is then refused
+leaves nothing behind to compare against; and a file nothing has built yet
+reads as `module`, because a client that renders stale JS is worse than one
+that reloads too often.
+
+That compile takes a permit from the compile gate like any other, and a refused or failed
+one reads as `module` — the fallback is always the reload.
+
+Tailwind is the exception. A `type="text/tailwindcss"` block is compiled by
+`@tailwindcss/browser` when that script loads, and it exposes no rebuild hook
+to call afterwards, so any swap that would touch such a block reloads the page
+instead.
 
 ## Content collections and Markdown (`src/transform/content.rs`)
 
@@ -464,7 +515,7 @@ through the same `Tenant::write` as the editor, so previews follow.
 
 ```
 src/main.rs            flags, base loading, restore, listener
-src/store.rs           Base, Tenant (overlay, version, events, persistence), Store, clean_path, valid_id
+src/store.rs           Base, Tenant (overlay, version, events, persistence), Store, UpdateKind, clean_path, valid_id
 src/http/mod.rs        routers, host dispatch, the two token middlewares, MIME table
 src/http/api.rs        editor page, /api handlers, SSE, check_tenant
 src/http/archive.rs    tar.gz export and import of a tenant tree

--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ cargo build --release
 Open <http://localhost:4321/>, create a tenant `acme` from the `starter` base,
 and the preview appears at <http://acme.localhost:4321/> (`*.localhost` resolves
 to 127.0.0.1 in Chrome and Firefox without any setup). Edit a file on the left;
-the preview reloads.
+the preview updates — a stylesheet swaps into the open page, anything else
+reloads it.
 
 With `ANTHROPIC_API_KEY` set, the Chat tab talks to Claude with `read_file`,
 `write_file`, `delete_file`, `list_files` and `check_site` tools scoped to that
@@ -252,7 +253,7 @@ Editor host (`localhost`):
 | GET | `/api/t/{id}/files` | merged base + overlay listing |
 | GET | `/api/t/{id}/export` | tar.gz of the merged tree; `?overlay=1` for the edits alone |
 | GET/PUT/DELETE | `/api/t/{id}/file/{path}` | raw file bytes |
-| GET | `/api/t/{id}/events` | SSE: `update` / `delete` with the new version |
+| GET | `/api/t/{id}/events` | SSE: `update` / `delete` with the new version and a `kind` (`css`, `style`, `module`) |
 | GET | `/api/t/{id}/check` | compile every source file, return diagnostics |
 | POST | `/api/t/{id}/chat` | `{messages:[{role,content}], chat?}` → `{text, changes, chat}`, or SSE with `Accept: text/event-stream` |
 | GET | `/api/t/{id}/chats` | saved conversations, newest first |
@@ -302,7 +303,7 @@ Tenant host (`<id>.<domain>`):
 | `/__sl/content/<collection>` | `{entries, dates}` — the collection's entries and the schema's date fields; Markdown arrives rendered, MDX entries render through their compiled module |
 | `/__sl/shim/astro-*.js` | browser stand-ins for `astro:content`, `astro:assets`, `astro:transitions`, …; `astro-jsx-runtime.js` is Astro's JSX runtime and `astro:jsx` renderer |
 | `/__sl/astro.js` | Astro's runtime + container API, bundled once per Astro version |
-| `/__sl/events` | same SSE stream as the API; the page reloads itself on it |
+| `/__sl/events` | same SSE stream as the API; the page swaps CSS or reloads itself on it |
 | anything under `public/` | served directly |
 
 ## How a page renders
@@ -328,7 +329,16 @@ Tenant host (`<id>.<domain>`):
    `routeType: "endpoint"` runs its `GET` (or `ALL`) handler with an
    `APIContext`. An HTML response is written as a page; anything else — XML,
    JSON, plain text — is shown with its status and content-type above the body.
-8. `live.js` holds an `EventSource`; any write to the tenant reloads the page.
+8. `live.js` holds an `EventSource`. Each event carries a `kind`: a `.css`,
+   `.scss` or `.sass` write is `css`, an `.astro` write whose compiled JS is
+   byte-identical to the last build changed only its `<style>` blocks and is
+   `style`, and everything else is `module`. On `css` and `style` the CSS
+   module is re-imported and the matching `<style data-sl=…>` swapped in place,
+   leaving the page's DOM and JS state alone; on `module` — or on anything the
+   daemon cannot prove, or while the error overlay is up — the page reloads.
+   Tailwind is the exception: a `type="text/tailwindcss"` block is compiled by
+   Tailwind's browser build when it loads and there is no rebuild hook to call,
+   so a write that touches one reloads the page.
 
 Error states are pages too: a compile error, a missing import, a 404 route or
 a failing `getStaticPaths` render an overlay that lists the daemon's

--- a/assets/live.js
+++ b/assets/live.js
@@ -5,13 +5,77 @@
   if (prev && prev.readyState !== EventSource.CLOSED) return;
   const es = new EventSource("/__sl/events");
   window.__sl_es = es;
+
+  const reload = () => location.reload();
+  const styles = () => Array.from(document.querySelectorAll("style[data-sl]"));
+  // Tailwind's browser build compiles a type="text/tailwindcss" block when it loads and offers no rebuild hook.
+  const tailwind = (el) => el.hasAttribute("type");
+  const rawUrl = (path) => `/__sl/raw/${path}`;
+  const quoteRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+  function put(el, css) {
+    el.textContent = css;
+    (globalThis.__sl_css ||= new Map()).set(el.dataset.sl, css);
+  }
+
+  async function fetchCss(el, url) {
+    const mod = await import(url);
+    if (typeof mod.default !== "string") throw new Error(`${url} exported no CSS`);
+    put(el, mod.default);
+  }
+
+  // A `.css` module has a block of its own. One reached through another sheet's `@import` — the
+  // shape `global.css` uses for `tokens.css` — has none, and a fresh query on its URL is what makes
+  // the browser fetch it again.
+  function cssJobs(path, version) {
+    const fresh = `${rawUrl(path)}?v=${version}`;
+    const stale = new RegExp(`${quoteRe(rawUrl(path))}(\\?v=\\d+)?(?=[)"'\\s;,]|$)`, "g");
+    const jobs = [];
+    for (const el of styles()) {
+      const imported = el.textContent.replace(stale, fresh);
+      const own = el.dataset.sl === path;
+      if (!own && imported === el.textContent) continue;
+      if (tailwind(el)) return null;
+      jobs.push(own ? () => fetchCss(el, `/__sl/m/${path}?v=${version}`) : async () => put(el, imported));
+    }
+    return jobs;
+  }
+
+  // The `<style>` blocks of one component, keyed `<file>?<index>` as shell.js wrote them.
+  function styleJobs(path, version) {
+    const prefix = `${path}?`;
+    const jobs = [];
+    for (const el of styles()) {
+      if (!el.dataset.sl.startsWith(prefix)) continue;
+      const index = Number(el.dataset.sl.slice(prefix.length));
+      if (!Number.isInteger(index) || index < 0 || tailwind(el)) return null;
+      jobs.push(() => fetchCss(el, `/__sl/m/${path}?astro&type=style&index=${index}&lang.css&v=${version}`));
+    }
+    return jobs;
+  }
+
+  async function swap(d) {
+    // The overlay is not the rendered page: only a reload can put the page back.
+    if (!document.body || document.body.hasAttribute("data-sl-overlay")) return false;
+    const jobs = d.kind === "css" ? cssJobs(d.path, d.version) : d.kind === "style" ? styleJobs(d.path, d.version) : null;
+    if (!jobs || jobs.length === 0) return false;
+    for (const job of jobs) await job();
+    return true;
+  }
+
   es.addEventListener("hello", (e) => {
     const v = Number(e.data);
-    if (window.__sl && window.__sl.version && v > window.__sl.version) location.reload();
+    if (window.__sl && window.__sl.version && v > window.__sl.version) reload();
   });
   es.onmessage = (e) => {
     let d;
     try { d = JSON.parse(e.data); } catch { return; }
-    if (d.type === "update" || d.type === "delete") location.reload();
+    if (d.type !== "update" && d.type !== "delete") return;
+    if (d.type === "delete" || !d.path) return reload();
+    swap(d).then((swapped) => {
+      // the page now matches this version, so a reconnect's hello must not send it back
+      if (swapped && window.__sl) window.__sl.version = d.version;
+      else reload();
+    }, reload);
   };
 })();

--- a/assets/shell.js
+++ b/assets/shell.js
@@ -126,6 +126,7 @@ function prettyJSON(body) {
   }
 }
 
+// data-sl-overlay marks a document that is not the rendered page, so live.js reloads rather than swapping CSS into it.
 function showResponse({ component, status, statusText, type, body }) {
   const text = /\bjson\b/i.test(type) ? prettyJSON(body) : body;
   replaceDocument(`<!doctype html><html><head><meta charset="utf-8"><title>${esc(component)}</title>
@@ -133,7 +134,7 @@ function showResponse({ component, status, statusText, type, body }) {
 h1{color:#7aa2f7;font-size:18px;margin:0 0 4px}p{margin:0 0 12px;color:#565f89}pre{white-space:pre-wrap;background:#16161e;padding:12px;border-radius:6px;overflow:auto}
 b{color:#9ece6a}small{color:#565f89}</style>
 <script type="module" src="/__sl/live.js"></script></head>
-<body><h1>${status} ${esc(statusText || "")}</h1><p>${esc(component)} → <b>${esc(type || "no content-type")}</b></p><pre>${esc(text)}</pre>
+<body data-sl-overlay><h1>${status} ${esc(statusText || "")}</h1><p>${esc(component)} → <b>${esc(type || "no content-type")}</b></p><pre>${esc(text)}</pre>
 <small>sandbox-lite · tenant ${esc(sl.tenant)} · the page reloads itself when a file changes</small></body></html>`);
 }
 
@@ -147,7 +148,7 @@ function showError({ title, message, stack, diagnostics = [], routes }) {
 h1{color:#f7768e;font-size:18px;margin:0 0 12px}pre{white-space:pre-wrap;background:#16161e;padding:12px;border-radius:6px;overflow:auto}
 ul{padding-left:18px}b{color:#7aa2f7}i{color:#9ece6a}a{color:#7dcfff}small{color:#565f89}</style>
 <script type="module" src="/__sl/live.js"></script></head>
-<body><h1>${esc(title)}</h1><pre>${esc(message || "")}</pre>${diag ? `<ul>${diag}</ul>` : ""}${stack ? `<pre>${esc(stack)}</pre>` : ""}${list}
+<body data-sl-overlay><h1>${esc(title)}</h1><pre>${esc(message || "")}</pre>${diag ? `<ul>${diag}</ul>` : ""}${stack ? `<pre>${esc(stack)}</pre>` : ""}${list}
 <small>sandbox-lite · tenant ${esc(sl.tenant)} · the page reloads itself when a file changes</small></body></html>`);
 }
 

--- a/e2e/live-reload.spec.ts
+++ b/e2e/live-reload.spec.ts
@@ -1,4 +1,15 @@
+import type { Page } from '@playwright/test';
+
 import { expect, test } from './fixtures';
+
+// A marker on `window` is how a swap is told from a reload: only a navigation clears it.
+async function mark(page: Page): Promise<void> {
+  await page.evaluate(() => ((window as any).__slMarker = 'kept'));
+}
+
+function marker(page: Page): Promise<string | undefined> {
+  return page.evaluate(() => (window as any).__slMarker);
+}
 
 test('a written component shows up in the open preview within 3 s', async ({ daemon, page }) => {
   const site = await daemon.tenant('live', 'starter');
@@ -12,4 +23,51 @@ test('a written component shows up in the open preview within 3 s', async ({ dae
 
   await expect(page.locator('footer')).toContainText('edited by e2e and rendered live by Astro', { timeout: 3_000 });
   await expect(page).toHaveTitle('Home · Lumen Studio');
+});
+
+test('a stylesheet swaps in place, without a reload', async ({ daemon, page }) => {
+  const site = await daemon.tenant('live-css', 'starter');
+  await page.goto(site.url('/'));
+  await expect(page.locator('html')).toHaveCSS('background-color', 'rgb(251, 250, 247)');
+  await mark(page);
+
+  // tokens.css is not a module of its own: global.css reaches it through an `@import`.
+  const tokens = await site.read('src/styles/tokens.css');
+  const edited = tokens.replace('--bg: #fbfaf7;', '--bg: #ff0000;');
+  expect(edited).not.toBe(tokens);
+  await site.write('src/styles/tokens.css', edited);
+
+  await expect(page.locator('html')).toHaveCSS('background-color', 'rgb(255, 0, 0)', { timeout: 3_000 });
+  expect(await marker(page), 'the page was not reloaded').toBe('kept');
+});
+
+test("a component's style block swaps in place, without a reload", async ({ daemon, page }) => {
+  const site = await daemon.tenant('live-style', 'starter');
+  await page.goto(site.url('/'));
+  const card = page.locator('article.card').first();
+  await expect(card).toHaveCSS('background-color', 'rgb(255, 255, 255)');
+  await mark(page);
+
+  const source = await site.read('src/components/Card.astro');
+  const edited = source.replace('.card { background: var(--card);', '.card { background: rgb(0, 128, 0);');
+  expect(edited).not.toBe(source);
+  await site.write('src/components/Card.astro', edited);
+
+  await expect(card).toHaveCSS('background-color', 'rgb(0, 128, 0)', { timeout: 3_000 });
+  expect(await marker(page), 'the page was not reloaded').toBe('kept');
+});
+
+test('an edit to the frontmatter still reloads', async ({ daemon, page }) => {
+  const site = await daemon.tenant('live-module', 'starter');
+  await page.goto(site.url('/'));
+  await expect(page.locator('h1')).toHaveText('Design that ships.');
+  await mark(page);
+
+  const source = await site.read('src/pages/index.astro');
+  const edited = source.replace('const headline = "Design that ships.";', 'const headline = "Design that reloads.";');
+  expect(edited).not.toBe(source);
+  await site.write('src/pages/index.astro', edited);
+
+  await expect(page.locator('h1')).toHaveText('Design that reloads.', { timeout: 5_000 });
+  expect(await marker(page), 'the page was reloaded').toBeUndefined();
 });

--- a/src/http/ai.rs
+++ b/src/http/ai.rs
@@ -124,7 +124,8 @@ fn file_tool(st: &AppState, t: &Tenant, name: &str, input: &Value, changes: &mut
         "write_file" => {
             let Some(p) = path() else { return "error: bad path".into() };
             let content = input.get("content").and_then(|c| c.as_str()).unwrap_or("");
-            match t.write(&p, content.as_bytes().to_vec()) {
+            let kind = st.engine.update_kind(t, &p, content.as_bytes());
+            match t.write(&p, content.as_bytes().to_vec(), kind) {
                 Ok(_) => {
                     changes.push(p.clone());
                     format!("wrote {p} ({} bytes)", content.len())

--- a/src/http/api.rs
+++ b/src/http/api.rs
@@ -215,9 +215,17 @@ pub async fn write_file(AxState(st): AxState<State>, Path((id, path)): Path<(Str
         Err(r) => return r,
     };
     let Some(path) = clean_path(&path) else { return err(StatusCode::BAD_REQUEST, "bad path") };
-    match t.write(&path, body.to_vec()) {
-        Ok(version) => Json(json!({ "path": path, "version": version })).into_response(),
-        Err(e @ WriteError::Quota { .. }) => err(StatusCode::PAYLOAD_TOO_LARGE, e.to_string()),
+    // Classifying an `.astro` write compiles it, so the whole write goes to a blocking thread.
+    let p2 = path.clone();
+    let written = tokio::task::spawn_blocking(move || {
+        let kind = st.engine.update_kind(&t, &p2, &body);
+        t.write(&p2, body.to_vec(), kind)
+    })
+    .await;
+    match written {
+        Ok(Ok(version)) => Json(json!({ "path": path, "version": version })).into_response(),
+        Ok(Err(e @ WriteError::Quota { .. })) => err(StatusCode::PAYLOAD_TOO_LARGE, e.to_string()),
+        Ok(Err(e)) => err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
         Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -119,6 +119,35 @@ fn now_millis() -> u64 {
     SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_millis() as u64).unwrap_or(1)
 }
 
+/// How the live-reload client should apply one change: swap a stylesheet, swap a component's
+/// `<style>` blocks, or reload. A client that renders stale JS is worse than one that reloads too
+/// often, so anything unproven is `Module`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum UpdateKind {
+    Css,
+    Style,
+    Module,
+}
+
+impl UpdateKind {
+    /// What the path alone proves. `.astro` needs its compiled JS compared against the last build
+    /// before it can claim `Style`, which is `Engine::update_kind`'s job.
+    pub fn from_path(path: &str) -> UpdateKind {
+        match path.rsplit_once('.').map(|(_, e)| e.to_ascii_lowercase()).as_deref() {
+            Some("css" | "scss" | "sass") => UpdateKind::Css,
+            _ => UpdateKind::Module,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            UpdateKind::Css => "css",
+            UpdateKind::Style => "style",
+            UpdateKind::Module => "module",
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum WriteError {
     Quota { quota: u64, after: u64 },
@@ -219,7 +248,10 @@ impl Tenant {
         out.into_iter().map(|(path, (size, modified))| Entry { path, size, modified }).collect()
     }
 
-    pub fn write(&self, path: &str, bytes: Vec<u8>) -> Result<u64, WriteError> {
+    /// The caller says how the preview should apply the write: `UpdateKind::from_path` is the whole
+    /// answer for a stylesheet, and proving `Style` takes a compile — `Engine::update_kind` — which
+    /// is why it does not happen here.
+    pub fn write(&self, path: &str, bytes: Vec<u8>, kind: UpdateKind) -> Result<u64, WriteError> {
         // held across the disk write so a concurrent write cannot slip past the quota check
         let mut overlay = self.overlay.write().unwrap();
         let replaced = overlay.get(path).and_then(|d| d.as_ref()).map_or(0, |d| d.size());
@@ -233,7 +265,7 @@ impl Tenant {
         if was_tombstone {
             self.persist_tombstones()?;
         }
-        Ok(self.bump("update", path))
+        Ok(self.bump("update", path, kind))
     }
 
     /// Applies a whole import: every removal and every file land under one lock, one version bump
@@ -274,7 +306,7 @@ impl Tenant {
         *overlay = next;
         drop(overlay);
         self.persist_tombstones()?;
-        Ok(Applied { version: self.bump("update", ""), written, deleted: removed })
+        Ok(Applied { version: self.bump("update", "", UpdateKind::Module), written, deleted: removed })
     }
 
     /// Writes the file under `--data-dir` when there is one, and says how the overlay should hold it:
@@ -309,7 +341,7 @@ impl Tenant {
         }
         self.forget_on_disk(path)?;
         self.persist_tombstones()?;
-        Ok(self.bump("delete", path))
+        Ok(self.bump("delete", path, UpdateKind::Module))
     }
 
     fn persist_tombstones(&self) -> io::Result<()> {
@@ -319,7 +351,7 @@ impl Tenant {
         std::fs::write(dir.join("deleted.json"), serde_json::to_vec(&list)?)
     }
 
-    fn bump(&self, kind: &str, path: &str) -> u64 {
+    fn bump(&self, event: &str, path: &str, kind: UpdateKind) -> u64 {
         let mut v = self.version.load(Ordering::Relaxed);
         loop {
             let next = now_millis().max(v + 1);
@@ -331,8 +363,11 @@ impl Tenant {
                 Err(cur) => v = cur,
             }
         }
-        let _ =
-            self.events.send(format!(r#"{{"type":"{kind}","path":{},"version":{v}}}"#, serde_json::to_string(path).unwrap_or_default()));
+        let _ = self.events.send(format!(
+            r#"{{"type":"{event}","path":{},"kind":"{}","version":{v}}}"#,
+            serde_json::to_string(path).unwrap_or_default(),
+            kind.as_str()
+        ));
         v
     }
 
@@ -484,15 +519,15 @@ mod tests {
     #[test]
     fn quota_bounds_the_overlay_after_the_write() {
         let t = tenant(10, None);
-        t.write("a", vec![0; 6]).unwrap();
-        let err = t.write("b", vec![0; 5]).unwrap_err();
+        t.write("a", vec![0; 6], UpdateKind::Module).unwrap();
+        let err = t.write("b", vec![0; 5], UpdateKind::Module).unwrap_err();
         assert!(matches!(err, WriteError::Quota { quota: 10, after: 11 }), "{err}");
         assert!(err.to_string().contains("quota"));
         assert_eq!(t.overlay_stats(), (1, 6));
-        t.write("a", vec![0; 10]).unwrap();
-        assert!(t.write("a", vec![0; 11]).is_err());
+        t.write("a", vec![0; 10], UpdateKind::Module).unwrap();
+        assert!(t.write("a", vec![0; 11], UpdateKind::Module).is_err());
         t.delete("a").unwrap();
-        t.write("b", vec![0; 10]).unwrap();
+        t.write("b", vec![0; 10], UpdateKind::Module).unwrap();
         assert_eq!(t.overlay_stats(), (1, 10));
     }
 
@@ -508,12 +543,35 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
         let big = INLINE_LIMIT as usize + 1;
         let t = tenant(2 * big as u64 - 1, Some(dir.clone()));
-        t.write("big", vec![0; big]).unwrap();
+        t.write("big", vec![0; big], UpdateKind::Module).unwrap();
         assert!(matches!(t.data("big"), Some(FileData::Disk(_, n)) if n == big as u64));
-        assert!(matches!(t.write("big2", vec![0; big]), Err(WriteError::Quota { .. })));
+        assert!(matches!(t.write("big2", vec![0; big], UpdateKind::Module), Err(WriteError::Quota { .. })));
         assert!(!dir.join("files").join("big2").exists());
         assert_eq!(t.overlay_stats(), (1, big as u64));
         std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn only_a_stylesheet_extension_swaps_without_the_compiler() {
+        for path in ["src/styles/tokens.css", "a.scss", "a.sass", "SRC/A.CSS"] {
+            assert_eq!(UpdateKind::from_path(path), UpdateKind::Css, "{path}");
+        }
+        for path in ["src/pages/index.astro", "src/lib/x.ts", "package.json", "src/styles", "a.css/b"] {
+            assert_eq!(UpdateKind::from_path(path), UpdateKind::Module, "{path}");
+        }
+    }
+
+    #[test]
+    fn an_update_event_carries_the_kind() {
+        let t = tenant(u64::MAX, None);
+        let mut events = t.events.subscribe();
+        t.write("src/styles/a.css", b"a{}".to_vec(), UpdateKind::from_path("src/styles/a.css")).unwrap();
+        t.write("src/x.astro", b"<p/>".to_vec(), UpdateKind::Style).unwrap();
+        t.delete("src/styles/a.css").unwrap();
+        let seen: Vec<String> = (0..3).map(|_| events.try_recv().unwrap()).collect();
+        assert!(seen[0].contains(r#""type":"update","path":"src/styles/a.css","kind":"css""#), "{}", seen[0]);
+        assert!(seen[1].contains(r#""kind":"style""#), "{}", seen[1]);
+        assert!(seen[2].contains(r#""type":"delete","path":"src/styles/a.css","kind":"module""#), "{}", seen[2]);
     }
 
     #[test]

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -15,11 +15,11 @@ use std::sync::{Arc, Condvar, Mutex};
 use std::time::{Duration, Instant};
 
 use serde::Serialize;
-use xxhash_rust::xxh3::xxh3_128;
+use xxhash_rust::xxh3::{Xxh3Default, xxh3_128};
 
 use crate::metrics::Metrics;
 use crate::resolve::{Resolver, dirname};
-use crate::store::Tenant;
+use crate::store::{Tenant, UpdateKind};
 
 #[derive(Serialize, Clone, Debug)]
 pub struct Diag {
@@ -361,9 +361,16 @@ impl Drop for Compiling {
     }
 }
 
+/// How many `(tenant, .astro path)` pairs keep a compiled-JS fingerprint. Past that the map is
+/// emptied rather than evicted one by one: a forgotten entry costs a page reload, nothing more.
+const LAST_JS_ENTRIES: usize = 4096;
+
 pub struct Engine {
     pub cfg: Config,
     cache: Mutex<Cache>,
+    /// The JS each `.astro` module last compiled to, so a write can be told apart from an edit that
+    /// only moved a `<style>` block. Written by every module build, read once per write.
+    last_js: Mutex<HashMap<(String, String), u128>>,
     sass: scss::Sass,
     gate: Gate,
     metrics: Arc<Metrics>,
@@ -376,6 +383,7 @@ impl Engine {
         Engine {
             cfg,
             cache: Mutex::new(Cache { map: HashMap::new(), order: VecDeque::new(), bytes: 0, hits: 0, misses: 0 }),
+            last_js: Mutex::new(HashMap::new()),
             sass,
             gate,
             metrics,
@@ -436,6 +444,15 @@ impl Engine {
 
     pub fn build(&self, tenant: &Tenant, path: &str, kind: Kind) -> Result<Arc<Built>, BuildError> {
         let data = tenant.read(path).ok_or_else(|| BuildError::not_found(path))?;
+        let built = self.build_bytes(tenant, path, kind, &data)?;
+        self.remember(tenant, path, kind, &built);
+        Ok(built)
+    }
+
+    /// `build` of a source the tenant may not hold yet. The cache is content-addressed, so building
+    /// the bytes of a write before it lands is the compile the next module request would have paid
+    /// for anyway.
+    fn build_bytes(&self, tenant: &Tenant, path: &str, kind: Kind, data: &[u8]) -> Result<Arc<Built>, BuildError> {
         let site = crate::resolve::tenant_site(tenant);
         let mut h = Vec::with_capacity(data.len() + path.len() + 32);
         h.extend_from_slice(kind.tag().as_bytes());
@@ -444,10 +461,10 @@ impl Engine {
         h.push(0);
         h.extend_from_slice(site.as_deref().unwrap_or("").as_bytes());
         h.push(0);
-        if scss::is_sass_path(path) || (path.ends_with(".astro") && scss::uses_sass(&String::from_utf8_lossy(&data))) {
+        if scss::is_sass_path(path) || (path.ends_with(".astro") && scss::uses_sass(&String::from_utf8_lossy(data))) {
             h.extend_from_slice(&scss::fingerprint(tenant).to_le_bytes());
         }
-        h.extend_from_slice(&data);
+        h.extend_from_slice(data);
         let key = xxh3_128(&h);
         if let Some(b) = self.cached(key) {
             return Ok(b);
@@ -456,13 +473,45 @@ impl Engine {
         let started = Instant::now();
         let spawned = self.on_parser_stack(|| {
             let _compiling = Compiling::enter();
-            self.compile(tenant, path, kind, &data, site.as_deref())
+            self.compile(tenant, path, kind, data, site.as_deref())
         });
         self.metrics.compiled(kind, started.elapsed());
         let compiled = spawned.map_err(|e| BuildError::compile(format!("{path}: cannot start a compiler thread: {e}"), vec![]))?;
         let built = Arc::new(compiled?);
         self.insert(key, built.clone());
         Ok(built)
+    }
+
+    /// Only ever called for content the tenant holds, so a fingerprint here is one a page could
+    /// have loaded. A speculative build — the one `update_kind` runs on bytes not yet written —
+    /// must not land in the map: were the write then refused, the next write would be compared
+    /// against JS the browser never ran.
+    fn remember(&self, tenant: &Tenant, path: &str, kind: Kind, built: &Built) {
+        if kind != Kind::Module || !path.ends_with(".astro") {
+            return;
+        }
+        let mut map = self.last_js.lock().unwrap();
+        if map.len() >= LAST_JS_ENTRIES {
+            map.clear();
+        }
+        map.insert((tenant.id.clone(), path.to_string()), module_fingerprint(built));
+    }
+
+    /// How the live-reload client should apply a write of `bytes` to `path`. A stylesheet swaps in
+    /// place. An `.astro` file that compiles to the JS the last build produced moved only its
+    /// `<style>` blocks, so those swap instead. Everything else reloads, and so does anything this
+    /// cannot prove: an `.astro` file nothing has built yet, one that no longer compiles, one whose
+    /// hoisted `<script>` changed.
+    pub fn update_kind(&self, tenant: &Tenant, path: &str, bytes: &[u8]) -> UpdateKind {
+        if !path.ends_with(".astro") {
+            return UpdateKind::from_path(path);
+        }
+        let before = self.last_js.lock().unwrap().get(&(tenant.id.clone(), path.to_string())).copied();
+        let Some(before) = before else { return UpdateKind::Module };
+        match self.build_bytes(tenant, path, Kind::Module, bytes) {
+            Ok(built) if module_fingerprint(&built) == before => UpdateKind::Style,
+            _ => UpdateKind::Module,
+        }
     }
 
     fn compile(&self, tenant: &Tenant, path: &str, kind: Kind, data: &[u8], site: Option<&str>) -> Result<Built, BuildError> {
@@ -600,6 +649,23 @@ impl Engine {
     }
 }
 
+/// Everything a component renders except its CSS: the module body, and the hoisted scripts, which
+/// the body only names by index. Two builds with the same fingerprint differ in their `<style>`
+/// blocks or not at all.
+fn module_fingerprint(built: &Built) -> u128 {
+    let mut h = Xxh3Default::new();
+    h.update(built.body.as_bytes());
+    for script in &built.scripts {
+        let (tag, code) = match script {
+            astro::Script::Inline(code) => (b"i", code),
+            astro::Script::External(src) => (b"e", src),
+        };
+        h.update(tag);
+        h.update(code.as_bytes());
+    }
+    h.digest128()
+}
+
 /// No Rust compiler exists for `.vue` or `.svelte`, so the file is served as a module that
 /// compiles its source in the browser and re-exports the component. The source it carries has
 /// been through `sfc::strip_types`, so its `<script>` blocks are JavaScript.
@@ -659,7 +725,7 @@ mod tests {
 
     use super::*;
     use crate::resolve::Resolver;
-    use crate::store::{Base, Store, Tenant};
+    use crate::store::{Base, Store, Tenant, UpdateKind};
 
     const PAGE: &str = "---\nimport { Chart } from \"some-widgets\";\n---\n<Chart client:load />\n";
     const PAGE_PATH: &str = "src/pages/index.astro";
@@ -673,7 +739,7 @@ mod tests {
         std::fs::remove_dir(&root).unwrap();
         let tenant = store.create_tenant("t", "b").unwrap();
         for (path, body) in files {
-            tenant.write(path, body.as_bytes().to_vec()).unwrap();
+            tenant.write(path, body.as_bytes().to_vec(), UpdateKind::from_path(path)).unwrap();
         }
         tenant
     }
@@ -922,6 +988,57 @@ mod tests {
         let closed = Engine { gate: Gate::new(0, Duration::from_millis(50)), ..engine };
         assert!(closed.build(&t, "src/hit.ts", Kind::Module).is_ok());
         assert_eq!(build_err(closed.build(&t, "src/miss.ts", Kind::Module)).status, 503);
+    }
+
+    const CARD: &str = "---\nconst n = 1;\n---\n<p>{n}</p>\n<style>p{color:red}</style>\n<script>console.log(1)</script>\n";
+    const CARD_PATH: &str = "src/components/Card.astro";
+
+    /// Issue #13: what the client is told a write changed. Only an `.astro` file that compiles to
+    /// the JS the page is already running may swap its styles; everything else reloads.
+    #[test]
+    fn an_astro_write_is_a_style_swap_only_when_its_js_is_unchanged() {
+        let t = tenant(&[(CARD_PATH, CARD)]);
+        let e = engine();
+        let restyled = CARD.replace("color:red", "color:blue");
+        assert_eq!(
+            e.update_kind(&t, CARD_PATH, restyled.as_bytes()),
+            UpdateKind::Module,
+            "nothing has built this file, so nothing can be proved about it"
+        );
+        e.build(&t, CARD_PATH, Kind::Module).unwrap();
+        assert_eq!(e.update_kind(&t, CARD_PATH, restyled.as_bytes()), UpdateKind::Style);
+        for edited in [
+            CARD.replace("console.log(1)", "console.log(2)"),
+            CARD.replace("const n = 1;", "const n = 2;"),
+            CARD.replace("<p>{n}</p>", "<p>{n}!</p>"),
+            CARD.replace("<style>p{color:red}</style>", ""),
+            "---\nconst n = ;\n---\n".to_string(),
+        ] {
+            assert_eq!(e.update_kind(&t, CARD_PATH, edited.as_bytes()), UpdateKind::Module, "{edited}");
+        }
+    }
+
+    /// A refused write must leave no fingerprint behind, or the write after it would be compared
+    /// against JS no browser ever ran.
+    #[test]
+    fn a_classified_write_that_never_lands_is_not_remembered() {
+        let t = tenant(&[(CARD_PATH, CARD)]);
+        let e = engine();
+        e.build(&t, CARD_PATH, Kind::Module).unwrap();
+        let rewritten = CARD.replace("const n = 1;", "const n = 2;");
+        assert_eq!(e.update_kind(&t, CARD_PATH, rewritten.as_bytes()), UpdateKind::Module);
+        let restyled = rewritten.replace("color:red", "color:blue");
+        assert_eq!(e.update_kind(&t, CARD_PATH, restyled.as_bytes()), UpdateKind::Module);
+    }
+
+    #[test]
+    fn a_stylesheet_needs_no_compile_to_be_classified() {
+        let t = tenant(&[]);
+        let e = engine();
+        assert_eq!(e.update_kind(&t, "src/styles/tokens.css", b"a{}"), UpdateKind::Css);
+        assert_eq!(e.update_kind(&t, "src/styles/app.scss", b"a{}"), UpdateKind::Css);
+        assert_eq!(e.update_kind(&t, "src/lib/x.ts", b"export {};"), UpdateKind::Module);
+        assert_eq!(e.stats().misses, 0);
     }
 
     #[test]

--- a/src/transform/scss.rs
+++ b/src/transform/scss.rs
@@ -330,7 +330,7 @@ mod tests {
     use std::time::{Duration, Instant};
 
     use super::{MAX_FILE, MAX_OUTPUT, MAX_READ, Sass, uses_sass};
-    use crate::store::{Base, Store, Tenant};
+    use crate::store::{Base, Store, Tenant, UpdateKind};
 
     fn tenant(files: &[(&str, String)]) -> Arc<Tenant> {
         let store = Store::new(None, u64::MAX);
@@ -338,7 +338,7 @@ mod tests {
         store.add_base(Base::load("starter", &root).unwrap());
         let t = store.create_tenant("t", "starter").unwrap();
         for (path, body) in files {
-            t.write(path, body.clone().into_bytes()).unwrap();
+            t.write(path, body.clone().into_bytes(), UpdateKind::from_path(path)).unwrap();
         }
         t
     }


### PR DESCRIPTION
Closes #13

Every write reloaded the open preview, which threw away scroll position, island state
and anything typed into a form — even when all that changed was a colour.

## What the daemon says

The SSE payload gains a `kind`:

| kind | when |
|---|---|
| `css` | a `.css`, `.scss` or `.sass` write |
| `style` | an `.astro` write whose compiled JS is byte-identical to the last build of that file — only its `<style>` blocks moved |
| `module` | everything else, and everything unproven |

`{"type":"update","path":"src/styles/tokens.css","kind":"css","version":N}`.
`delete`, an import's empty-path `write_many`, and any `.astro` file nothing has built
yet are all `module`: a client rendering stale JS is worse than one that reloads too
often, so when in doubt the answer is `module`.

### Where the comparison happens, and why

`Tenant::write` now takes the kind from its caller instead of deciding
(`write(path, bytes, kind)`), because proving `style` costs a compile and `write` must
stay cheap. `Engine::update_kind` owns that half, against `last_js` — a bounded
`(tenant, path) → fingerprint` map that every `Kind::Module` build of an `.astro` file
writes. I chose the map over asking the module handler at request time for three
reasons:

- The answer is needed *before* `bump` sends the event; a handler that learns after the
  fact is too late, and a second event would arrive after the client had already reloaded.
- The map costs nothing on the read path: the page render already builds every `.astro`
  module it uses, so the "before" fingerprint is a by-product of serving the page.
- The "after" fingerprint is not wasted work either. The cache is content-addressed, so
  `build_bytes` on the incoming bytes leaves exactly the entry the next
  `GET /__sl/m/<file>` would have paid for.

Rebased onto #53, that compile takes a permit from the new compile gate like any other,
so classification cannot outrun the gate's ceiling; a refused or failed compile reads as
`module`, which is the reload.

Two details the map has to get right, both covered by unit tests:

- The fingerprint covers the module body **and** the hoisted `<script>` sources. The body
  only names a script by index, so `<script>console.log(1)</script>` →
  `console.log(2)` produces byte-identical JS; without the scripts in the fingerprint
  that edit would be classified `style` and never run.
- The map is written only from `build`, i.e. only for content the tenant actually holds.
  A speculative build whose write is then refused by the quota must leave nothing behind,
  or the write after it would be compared against JS no browser ever ran.

## What the client does

`live.js` on `css` re-imports `/__sl/m/<path>?v=<new version>` and replaces the text of
`<style data-sl="<path>">`; on `style` it re-imports
`?astro&type=style&index=<i>&lang.css&v=…` for each `<style data-sl="<file>?<i>">` the
page actually has. A successful swap also advances `window.__sl.version`, so a later
reconnect's `hello` does not read the page as stale.

One case needed more than a key lookup: `global.css` reaches `tokens.css` through a CSS
`@import`, so `tokens.css` has no block of its own. There the importing block's
`/__sl/raw/src/styles/tokens.css` URL gets a fresh `?v=`, which is what makes the browser
fetch the file again.

Anything else reloads: an unknown kind, a `delete`, a block the page does not have, a
failed swap, and — always — a page showing the error overlay. The overlay is not the
rendered page, and swapping CSS into it would leave a broken build on screen forever;
`shell.js` marks those documents `<body data-sl-overlay>`. The existing error-overlay
spec exercises this: fixing the file restores byte-identical JS, so the fix classifies as
`style`, and only the overlay check turns it back into the reload that spec expects.

## Tailwind

No swap. A `type="text/tailwindcss"` block is compiled by `@tailwindcss/browser` when
that script loads, and it exposes no documented rebuild entry point to call afterwards, so
any swap that would touch such a block reloads the page instead. Said plainly in the
README and in ARCHITECTURE.md. If a rebuild hook appears, it is a two-line change in
`live.js`.

## Tests

- `e2e/live-reload.spec.ts`: editing `src/styles/tokens.css` turns the page red, editing
  `Card.astro`'s `<style>` block turns the cards green, and both keep a `window` marker
  set before the edit — a navigation would clear it. Editing `index.astro`'s frontmatter
  still reloads, asserted by the marker being gone.
- `src/transform/mod.rs`: the classification itself — a style-only edit is `Style` once
  the file has been built and `Module` before that; a script edit, a frontmatter edit, a
  template edit, a removed `<style>` and a file that no longer compiles are all `Module`;
  a refused write leaves no fingerprint; a stylesheet is classified with zero compiles.
- `src/store.rs`: `UpdateKind::from_path` per extension, and the JSON the event carries.

CI green on the branch: https://github.com/productdevbook/sandbox-lite/actions/runs/34057691289
(fmt, clippy `-D warnings`, tests, release build, `sandbox-lite check`, the smoke test,
`bench/mem.sh` and the Playwright suite in Chromium). The head commit is that tree rebased
onto ad7f81d, a CI-workflow-only commit, with no file conflicts.

## Noticed, did not fix

- **A stylesheet the open page does not show still reloads it.** If no `<style data-sl>`
  matches — the file is not imported by this page, or the component is not on it —
  `live.js` falls back to a reload. Correct, but not minimal.
- **`last_js` tracks the daemon's last build, not what the open page is running.** If a
  `module` event never reaches a client (a dropped SSE message on a live connection), a
  later style-only write can be classified `style` while that client still runs older JS.
  Reconnects are covered by the `hello` version check; a survived-but-lossy connection is
  not. Closing it properly means the client telling the daemon which version it rendered.
- **The map is cleared, not evicted, at 4096 entries, and a removed tenant's rows stay
  until then.** Entries are ~100 bytes and a forgotten one only costs a reload, so this is
  cheap rather than right; an LRU or a hook in `Store::remove_tenant` would be tidier.
- **A write of an already-built `.astro` file now costs a compile on the write path.** It
  is the compile the next module request would have paid, and it seeds the cache — except
  when the write is then refused by the quota, where it is thrown away.
- **`.vue`/`.svelte` `<style>` blocks register in the same registry but are compiled in
  the browser**, so editing one is a `module` write and reloads. Same for a `<style>` in a
  `.md`/`.mdx` layout reached through a component that changed.
- **The editor's own SSE handler ignores `kind`** and still refreshes its file list and
  open file on every update. That is the right behaviour there, but it means nothing in
  the editor UI shows which kind a write was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
