### PR TITLE
errors: stop serving a failed build as empty content

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -470,6 +470,16 @@ entry per item, other JSON as one entry; `.yaml`/`.yml` as one entry. The
 compiled module at `/__sl/m/<filePath>` and returns its `Content`,
 `getHeadings()` and `frontmatter`.
 
+Every way the collection can fail to build answers **500** with the message and
+a diagnostic, and the shim throws it so the shell's error overlay renders it: a
+config past the size or nesting cap, a config that does not parse, a glob
+pattern that does not compile, a `file()` loader whose source is absent or
+malformed, and an entry file that is listed but cannot be read, whose JSON is
+invalid or whose frontmatter is not a YAML mapping. An empty collection means a
+collection with no entries and nothing else — a page rendered from a failed
+build is indistinguishable from a page rendered from a tenant that has no posts
+(issue #48).
+
 Which files those are comes from `src/content.config.ts` (or the Astro 2–4
 `src/content/config.ts`), parsed with oxc and never executed. `parse_config`
 maps `export const collections = { name: … }` to the `defineCollection({…})`
@@ -483,7 +493,8 @@ literal, which become the `dates` list the shim turns into `Date` objects.
 Anything the reader cannot see through — a computed pattern, a custom loader,
 a schema built by a function — leaves that part unset, and the collection
 falls back to `src/content/<name>/` with the shim's ISO-shaped-string guess
-for dates.
+for dates. That fallback is for a config the reader read and could not follow;
+a config it could not read at all is the error above.
 
 ## `check` (`src/check.rs`)
 
@@ -555,6 +566,7 @@ src/transform/scss.rs  grass over a tenant snapshot, size and time limits, finge
 src/transform/glob.rs  import.meta.glob detection and expansion
 src/transform/sfc.rs   TypeScript out of the <script> blocks of a .vue or .svelte file
 src/transform/markdown.rs, content.rs   Markdown pages and collections
+src/silent_failures.rs the check that reads src/ for failures answered as empty content (#48)
 src/transform/mdx.rs   MDX pages and entries through satteri-mdxjs
 src/check.rs           the check subcommand
 assets/shell.html, shell.js, live.js    the browser side of a render

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -97,8 +97,9 @@ roles or per-tenant credentials on the API side.
   Two parsed sources do not reach grass or oxc through `Engine::build`, and get
   the bounds where they are loaded instead:
   - `src/content.config.ts`, read by the content route — past the size or the
-    nesting cap it is left unparsed and the collection falls back to the
-    directory layout.
+    nesting cap the collection answers 500 with the diagnostic. It used to fall
+    back to the directory layout, which served a config nobody had read as if
+    the tenant had written no config at all (issue #48).
   - Sass partials, which grass reads itself and compiles on its own thread
     (see below) rather than on the one `Engine::build` reserved. Each is
     refused past the nesting cap, and that thread gets a 64 MiB stack.

--- a/assets/shims/astro-content.js
+++ b/assets/shims/astro-content.js
@@ -33,7 +33,11 @@ function reviveFields(data, paths) {
 function load(name) {
   if (!cache.has(name)) {
     cache.set(name, fetch(slUrl(`/__sl/content/${encodeURIComponent(name)}?v=${globalThis.__sl?.version ?? ""}`)).then(async (r) => {
-      if (!r.ok) throw new Error(`content collection '${name}' is not available (${r.status})`);
+      if (!r.ok) {
+        // The daemon answers a collection it could not build with the diagnostic; the overlay renders this message.
+        const detail = await r.json().then((b) => b?.error).catch(() => undefined);
+        throw new Error(detail ? `content collection '${name}': ${detail}` : `content collection '${name}' is not available (${r.status})`);
+      }
       const { entries, dates } = await r.json();
       for (const e of entries) e.data = dates ? reviveFields(e.data, dates) : reviveDates(e.data);
       return entries;

--- a/src/check.rs
+++ b/src/check.rs
@@ -75,7 +75,7 @@ pub fn inspect(dir: &Path) -> Result<Report, String> {
         sass: 0,
         mdx: 0,
         endpoints: 0,
-        integrations: package_deps(&tenant).into_iter().map(|(n, _)| n).filter(|n| n.starts_with("@astrojs/")).collect(),
+        integrations: package_deps(&tenant)?.into_iter().map(|(n, _)| n).filter(|n| n.starts_with("@astrojs/")).collect(),
         bare_imports: BTreeSet::new(),
     };
     for entry in tenant.list() {
@@ -93,7 +93,7 @@ pub fn inspect(dir: &Path) -> Result<Report, String> {
             continue;
         }
         report.files += 1;
-        if path.ends_with(".astro") && tenant.read_text(&path).is_some_and(|t| scss::uses_sass(&t)) {
+        if path.ends_with(".astro") && tenant.read_text(&path).ok().flatten().is_some_and(|t| scss::uses_sass(&t)) {
             report.sass += 1;
         }
         match engine.build(&tenant, &path, Kind::Module) {

--- a/src/http/ai.rs
+++ b/src/http/ai.rs
@@ -117,10 +117,11 @@ fn file_tool(st: &AppState, t: &Tenant, name: &str, input: &Value, changes: &mut
     let path = || input.get("path").and_then(|p| p.as_str()).and_then(clean_path);
     match name {
         "list_files" => t.list().iter().map(|e| format!("{} ({} bytes)", e.path, e.size)).collect::<Vec<_>>().join("\n"),
-        "read_file" => match path().and_then(|p| t.read(&p)) {
-            Some(bytes) if bytes.len() <= MAX_READ => String::from_utf8_lossy(&bytes).into_owned(),
-            Some(_) => "error: file too large to read".into(),
-            None => "error: no such file".into(),
+        "read_file" => match path().map(|p| t.read(&p)).transpose() {
+            Ok(Some(Some(bytes))) if bytes.len() <= MAX_READ => String::from_utf8_lossy(&bytes).into_owned(),
+            Ok(Some(Some(_))) => "error: file too large to read".into(),
+            Ok(_) => "error: no such file".into(),
+            Err(e) => format!("error: {e}"),
         },
         "write_file" => {
             let Some(p) = path() else { return "error: bad path".into() };
@@ -555,8 +556,9 @@ pub async fn chat(AxState(st): AxState<State>, Path(id): Path<String>, headers: 
     let Some(t) = st.store.tenant(&id) else { return err(StatusCode::NOT_FOUND, "unknown tenant") };
     let conv = match &req.chat {
         Some(chat) => match st.chats.load(&t, chat) {
-            Some(c) => c,
-            None => return err(StatusCode::NOT_FOUND, "unknown chat"),
+            Ok(Some(c)) => c,
+            Ok(None) => return err(StatusCode::NOT_FOUND, "unknown chat"),
+            Err(e) => return err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
         },
         None => Conversation::new(super::chats::new_id()),
     };
@@ -775,7 +777,7 @@ mod tests {
         assert!(done[0]["version"].as_u64().unwrap() > 0);
 
         let t = f.st.store.tenant("acme").unwrap();
-        assert_eq!(t.read_text("src/pages/new.astro").as_deref(), Some("<h1>hi</h1>"));
+        assert_eq!(t.read_text("src/pages/new.astro").unwrap().as_deref(), Some("<h1>hi</h1>"));
 
         // the second request has to carry the first turn's blocks back, with the tool result after them
         let seen = f.seen.lock().unwrap();
@@ -795,7 +797,7 @@ mod tests {
         assert_eq!(messages[2]["content"][0]["tool_use_id"], "toolu_1");
 
         let chat_id = done[0]["chat"].as_str().unwrap();
-        let stored = f.st.chats.load(&t, chat_id).expect("the conversation was saved");
+        let stored = f.st.chats.load(&t, chat_id).unwrap().expect("the conversation was saved");
         assert_eq!(stored.title, "add a page");
         assert_eq!(stored.messages[0], Turn { role: "user".into(), text: "add a page".into(), tools: vec![] });
         assert_eq!(
@@ -806,7 +808,7 @@ mod tests {
                 tools: vec![ToolCall { name: "write_file".into(), path: "src/pages/new.astro".into() }],
             }
         );
-        assert_eq!(f.st.chats.list(&t).len(), 1);
+        assert_eq!(f.st.chats.list(&t).unwrap().len(), 1);
     }
 
     #[tokio::test]
@@ -840,8 +842,8 @@ mod tests {
             ])
         );
         let t = f.st.store.tenant("acme").unwrap();
-        assert_eq!(f.st.chats.load(&t, &chat_id).unwrap().messages.len(), 4, "in memory, without a data dir");
-        assert_eq!(f.st.chats.list(&t).len(), 1);
+        assert_eq!(f.st.chats.load(&t, &chat_id).unwrap().unwrap().messages.len(), 4, "in memory, without a data dir");
+        assert_eq!(f.st.chats.list(&t).unwrap().len(), 1);
     }
 
     #[tokio::test]
@@ -904,7 +906,7 @@ mod tests {
         let (status, _) = post_chat(&f.st, None, ask("carry on", Some("old"))).await;
         assert_eq!(status, StatusCode::OK);
 
-        let stored = f.st.chats.load(&t, "old").unwrap();
+        let stored = f.st.chats.load(&t, "old").unwrap().unwrap();
         assert_eq!(stored.summary, STUB_SUMMARY);
         assert_eq!(stored.messages.len(), window * 2 - dropped + 2, "the window, plus this request's two turns");
         assert_eq!(stored.messages[0].text, format!("turn {dropped}"));
@@ -959,7 +961,7 @@ mod tests {
         let (status, _) = post_chat(&f.st, None, ask("carry on", Some("old"))).await;
         assert_eq!(status, StatusCode::OK, "a summary that cannot be written is not a failed request");
 
-        let stored = f.st.chats.load(&t, "old").unwrap();
+        let stored = f.st.chats.load(&t, "old").unwrap().unwrap();
         assert_eq!(stored.summary, "");
         assert_eq!(stored.messages.len(), window * 4 + 2, "no turn is dropped without a summary to stand for it");
         let seen = f.seen.lock().unwrap();

--- a/src/http/anthropic.rs
+++ b/src/http/anthropic.rs
@@ -88,7 +88,21 @@ impl Reply {
             "content_block_stop" => {
                 let slot = self.slot(v)?;
                 if slot.value["type"] == "tool_use" {
-                    let input = serde_json::from_str(&slot.json).unwrap_or_else(|_| json!({}));
+                    // A tool whose input schema is empty streams no partial_json at all; a tool call
+                    // whose arguments arrived broken must not run as if it had been called with none.
+                    let input = if slot.json.is_empty() {
+                        json!({})
+                    } else {
+                        match serde_json::from_str(&slot.json) {
+                            Ok(input) => input,
+                            Err(e) => {
+                                let message = format!("the model's tool arguments did not parse: {e}");
+                                self.error = Some(message.clone());
+                                return Some(Emit::Error(message));
+                            }
+                        }
+                    };
+                    let slot = self.slot(v)?;
                     if let Some(block) = slot.value.as_object_mut() {
                         block.insert("input".into(), input);
                     }

--- a/src/http/api.rs
+++ b/src/http/api.rs
@@ -73,20 +73,31 @@ fn module_stats(st: &AppState) -> Vec<Value> {
 
 /// Conversations and the bytes they hold across every tenant. They are outside the tenant quota,
 /// so `overlay_bytes` does not see them and this is the only place the chats directory is counted.
-fn chat_stats(st: &AppState) -> Value {
-    let (conversations, bytes) = st.store.tenants().iter().map(|t| st.chats.usage(t)).fold((0, 0), |(n, b), (cn, cb)| (n + cn, b + cb));
-    json!({
+fn chat_stats(st: &AppState) -> std::io::Result<Value> {
+    let (mut conversations, mut bytes) = (0usize, 0u64);
+    for t in st.store.tenants() {
+        let (n, b) = st.chats.usage(&t)?;
+        conversations += n;
+        bytes += b;
+    }
+    Ok(json!({
         "conversations": conversations,
         "bytes": bytes,
         "max_per_tenant": st.chats.cap(),
         "window_turns": st.chats.window(),
-    })
+    }))
 }
 
-pub async fn stats(AxState(st): AxState<State>) -> Json<Value> {
+pub async fn stats(AxState(st): AxState<State>) -> Response {
     let tenants = st.store.tenants();
     let overlay_bytes: u64 = tenants.iter().map(|t| t.overlay_stats().1).sum();
     let subscribers: usize = tenants.iter().map(|t| t.events.receiver_count()).sum();
+    // A gauge that reads zero because a directory could not be listed is a wrong number, not a
+    // missing one, and nothing downstream can tell the two apart.
+    let chats = match chat_stats(&st) {
+        Ok(chats) => chats,
+        Err(e) => return err(StatusCode::INTERNAL_SERVER_ERROR, format!("chats: {e}")),
+    };
     Json(json!({
         "rss_kb": rss_kb(),
         "uptime_s": st.started.elapsed().as_secs(),
@@ -97,7 +108,7 @@ pub async fn stats(AxState(st): AxState<State>) -> Json<Value> {
         "cache": st.engine.stats(),
         "sass": st.engine.sass_stats(),
         "compiles": st.engine.compile_stats(),
-        "chats": chat_stats(&st),
+        "chats": chats,
         "screenshots": st.shots.stats(),
         "modules": module_stats(&st),
         "ai": st.api_key.is_some(),
@@ -107,6 +118,7 @@ pub async fn stats(AxState(st): AxState<State>) -> Json<Value> {
         "port": st.port,
         "astro": include_str!("../../assets/astro.version").trim(),
     }))
+    .into_response()
 }
 
 fn snapshot(st: &AppState) -> Snapshot {
@@ -230,7 +242,11 @@ pub async fn create_tenant(AxState(st): AxState<State>, Json(req): Json<CreateRe
 
 pub async fn delete_tenant(AxState(st): AxState<State>, Path(id): Path<String>) -> Response {
     st.chats.forget(&id);
-    if st.store.remove_tenant(&id) { StatusCode::NO_CONTENT.into_response() } else { err(StatusCode::NOT_FOUND, "unknown tenant") }
+    match st.store.remove_tenant(&id) {
+        Ok(true) => StatusCode::NO_CONTENT.into_response(),
+        Ok(false) => err(StatusCode::NOT_FOUND, "unknown tenant"),
+        Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, format!("tenant '{id}' was dropped but its data directory was not: {e}")),
+    }
 }
 
 pub async fn files(AxState(st): AxState<State>, Path(id): Path<String>) -> Response {
@@ -249,8 +265,9 @@ pub async fn read_file(AxState(st): AxState<State>, Path((id, path)): Path<(Stri
     };
     let Some(path) = clean_path(&path) else { return err(StatusCode::BAD_REQUEST, "bad path") };
     match t.read(&path) {
-        Some(bytes) => ([(header::CONTENT_TYPE, mime(&path)), (header::CACHE_CONTROL, "no-store")], bytes.to_vec()).into_response(),
-        None => err(StatusCode::NOT_FOUND, "no such file"),
+        Ok(Some(bytes)) => ([(header::CONTENT_TYPE, mime(&path)), (header::CACHE_CONTROL, "no-store")], bytes.to_vec()).into_response(),
+        Ok(None) => err(StatusCode::NOT_FOUND, "no such file"),
+        Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, format!("{path}: {e}")),
     }
 }
 
@@ -292,7 +309,13 @@ pub async fn delete_file(AxState(st): AxState<State>, Path((id, path)): Path<(St
 
 pub fn sse(t: &Tenant) -> Sse<impl Stream<Item = Result<Event, Infallible>> + use<>> {
     let hello = tokio_stream::once(Ok(Event::default().event("hello").data(t.version().to_string())));
-    let updates = BroadcastStream::new(t.events.subscribe()).filter_map(|r| r.ok()).map(|s| Ok(Event::default().data(s)));
+    // A subscriber that fell behind the 64-slot channel has missed edits. Dropped, the last one it
+    // missed is a reload that never happens and a preview that quietly stops following the tenant.
+    // An update with no path is what a whole-tree change already looks like to both clients, and it
+    // reloads rather than swapping CSS, which is the only safe thing to do about writes nobody saw.
+    let missed = r#"{"type":"update","path":"","kind":"module","version":0}"#;
+    let updates =
+        BroadcastStream::new(t.events.subscribe()).map(|r| r.unwrap_or_else(|_| missed.to_string())).map(|s| Ok(Event::default().data(s)));
     Sse::new(hello.chain(updates)).keep_alive(KeepAlive::default())
 }
 
@@ -339,6 +362,8 @@ pub async fn check(AxState(st): AxState<State>, Path(id): Path<String>) -> Respo
         Err(r) => return r,
     };
     let st2 = st.clone();
-    let out = tokio::task::spawn_blocking(move || check_tenant(&st2, &t)).await.unwrap_or_else(|e| json!({ "error": e.to_string() }));
-    Json(out).into_response()
+    match tokio::task::spawn_blocking(move || check_tenant(&st2, &t)).await {
+        Ok(out) => Json(out).into_response(),
+        Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
+    }
 }

--- a/src/http/archive.rs
+++ b/src/http/archive.rs
@@ -256,7 +256,7 @@ mod tests {
 
     fn bytes_of(f: &Fixture, id: &str) -> Vec<(String, Vec<u8>)> {
         let t = f.state.store.tenant(id).unwrap();
-        t.list().into_iter().map(|e| (e.path.clone(), t.read(&e.path).unwrap().to_vec())).collect()
+        t.list().into_iter().map(|e| (e.path.clone(), t.read(&e.path).unwrap().unwrap().to_vec())).collect()
     }
 
     fn tar_gz(entries: &[(&str, EntryType, &[u8])]) -> Vec<u8> {
@@ -331,7 +331,7 @@ mod tests {
         assert_eq!(serde_json::from_slice::<Value>(&report).unwrap()["deleted"], 1);
         let t = f.state.store.tenant("a").unwrap();
         assert_eq!(t.overlay_stats().0, 1);
-        assert_eq!(t.read_text("src/pages/index.astro").as_deref(), Some("<h1>base</h1>\n"));
+        assert_eq!(t.read_text("src/pages/index.astro").unwrap().as_deref(), Some("<h1>base</h1>\n"));
         assert!(!f.root.join("data/a/files/src/pages/index.astro").exists());
     }
 

--- a/src/http/chats.rs
+++ b/src/http/chats.rs
@@ -6,7 +6,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 use std::io;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::RwLock;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -172,13 +172,17 @@ impl Chats {
         self.cap
     }
 
-    pub fn load(&self, t: &Tenant, id: &str) -> Option<Conversation> {
+    /// `Ok(None)` is a chat that is not there; `Err` is one that is and could not be read back.
+    /// Answering "unknown chat" for the second loses a conversation the caller still has.
+    pub fn load(&self, t: &Tenant, id: &str) -> io::Result<Option<Conversation>> {
         if !valid_id(id) {
-            return None;
+            return Ok(None);
         }
-        match dir(t) {
-            Some(dir) => serde_json::from_slice(&std::fs::read(dir.join(format!("{id}.json"))).ok()?).ok(),
-            None => self.mem.read().unwrap().get(&t.id)?.get(id).cloned(),
+        let Some(dir) = dir(t) else { return Ok(self.mem.read().unwrap().get(&t.id).and_then(|m| m.get(id)).cloned()) };
+        match std::fs::read(dir.join(format!("{id}.json"))) {
+            Ok(raw) => serde_json::from_slice(&raw).map(Some).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e)),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e),
         }
     }
 
@@ -192,68 +196,74 @@ impl Chats {
                 self.mem.write().unwrap().entry(t.id.clone()).or_default().insert(chat.id.clone(), chat.clone());
             }
         }
-        self.evict(t, &chat.id);
-        Ok(())
+        self.evict(t, &chat.id)
     }
 
     /// Brings the tenant back under the cap after a save. The count is taken first because it
     /// costs one `read_dir`, where choosing what to drop costs a parse of every conversation.
-    fn evict(&self, t: &Tenant, saved: &str) {
-        if self.count(t) <= self.cap {
-            return;
+    fn evict(&self, t: &Tenant, saved: &str) -> io::Result<()> {
+        if self.count(t)? <= self.cap {
+            return Ok(());
         }
-        for id in evictable(&self.list(t), self.cap, saved) {
-            self.delete(t, &id);
+        for id in evictable(&self.list(t)?, self.cap, saved) {
+            self.delete(t, &id)?;
         }
+        Ok(())
     }
 
-    fn count(&self, t: &Tenant) -> usize {
+    fn count(&self, t: &Tenant) -> io::Result<usize> {
         match dir(t) {
-            Some(dir) => std::fs::read_dir(dir).into_iter().flatten().flatten().filter(is_chat_file).count(),
-            None => self.mem.read().unwrap().get(&t.id).map_or(0, BTreeMap::len),
+            Some(dir) => Ok(chat_files(&dir)?.len()),
+            None => Ok(self.mem.read().unwrap().get(&t.id).map_or(0, BTreeMap::len)),
         }
     }
 
     /// What the tenant's conversations hold: the size of the files under `<data-dir>/<id>/chats/`,
     /// or what the in-memory ones would serialize to.
-    pub fn usage(&self, t: &Tenant) -> (usize, u64) {
+    pub fn usage(&self, t: &Tenant) -> io::Result<(usize, u64)> {
         match dir(t) {
-            Some(dir) => std::fs::read_dir(dir)
-                .into_iter()
-                .flatten()
-                .flatten()
-                .filter(is_chat_file)
-                .filter_map(|e| e.metadata().ok())
-                .fold((0, 0), |(n, bytes), m| (n + 1, bytes + m.len())),
-            None => self.mem.read().unwrap().get(&t.id).map_or((0, 0), |m| {
+            Some(dir) => {
+                let mut out = (0usize, 0u64);
+                for entry in chat_files(&dir)? {
+                    out = (out.0 + 1, out.1 + entry.metadata()?.len());
+                }
+                Ok(out)
+            }
+            None => Ok(self.mem.read().unwrap().get(&t.id).map_or((0, 0), |m| {
                 m.values().fold((0, 0), |(n, bytes), c| (n + 1, bytes + serde_json::to_vec(c).map_or(0, |v| v.len() as u64)))
-            }),
+            })),
         }
     }
 
-    /// Newest first.
-    pub fn list(&self, t: &Tenant) -> Vec<Conversation> {
+    /// Newest first. A conversation file that cannot be read fails the listing rather than
+    /// disappearing from it: a short list looks exactly like a tenant that had fewer chats.
+    pub fn list(&self, t: &Tenant) -> io::Result<Vec<Conversation>> {
         let mut all: Vec<Conversation> = match dir(t) {
-            Some(dir) => std::fs::read_dir(dir)
-                .into_iter()
-                .flatten()
-                .flatten()
-                .filter(is_chat_file)
-                .filter_map(|e| serde_json::from_slice(&std::fs::read(e.path()).ok()?).ok())
-                .collect(),
+            Some(dir) => {
+                let mut out = Vec::new();
+                for entry in chat_files(&dir)? {
+                    let raw = std::fs::read(entry.path())?;
+                    out.push(serde_json::from_slice(&raw).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?);
+                }
+                out
+            }
             None => self.mem.read().unwrap().get(&t.id).map(|m| m.values().cloned().collect()).unwrap_or_default(),
         };
         all.sort_by(|a, b| b.updated.cmp(&a.updated).then_with(|| a.id.cmp(&b.id)));
-        all
+        Ok(all)
     }
 
-    pub fn delete(&self, t: &Tenant, id: &str) -> bool {
+    /// `Ok(false)` is a chat that was not there. An `Err` is a chat still there after a delete that
+    /// answered 204.
+    pub fn delete(&self, t: &Tenant, id: &str) -> io::Result<bool> {
         if !valid_id(id) {
-            return false;
+            return Ok(false);
         }
-        match dir(t) {
-            Some(dir) => std::fs::remove_file(dir.join(format!("{id}.json"))).is_ok(),
-            None => self.mem.write().unwrap().get_mut(&t.id).is_some_and(|m| m.remove(id).is_some()),
+        let Some(dir) = dir(t) else { return Ok(self.mem.write().unwrap().get_mut(&t.id).is_some_and(|m| m.remove(id).is_some())) };
+        match std::fs::remove_file(dir.join(format!("{id}.json"))) {
+            Ok(()) => Ok(true),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(false),
+            Err(e) => Err(e),
         }
     }
 
@@ -269,6 +279,25 @@ fn dir(t: &Tenant) -> Option<PathBuf> {
 
 fn is_chat_file(e: &std::fs::DirEntry) -> bool {
     e.file_name().to_string_lossy().ends_with(".json")
+}
+
+/// A tenant that has never been chatted with has no `chats/` directory, which is an empty listing.
+/// Anything else that stops the directory being read is not one, and must not be counted as one:
+/// a zero here silently stops the cap being enforced and understates what the tenant is holding.
+fn chat_files(dir: &Path) -> io::Result<Vec<std::fs::DirEntry>> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e),
+    };
+    let mut out = Vec::new();
+    for entry in entries {
+        let entry = entry?;
+        if is_chat_file(&entry) {
+            out.push(entry);
+        }
+    }
+    Ok(out)
 }
 
 fn now_millis() -> u64 {
@@ -293,7 +322,10 @@ pub async fn list(AxState(st): AxState<State>, AxPath(id): AxPath<String>) -> Re
         Ok(t) => t,
         Err(r) => return r,
     };
-    Json(json!({ "chats": st.chats.list(&t).iter().map(Conversation::brief).collect::<Vec<_>>() })).into_response()
+    match st.chats.list(&t) {
+        Ok(all) => Json(json!({ "chats": all.iter().map(Conversation::brief).collect::<Vec<_>>() })).into_response(),
+        Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
+    }
 }
 
 pub async fn get(AxState(st): AxState<State>, AxPath((id, chat)): AxPath<(String, String)>) -> Response {
@@ -302,8 +334,9 @@ pub async fn get(AxState(st): AxState<State>, AxPath((id, chat)): AxPath<(String
         Err(r) => return r,
     };
     match st.chats.load(&t, &chat) {
-        Some(c) => Json(c).into_response(),
-        None => err(StatusCode::NOT_FOUND, "unknown chat"),
+        Ok(Some(c)) => Json(c).into_response(),
+        Ok(None) => err(StatusCode::NOT_FOUND, "unknown chat"),
+        Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
     }
 }
 
@@ -312,7 +345,11 @@ pub async fn remove(AxState(st): AxState<State>, AxPath((id, chat)): AxPath<(Str
         Ok(t) => t,
         Err(r) => return r,
     };
-    if st.chats.delete(&t, &chat) { StatusCode::NO_CONTENT.into_response() } else { err(StatusCode::NOT_FOUND, "unknown chat") }
+    match st.chats.delete(&t, &chat) {
+        Ok(true) => StatusCode::NO_CONTENT.into_response(),
+        Ok(false) => err(StatusCode::NOT_FOUND, "unknown chat"),
+        Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
+    }
 }
 
 #[cfg(test)]
@@ -468,12 +505,12 @@ mod tests {
                 let mut c = conversation(&format!("c{i}"), 2);
                 c.updated = 1000 + i as u64;
                 chats.save(&t, &c).unwrap();
-                assert!(chats.list(&t).len() <= 3, "persist={persist}, after {i}");
+                assert!(chats.list(&t).unwrap().len() <= 3, "persist={persist}, after {i}");
             }
-            let left: Vec<String> = chats.list(&t).into_iter().map(|c| c.id).collect();
+            let left: Vec<String> = chats.list(&t).unwrap().into_iter().map(|c| c.id).collect();
             assert_eq!(left, ["c5", "c4", "c3"], "persist={persist}");
-            assert!(chats.load(&t, "c0").is_none(), "persist={persist}");
-            let (count, bytes) = chats.usage(&t);
+            assert!(chats.load(&t, "c0").unwrap().is_none(), "persist={persist}");
+            let (count, bytes) = chats.usage(&t).unwrap();
             assert_eq!(count, 3, "persist={persist}");
             assert!(bytes > 0, "persist={persist}");
             let _ = std::fs::remove_dir_all(&root);
@@ -483,7 +520,7 @@ mod tests {
     #[test]
     fn usage_is_zero_for_a_tenant_that_has_never_chatted() {
         let (t, root) = tenant(true);
-        assert_eq!(Chats::default().usage(&t), (0, 0));
+        assert_eq!(Chats::default().usage(&t).unwrap(), (0, 0));
         let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -383,7 +383,7 @@ mod tests {
         let (status, body) = post(&app, "/api/bases/theme/reload", "").await;
         assert_eq!(status, StatusCode::OK, "{body}");
         assert!(body.contains(r#""tenants":["acme"]"#), "{body}");
-        assert_eq!(t.read_text("src/pages/index.astro").as_deref(), Some("<h1>two</h1>\n"));
+        assert_eq!(t.read_text("src/pages/index.astro").unwrap().as_deref(), Some("<h1>two</h1>\n"));
         assert!(t.version() > version);
         assert_eq!(post(&app, "/api/bases/nope/reload", "").await.0, StatusCode::NOT_FOUND);
         std::fs::remove_dir_all(&root).unwrap();

--- a/src/http/preview.rs
+++ b/src/http/preview.rs
@@ -71,7 +71,7 @@ async fn module_response(st: &State, id: &TenantId, path: String, query: &str, k
     let versioned = query.split('&').any(|p| p.starts_with("v="));
     let st2 = st.clone();
     let result = tokio::task::spawn_blocking(move || {
-        let resolver = Resolver::new(&t, &st2.engine.cfg.cdn, t.version());
+        let resolver = Resolver::new(&t, &st2.engine.cfg.cdn, t.version()).map_err(|e| BuildError::compile(e, vec![]))?;
         st2.engine.serve(&t, &path, kind, &resolver)
     })
     .await;
@@ -90,9 +90,13 @@ pub async fn raw(AxState(st): AxState<State>, Extension(id): Extension<TenantId>
         Err(r) => return r,
     };
     let Some(path) = clean_path(&path) else { return err(StatusCode::BAD_REQUEST, "bad path") };
-    match t.read(&path).filter(|_| !is_private_path(&path)) {
-        Some(bytes) => ([(header::CONTENT_TYPE, mime(&path)), (header::CACHE_CONTROL, "no-cache")], bytes.to_vec()).into_response(),
-        None => err(StatusCode::NOT_FOUND, format!("{path}: not found")),
+    if is_private_path(&path) {
+        return err(StatusCode::NOT_FOUND, format!("{path}: not found"));
+    }
+    match t.read(&path) {
+        Ok(Some(bytes)) => ([(header::CONTENT_TYPE, mime(&path)), (header::CACHE_CONTROL, "no-cache")], bytes.to_vec()).into_response(),
+        Ok(None) => err(StatusCode::NOT_FOUND, format!("{path}: not found")),
+        Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, format!("{path}: {e}")),
     }
 }
 
@@ -104,9 +108,13 @@ pub async fn routes_json(AxState(st): AxState<State>, Extension(id): Extension<T
 }
 
 pub async fn renderers_json(AxState(st): AxState<State>, Extension(id): Extension<TenantId>) -> Response {
-    match tenant(&st, &id) {
-        Ok(t) => ([(header::CACHE_CONTROL, "no-cache")], Json(renderers(&t, &st.engine.cfg.cdn))).into_response(),
-        Err(r) => r,
+    let t = match tenant(&st, &id) {
+        Ok(t) => t,
+        Err(r) => return r,
+    };
+    match renderers(&t, &st.engine.cfg.cdn) {
+        Ok(list) => ([(header::CACHE_CONTROL, "no-cache")], Json(list)).into_response(),
+        Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, e),
     }
 }
 
@@ -123,10 +131,15 @@ pub async fn check(AxState(st): AxState<State>, Extension(id): Extension<TenantI
         Err(r) => return r,
     };
     let st2 = st.clone();
-    let out = tokio::task::spawn_blocking(move || check_tenant(&st2, &t)).await.unwrap_or_else(|e| json!({ "error": e.to_string() }));
+    let out = match tokio::task::spawn_blocking(move || check_tenant(&st2, &t)).await {
+        Ok(out) => out,
+        Err(e) => return err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
+    };
     ([(header::CACHE_CONTROL, "no-store")], Json(out)).into_response()
 }
 
+/// Issue #48: every way this can fail answers 500 with the diagnostic. An empty collection is a
+/// tenant with no entries, and a page rendered from one looks exactly like a page that is right.
 pub async fn content(AxState(st): AxState<State>, Extension(id): Extension<TenantId>, Path(name): Path<String>) -> Response {
     let t = match tenant(&st, &id) {
         Ok(t) => t,
@@ -136,25 +149,31 @@ pub async fn content(AxState(st): AxState<State>, Extension(id): Extension<Tenan
         return err(StatusCode::BAD_REQUEST, "bad collection name");
     }
     let st2 = st.clone();
-    let out = tokio::task::spawn_blocking(move || {
+    let collection = name.clone();
+    let joined = tokio::task::spawn_blocking(move || {
         let max = st2.engine.cfg.max_source_bytes;
-        st2.engine.on_parser_stack(move || content::collection_json(&t, &name, max))
+        st2.engine.on_parser_stack(move || content::collection_json(&t, &collection, max))
     })
     .await;
-    let out = out.ok().and_then(Result::ok).unwrap_or_else(content::empty_collection);
+    let out = match joined {
+        Ok(Ok(Ok(out))) => out,
+        Ok(Ok(Err(e))) => return build_error(e),
+        Ok(Err(e)) => return err(StatusCode::INTERNAL_SERVER_ERROR, format!("{name}: cannot start a compiler thread: {e}")),
+        Err(e) => return err(StatusCode::INTERNAL_SERVER_ERROR, format!("{name}: {e}")),
+    };
     ([(header::CACHE_CONTROL, "no-cache")], Json(out)).into_response()
 }
 
-fn env_map(t: &Tenant) -> Map<String, Value> {
+fn env_map(t: &Tenant) -> Result<Map<String, Value>, String> {
     let mut env = Map::new();
     env.insert("DEV".into(), json!(true));
     env.insert("PROD".into(), json!(false));
     env.insert("MODE".into(), json!("development"));
     env.insert("SSR".into(), json!(true));
     env.insert("BASE_URL".into(), json!("/"));
-    env.insert("SITE".into(), crate::resolve::tenant_site(t).map(Value::String).unwrap_or(Value::Null));
+    env.insert("SITE".into(), crate::resolve::tenant_site(t)?.map(Value::String).unwrap_or(Value::Null));
     env.insert("ASSETS_PREFIX".into(), Value::Null);
-    if let Some(dotenv) = t.read_text(".env") {
+    if let Some(dotenv) = t.read_text(".env").map_err(|e| format!(".env: {e}"))? {
         for line in dotenv.lines() {
             let line = line.trim();
             if line.starts_with('#') {
@@ -169,7 +188,7 @@ fn env_map(t: &Tenant) -> Map<String, Value> {
             env.insert(k.to_string(), Value::String(v.to_string()));
         }
     }
-    env
+    Ok(env)
 }
 
 pub async fn shim(AxState(st): AxState<State>, Extension(id): Extension<TenantId>, Path(name): Path<String>) -> Response {
@@ -178,7 +197,10 @@ pub async fn shim(AxState(st): AxState<State>, Extension(id): Extension<TenantId
         Err(r) => return r,
     };
     let Some(name) = name.strip_suffix(".js") else { return err(StatusCode::NOT_FOUND, "no such shim") };
-    let resolver = Resolver::new(&t, &st.engine.cfg.cdn, t.version());
+    let resolver = match Resolver::new(&t, &st.engine.cfg.cdn, t.version()) {
+        Ok(r) => r,
+        Err(e) => return err(StatusCode::INTERNAL_SERVER_ERROR, e),
+    };
     let body: String = match name {
         "astro-content" => include_str!("../../assets/shims/astro-content.js").into(),
         "astro-assets" => include_str!("../../assets/shims/astro-assets.js").into(),
@@ -197,9 +219,15 @@ pub async fn shim(AxState(st): AxState<State>, Extension(id): Extension<TenantId
         "renderer-svelte" => include_str!("../../assets/shims/renderer-svelte.js").into(),
         "renderer-svelte-client" => include_str!("../../assets/shims/renderer-svelte-client.js").into(),
         // The loaders build blob modules, whose bare specifiers no resolver sees, so their URLs are baked in.
-        "vue-loader" => include_str!("../../assets/shims/vue-loader.js")
-            .replace("%VUE_COMPILER%", &crate::resolve::vue_compiler_url(&t, &st.engine.cfg.cdn))
-            .replace("%VUE%", &resolver.resolve("", "vue")),
+        "vue-loader" => {
+            let compiler = match crate::resolve::vue_compiler_url(&t, &st.engine.cfg.cdn) {
+                Ok(url) => url,
+                Err(e) => return err(StatusCode::INTERNAL_SERVER_ERROR, e),
+            };
+            include_str!("../../assets/shims/vue-loader.js")
+                .replace("%VUE_COMPILER%", &compiler)
+                .replace("%VUE%", &resolver.resolve("", "vue"))
+        }
         "svelte-loader" => include_str!("../../assets/shims/svelte-loader.js").replace("%SVELTE%", &resolver.resolve("", "svelte")),
         "astro-config" => include_str!("../../assets/shims/astro-config.js").into(),
         "astro-loaders" => include_str!("../../assets/shims/astro-loaders.js").into(),
@@ -208,7 +236,11 @@ pub async fn shim(AxState(st): AxState<State>, Extension(id): Extension<TenantId
         "viewtransitions-css" => css::to_module("astro:viewtransitions", VIEW_TRANSITIONS_CSS, ""),
         "astro-env-client" | "astro-env-server" => {
             let mut out = String::new();
-            for (k, v) in env_map(&t) {
+            let env = match env_map(&t) {
+                Ok(env) => env,
+                Err(e) => return err(StatusCode::INTERNAL_SERVER_ERROR, e),
+            };
+            for (k, v) in env {
                 if k.starts_with("PUBLIC_") {
                     out.push_str(&format!("export const {k} = {v};\n"));
                 }
@@ -282,11 +314,18 @@ pub async fn page(AxState(st): AxState<State>, Extension(id): Extension<TenantId
     let decoded = percent_decode(uri.path());
     if let Some(rel) = clean_path(&decoded).filter(|rel| !is_private_path(rel)) {
         let public = format!("public/{rel}");
-        if let Some(bytes) = t.read(&public) {
-            return ([(header::CONTENT_TYPE, mime(&public)), (header::CACHE_CONTROL, "no-cache")], bytes.to_vec()).into_response();
+        match t.read(&public) {
+            Ok(Some(bytes)) => {
+                return ([(header::CONTENT_TYPE, mime(&public)), (header::CACHE_CONTROL, "no-cache")], bytes.to_vec()).into_response();
+            }
+            Ok(None) => {}
+            Err(e) => return err(StatusCode::INTERNAL_SERVER_ERROR, format!("{public}: {e}")),
         }
     }
-    let env = Value::Object(env_map(&t)).to_string().replace('<', "\\u003c");
+    let env = match env_map(&t) {
+        Ok(env) => Value::Object(env).to_string().replace('<', "\\u003c"),
+        Err(e) => return err(StatusCode::INTERNAL_SERVER_ERROR, e),
+    };
     let token = st.preview_secret.as_deref().map(|s| super::preview_token(s, &t.id)).unwrap_or_default();
     let token_query = if token.is_empty() { String::new() } else { format!("?sl_token={token}") };
     let html = SHELL_HTML
@@ -301,7 +340,20 @@ pub async fn page(AxState(st): AxState<State>, Extension(id): Extension<TenantId
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+    use std::sync::Arc;
+    use std::time::Instant;
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use serde_json::Value;
+    use tower::ServiceExt;
+
     use super::percent_decode;
+    use crate::http::{AppState, SameSite, app, chats};
+    use crate::metrics::Metrics;
+    use crate::store::{Base, Store, UpdateKind};
+    use crate::transform::{Config, Engine};
 
     #[test]
     fn percent_decode_takes_any_string() {
@@ -310,5 +362,60 @@ mod tests {
         assert_eq!(percent_decode("%C3%A9%"), "é%");
         assert_eq!(percent_decode("%+1%-1%2"), "%+1%-1%2");
         assert_eq!(percent_decode("%FF"), "\u{fffd}");
+    }
+
+    fn starter_app(files: &[(&str, &str)]) -> axum::Router {
+        let metrics = Arc::new(Metrics::default());
+        let store = Store::new(None, u64::MAX);
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("examples/starter");
+        store.add_base(Base::load("starter", &root).unwrap());
+        let t = store.create_tenant("acme", "starter").unwrap();
+        for (path, body) in files {
+            t.write(path, body.as_bytes().to_vec(), UpdateKind::from_path(path)).unwrap();
+        }
+        app(Arc::new(AppState {
+            store,
+            engine: Engine::new(Config { cache_bytes: 1 << 20, ..Config::default() }, metrics.clone()),
+            metrics,
+            chats: chats::Chats::default(),
+            shots: crate::http::ai::Shots::default(),
+            domain: "localhost".into(),
+            port: 4321,
+            model: "m".into(),
+            api_key: None,
+            api_base: "http://127.0.0.1:1".into(),
+            api_token: None,
+            preview_secret: None,
+            cookie_samesite: SameSite::Lax,
+            chrome: None,
+            started: Instant::now(),
+        }))
+    }
+
+    async fn collection(app: &axum::Router, name: &str) -> (StatusCode, Value) {
+        let req = Request::builder().uri(format!("/__sl/content/{name}")).header("host", "acme.localhost").body(Body::empty()).unwrap();
+        let res = app.clone().oneshot(req).await.unwrap();
+        let status = res.status();
+        let body = axum::body::to_bytes(res.into_body(), usize::MAX).await.unwrap();
+        (status, serde_json::from_slice(&body).unwrap())
+    }
+
+    #[tokio::test]
+    async fn a_collection_that_builds_is_served() {
+        let (status, body) = collection(&starter_app(&[]), "posts").await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(!body["entries"].as_array().unwrap().is_empty());
+    }
+
+    /// Issue #48: this answered 200 with `{"entries": []}`, and the page then rendered as a tenant
+    /// with no posts — a wrong answer wearing the shape of a right one.
+    #[tokio::test]
+    async fn a_collection_that_fails_to_build_is_a_500_with_the_diagnostic() {
+        let app = starter_app(&[("src/content/posts/bad.md", "---\ntitle: \"unterminated\n---\nbody\n")]);
+        let (status, body) = collection(&app, "posts").await;
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert!(body["error"].as_str().unwrap().contains("src/content/posts/bad.md"), "{body}");
+        assert_eq!(body["diagnostics"][0]["file"], "src/content/posts/bad.md");
+        assert_eq!(body["diagnostics"][0]["severity"], "error");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,8 @@ mod transform;
 
 #[cfg(test)]
 mod proptests;
+#[cfg(test)]
+mod silent_failures;
 
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/src/proptests.rs
+++ b/src/proptests.rs
@@ -202,7 +202,8 @@ proptest! {
 
     #[test]
     fn tsconfig_targets_stay_inside_the_tenant(text in prop_oneof![input(), tsconfig()]) {
-        let aliases = tsconfig_paths(&text);
+        // Junk that does not parse is refused rather than read as no aliases; what it does parse to has to hold.
+        let Ok(aliases) = tsconfig_paths(&text) else { return Ok(()) };
         for (key, target) in &aliases {
             prop_assert!(!key.ends_with('*'));
             assert_inside_tenant(target.strip_suffix('/').unwrap_or(target))?;
@@ -214,12 +215,14 @@ proptest! {
     fn import_map_keeps_every_string_entry(entries in prop::collection::vec((short(), short()), 0..4), junk in input()) {
         let map: Map<String, Value> = entries.into_iter().map(|(k, v)| (k, Value::String(v))).collect();
         let mut want: Vec<(String, String)> = map.iter().map(|(k, v)| (k.clone(), v.as_str().unwrap_or_default().to_string())).collect();
-        let mut got = import_map(&json!({ "imports": map, "site": junk }).to_string());
+        let mut got = import_map(&json!({ "imports": map, "site": junk }).to_string()).unwrap();
         prop_assert!(longest_key_first(&got));
         got.sort();
         want.sort();
         prop_assert_eq!(got, want);
-        prop_assert!(longest_key_first(&import_map(&junk)));
+        if let Ok(m) = import_map(&junk) {
+            prop_assert!(longest_key_first(&m));
+        }
     }
 
     #[test]
@@ -279,9 +282,11 @@ proptest! {
             prop_assert!(s.starts_with("---") && s.contains(fm));
             prop_assert!(fm.len() + body.len() + 7 <= s.len());
         }
-        let md = parse_markdown(&src);
-        prop_assert!(md.frontmatter.is_object());
-        prop_assert_eq!(md.body.as_str(), body);
+        // Frontmatter that is not a YAML mapping is refused; whatever is accepted is still an object.
+        if let Ok(md) = parse_markdown(&src) {
+            prop_assert!(md.frontmatter.is_object());
+            prop_assert_eq!(md.body.as_str(), body);
+        }
     }
 
     #[test]
@@ -295,8 +300,10 @@ proptest! {
     }
 
     #[test]
-    fn yaml_to_json_is_always_an_object(yaml in prop_oneof![input(), yaml()]) {
-        prop_assert!(yaml_to_json(&yaml).is_object());
+    fn yaml_to_json_is_an_object_whenever_it_answers(yaml in prop_oneof![input(), yaml()]) {
+        if let Ok(v) = yaml_to_json(&yaml) {
+            prop_assert!(v.is_object());
+        }
     }
 
     #[test]

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -4,6 +4,10 @@ pub const SHIM_PREFIX: &str = "/__sl/shim/";
 const EXTS: &[&str] = &["", ".ts", ".tsx", ".js", ".jsx", ".mjs", ".mts", ".json", ".astro", ".md", ".mdx", ".vue", ".svelte"];
 const INDEX: &[&str] = &["/index.ts", "/index.tsx", "/index.js", "/index.jsx", "/index.mjs", "/index.astro"];
 
+fn read_config(tenant: &Tenant, path: &str) -> Result<Option<String>, String> {
+    tenant.read_text(path).map_err(|e| format!("{path}: {e}"))
+}
+
 pub struct Resolver<'a> {
     tenant: &'a Tenant,
     cdn: &'a str,
@@ -14,11 +18,14 @@ pub struct Resolver<'a> {
 }
 
 impl<'a> Resolver<'a> {
-    pub fn new(tenant: &'a Tenant, cdn: &'a str, version: u64) -> Self {
-        let aliases = tenant.read_text("tsconfig.json").map(|t| tsconfig_paths(&t)).unwrap_or_default();
-        let imports = tenant.read_text("sandbox-lite.json").map(|t| import_map(&t)).unwrap_or_default();
-        let deps = package_deps(tenant);
-        Resolver { tenant, cdn, version, aliases, imports, deps }
+    /// A config file the tenant does not have is no aliases and no import map. One it has that does
+    /// not parse is refused: dropped, every specifier it would have redirected silently resolves to
+    /// a CDN URL instead of the tenant's own file.
+    pub fn new(tenant: &'a Tenant, cdn: &'a str, version: u64) -> Result<Self, String> {
+        let aliases = read_config(tenant, "tsconfig.json")?.map(|t| tsconfig_paths(&t)).transpose()?.unwrap_or_default();
+        let imports = read_config(tenant, "sandbox-lite.json")?.map(|t| import_map(&t)).transpose()?.unwrap_or_default();
+        let deps = package_deps(tenant)?;
+        Ok(Resolver { tenant, cdn, version, aliases, imports, deps })
     }
 
     pub fn version(&self) -> u64 {
@@ -126,9 +133,9 @@ pub fn package_name(spec: &str) -> (&str, &str) {
     if idx == 0 { (spec, "") } else { (&spec[..idx], &spec[idx..]) }
 }
 
-pub fn package_deps(tenant: &Tenant) -> Vec<(String, String)> {
-    let Some(text) = tenant.read_text("package.json") else { return vec![] };
-    let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) else { return vec![] };
+pub fn package_deps(tenant: &Tenant) -> Result<Vec<(String, String)>, String> {
+    let Some(text) = read_config(tenant, "package.json")? else { return Ok(vec![]) };
+    let json: serde_json::Value = serde_json::from_str(&text).map_err(|e| format!("package.json: {e}"))?;
     let mut out = Vec::new();
     for key in ["dependencies", "devDependencies"] {
         if let Some(map) = json.get(key).and_then(|d| d.as_object()) {
@@ -139,7 +146,7 @@ pub fn package_deps(tenant: &Tenant) -> Vec<(String, String)> {
             }
         }
     }
-    out
+    Ok(out)
 }
 
 #[derive(serde::Serialize, Clone, Debug)]
@@ -150,8 +157,8 @@ pub struct RendererCfg {
 }
 
 /// Framework renderers the preview should register, from package.json integrations and `sandbox-lite.json`.
-pub fn renderers(tenant: &Tenant, cdn: &str) -> Vec<RendererCfg> {
-    let deps = package_deps(tenant);
+pub fn renderers(tenant: &Tenant, cdn: &str) -> Result<Vec<RendererCfg>, String> {
+    let deps = package_deps(tenant)?;
     let range = |name: &str| deps.iter().find(|(n, _)| n == name).map(|(_, r)| r.clone());
     let mut out = Vec::new();
     if let Some(r) = range("@astrojs/react") {
@@ -187,8 +194,7 @@ pub fn renderers(tenant: &Tenant, cdn: &str) -> Vec<RendererCfg> {
             client: Some(shim_url("renderer-svelte-client")),
         });
     }
-    if let Some(text) = tenant.read_text("sandbox-lite.json")
-        && let Ok(json) = serde_json::from_str::<serde_json::Value>(&strip_jsonc(&text))
+    if let Some(json) = sandbox_lite_json(tenant)?
         && let Some(list) = json.get("renderers").and_then(|r| r.as_array())
     {
         for item in list {
@@ -204,24 +210,31 @@ pub fn renderers(tenant: &Tenant, cdn: &str) -> Vec<RendererCfg> {
             });
         }
     }
-    out
+    Ok(out)
 }
 
 /// `@vue/compiler-sfc` must match the `vue` it compiles for, and an Astro project never lists it.
-pub fn vue_compiler_url(tenant: &Tenant, cdn: &str) -> String {
-    let deps = package_deps(tenant);
+pub fn vue_compiler_url(tenant: &Tenant, cdn: &str) -> Result<String, String> {
+    let deps = package_deps(tenant)?;
     let range = deps.iter().find(|(n, _)| n == "@vue/compiler-sfc").or_else(|| deps.iter().find(|(n, _)| n == "vue"));
     let spec = match range {
         Some((_, r)) if !r.is_empty() && !r.contains(':') && !r.starts_with("file") => format!("@vue/compiler-sfc@{r}"),
         _ => "@vue/compiler-sfc".to_string(),
     };
-    format!("{}/{spec}", cdn.trim_end_matches('/'))
+    Ok(format!("{}/{spec}", cdn.trim_end_matches('/')))
 }
 
-pub fn tenant_site(tenant: &Tenant) -> Option<String> {
-    let text = tenant.read_text("sandbox-lite.json")?;
-    let json: serde_json::Value = serde_json::from_str(&strip_jsonc(&text)).ok()?;
-    json.get("site")?.as_str().map(|s| s.to_string())
+fn sandbox_lite_json(tenant: &Tenant) -> Result<Option<serde_json::Value>, String> {
+    let Some(text) = read_config(tenant, "sandbox-lite.json")? else { return Ok(None) };
+    serde_json::from_str(&strip_jsonc(&text)).map(Some).map_err(|e| format!("sandbox-lite.json: {e}"))
+}
+
+/// `Astro.site`, which the compiler bakes into every module. A `sandbox-lite.json` that does not
+/// parse leaves it undefined, and a canonical URL or an RSS feed built from it is then wrong
+/// without saying so.
+pub fn tenant_site(tenant: &Tenant) -> Result<Option<String>, String> {
+    let Some(json) = sandbox_lite_json(tenant)? else { return Ok(None) };
+    Ok(json.get("site").and_then(|s| s.as_str()).map(|s| s.to_string()))
 }
 
 fn is_external(spec: &str) -> bool {
@@ -351,11 +364,11 @@ pub fn strip_jsonc(text: &str) -> String {
     out
 }
 
-pub(crate) fn tsconfig_paths(text: &str) -> Vec<(String, String)> {
-    let Ok(json) = serde_json::from_str::<serde_json::Value>(&strip_jsonc(text)) else { return vec![] };
-    let Some(co) = json.get("compilerOptions") else { return vec![] };
+pub(crate) fn tsconfig_paths(text: &str) -> Result<Vec<(String, String)>, String> {
+    let json: serde_json::Value = serde_json::from_str(&strip_jsonc(text)).map_err(|e| format!("tsconfig.json: {e}"))?;
+    let Some(co) = json.get("compilerOptions") else { return Ok(vec![]) };
     let base_url = co.get("baseUrl").and_then(|b| b.as_str()).unwrap_or(".");
-    let Some(paths) = co.get("paths").and_then(|p| p.as_object()) else { return vec![] };
+    let Some(paths) = co.get("paths").and_then(|p| p.as_object()) else { return Ok(vec![]) };
     let mut out = Vec::new();
     for (key, targets) in paths {
         let Some(target) = targets.as_array().and_then(|a| a.first()).and_then(|t| t.as_str()) else { continue };
@@ -365,15 +378,15 @@ pub(crate) fn tsconfig_paths(text: &str) -> Vec<(String, String)> {
         out.push((key, target));
     }
     out.sort_by_key(|(k, _)| std::cmp::Reverse(k.len()));
-    out
+    Ok(out)
 }
 
-pub(crate) fn import_map(text: &str) -> Vec<(String, String)> {
-    let Ok(json) = serde_json::from_str::<serde_json::Value>(&strip_jsonc(text)) else { return vec![] };
-    let Some(imports) = json.get("imports").and_then(|p| p.as_object()) else { return vec![] };
+pub(crate) fn import_map(text: &str) -> Result<Vec<(String, String)>, String> {
+    let json: serde_json::Value = serde_json::from_str(&strip_jsonc(text)).map_err(|e| format!("sandbox-lite.json: {e}"))?;
+    let Some(imports) = json.get("imports").and_then(|p| p.as_object()) else { return Ok(vec![]) };
     let mut out: Vec<(String, String)> = imports.iter().filter_map(|(k, v)| v.as_str().map(|v| (k.clone(), v.to_string()))).collect();
     out.sort_by_key(|(k, _)| std::cmp::Reverse(k.len()));
-    out
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -416,8 +429,16 @@ mod tests {
     #[test]
     fn parses_tsconfig_aliases() {
         let t = r#"{"compilerOptions":{"baseUrl":".","paths":{"@/*":["src/*"],"@utils":["./src/utils/index.ts"]}}}"#;
-        let a = tsconfig_paths(t);
+        let a = tsconfig_paths(t).unwrap();
         assert!(a.contains(&("@/".to_string(), "src/".to_string())));
         assert!(a.contains(&("@utils".to_string(), "src/utils/index.ts".to_string())));
+    }
+
+    /// Issue #48: dropped, an alias table that does not parse sends `@/lib/x` to the CDN, where it
+    /// is a package that does not exist — with nothing said about the tsconfig that caused it.
+    #[test]
+    fn a_config_that_does_not_parse_is_an_error() {
+        assert!(tsconfig_paths(r#"{"compilerOptions":{"paths":}"#).is_err());
+        assert!(import_map("{ not json").is_err());
     }
 }

--- a/src/silent_failures.rs
+++ b/src/silent_failures.rs
@@ -1,0 +1,141 @@
+//! Issue #48, made permanent: a check that reads this crate's own source for the shape of that bug
+//! — a fallible operation whose error is thrown away and replaced with a value — on the code that
+//! answers requests.
+//!
+//! The rule is deliberately narrow. `unwrap_or` over an `Option` from string or JSON navigation
+//! (`as_str`, `strip_prefix`, `find`) is not error handling at all, and flagging it would bury the
+//! twenty lines that matter under a hundred that do not. So a line is flagged only when it names a
+//! source that can genuinely fail *and* a form that discards what it failed with. Test code is out
+//! of scope: everything from a file's first `#[cfg(test)]` is skipped.
+//!
+//! `TOLERATED` may only shrink. Each entry carries the reason the default is the right answer
+//! there, and adding one is a decision to be argued for in review — not a way to get to green.
+//!
+//! `DISCARDS` grows when a form gets past it. `Result::into_iter().flatten()` did: it reads as
+//! iteration rather than as error handling, and it is how `Chats::count` and `Chats::usage` turned
+//! a directory that could not be listed into a tenant holding nothing.
+
+use std::path::{Path, PathBuf};
+
+/// Operations whose failure carries information the caller needs.
+const FALLIBLE: [&str; 9] =
+    ["serde_json::from_", "serde_yaml::from_", "std::fs::", "spawn_blocking", "Result::ok", ".read(", "read_text(", ".send(", ".text()"];
+
+/// Forms that answer with a value instead of the failure.
+const DISCARDS: [&str; 7] =
+    ["let _ =", "unwrap_or_default()", "unwrap_or_else(", "unwrap_or(", ".ok()", "is_ok()", "into_iter().flatten()"];
+
+/// Every line the rule catches that is a deliberate fallback, with the reason. Keyed by the line's
+/// text so that moving code around does not silently re-tolerate something else.
+const TOLERATED: [(&str, &str); 8] = [
+    (
+        "if path.ends_with(\".astro\") && tenant.read_text(&path).ok().flatten().is_some_and(|t| scss::uses_sass(&t)) {",
+        "a census counter in `check`; the same file is compiled two lines later and reports the read failure there",
+    ),
+    (
+        "let stderr = std::fs::read_to_string(&log).unwrap_or_default();",
+        "chrome's log, read only to enrich a screenshot failure already being returned; no log is no extra detail",
+    ),
+    (
+        "let _ = tx.send(Ok(Event::default().event(event).data(data.to_string()))).await;",
+        "the SSE receiver is gone because the client disconnected, which is not a failure of the reply",
+    ),
+    (
+        "let body = resp.text().await.unwrap_or_default();",
+        "the body of an upstream response that already failed; its status is what is reported",
+    ),
+    (
+        "return Err(Fail { status: StatusCode::BAD_GATEWAY, error: serde_json::from_str(&body).unwrap_or(Value::String(body)) });",
+        "an upstream error body that is not JSON is passed through verbatim, so the diagnostic survives either way",
+    ),
+    (
+        "let status = std::fs::read_to_string(\"/proc/self/status\").ok()?;",
+        "there is no /proc off Linux; `rss_kb` is an Option and /metrics omits the gauge",
+    ),
+    (
+        "None => self.mem.read().unwrap().get(&t.id).map(|m| m.values().cloned().collect()).unwrap_or_default(),",
+        "an Option: a tenant with no conversations yet genuinely has an empty list",
+    ),
+    ("let _ = self.events.send(format!(", "a broadcast with no subscribers, which is the normal state of a tenant nobody is previewing"),
+];
+
+fn src_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+fn rust_files(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in std::fs::read_dir(dir).expect("src is readable") {
+        let path = entry.expect("a readable directory entry").path();
+        if path.is_dir() {
+            rust_files(&path, out);
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// The lines of `path` before its first `#[cfg(test)]`, as (1-based line number, trimmed text).
+fn production_lines(path: &Path) -> Vec<(usize, String)> {
+    let text = std::fs::read_to_string(path).expect("a readable source file");
+    text.lines()
+        .take_while(|line| !line.trim_start().starts_with("#[cfg(test)]"))
+        .enumerate()
+        .map(|(i, line)| (i + 1, line.trim().to_string()))
+        .collect()
+}
+
+fn is_swallow(line: &str) -> bool {
+    FALLIBLE.iter().any(|f| line.contains(f)) && DISCARDS.iter().any(|d| line.contains(d))
+}
+
+#[test]
+fn no_new_swallowed_failures() {
+    let mut files = Vec::new();
+    rust_files(&src_dir(), &mut files);
+    files.sort();
+    assert!(files.len() > 10, "the walk found only {} files, so it is not reading the crate", files.len());
+
+    let mut found = Vec::new();
+    for path in &files {
+        if path.ends_with("silent_failures.rs") {
+            continue;
+        }
+        for (number, line) in production_lines(path) {
+            if is_swallow(&line) {
+                found.push((path.strip_prefix(src_dir()).unwrap_or(path).display().to_string(), number, line));
+            }
+        }
+    }
+
+    let unexplained: Vec<String> = found
+        .iter()
+        .filter(|(_, _, line)| !TOLERATED.iter().any(|(tolerated, _)| tolerated == line))
+        .map(|(file, number, line)| format!("  {file}:{number}: {line}"))
+        .collect();
+    assert!(
+        unexplained.is_empty(),
+        "these discard a failure on a path that answers a request — turn each into an error the caller \
+         sees, or add it to TOLERATED in src/silent_failures.rs with the reason the default is right:\n{}",
+        unexplained.join("\n")
+    );
+
+    // The list may only shrink: an entry nothing matches any more is a fix that was made, and
+    // leaving it behind lets the next swallow of that shape in without review.
+    let stale: Vec<&str> =
+        TOLERATED.iter().map(|(line, _)| *line).filter(|tolerated| !found.iter().any(|(_, _, line)| line == tolerated)).collect();
+    assert!(stale.is_empty(), "TOLERATED entries that match nothing any more — delete them:\n  {}", stale.join("\n  "));
+}
+
+#[test]
+fn the_rule_catches_the_bug_it_was_written_for() {
+    // src/http/preview.rs before this change, verbatim.
+    assert!(is_swallow("let out = out.ok().and_then(Result::ok).unwrap_or_else(content::empty_collection);"));
+    assert!(is_swallow("let out = tokio::task::spawn_blocking(move || check_tenant(&st2, &t)).await.unwrap_or_else(|e| json!({}));"));
+    assert!(is_swallow("Some(\"yaml\" | \"yml\") => serde_yaml::from_str::<Value>(&text).ok(),"));
+    // src/http/chats.rs as #58 left it: a chats directory that cannot be listed read as no chats,
+    // which stopped the cap being enforced and understated the tenant's usage in /api/stats.
+    assert!(is_swallow("Some(dir) => std::fs::read_dir(dir).into_iter().flatten().flatten().filter(is_chat_file).count(),"));
+    // and not the Option navigation that makes up most of the crate's `unwrap_or`s
+    assert!(!is_swallow("let stem = rest.rsplit_once('.').map(|(s, _)| s).unwrap_or(rest);"));
+    assert!(!is_swallow("let base_url = co.get(\"baseUrl\").and_then(|b| b.as_str()).unwrap_or(\".\");"));
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -282,12 +282,14 @@ impl Tenant {
         self.data(path).is_some()
     }
 
-    pub fn read(&self, path: &str) -> Option<Arc<[u8]>> {
-        self.data(path).and_then(|d| d.read().ok())
+    /// `Ok(None)` is a file the tenant does not have; `Err` is one it has and could not read. A
+    /// `FileData::Disk` entry is re-read on every access, so the two are different answers.
+    pub fn read(&self, path: &str) -> io::Result<Option<Arc<[u8]>>> {
+        self.data(path).map(|d| d.read()).transpose()
     }
 
-    pub fn read_text(&self, path: &str) -> Option<String> {
-        self.read(path).map(|b| String::from_utf8_lossy(&b).into_owned())
+    pub fn read_text(&self, path: &str) -> io::Result<Option<String>> {
+        Ok(self.read(path)?.map(|b| String::from_utf8_lossy(&b).into_owned()))
     }
 
     pub fn list(&self) -> Vec<Entry> {
@@ -458,7 +460,8 @@ impl Tenant {
             overlay.insert(p, Some(d));
         }
         if let Ok(raw) = std::fs::read(dir.join("deleted.json")) {
-            let list: Vec<String> = serde_json::from_slice(&raw).unwrap_or_default();
+            // A tombstone list that is dropped brings deleted files back, which is not the tenant.
+            let list: Vec<String> = serde_json::from_slice(&raw).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
             for p in list {
                 overlay.entry(p).or_insert(None);
             }
@@ -600,7 +603,9 @@ impl Store {
         }
         let dir = data_dir.join(id);
         let meta = std::fs::read(dir.join("tenant.json")).map_err(|e| format!("tenant.json: {e}"))?;
-        let meta: serde_json::Value = serde_json::from_slice(&meta).unwrap_or_default();
+        // Read as null, a tenant.json that does not parse is reported as an unloaded base '' rather
+        // than as the unreadable file it is.
+        let meta: serde_json::Value = serde_json::from_slice(&meta).map_err(|e| format!("tenant.json does not parse: {e}"))?;
         let base_name = meta.get("base").and_then(|b| b.as_str()).unwrap_or("");
         let base = self.base(base_name).ok_or_else(|| format!("base '{base_name}' is not loaded"))?;
         let tenant = Tenant::new(id.to_string(), base, Some(dir.clone()), self.tenant_quota);
@@ -614,16 +619,17 @@ impl Store {
         v
     }
 
-    pub fn remove_tenant(&self, id: &str) -> bool {
-        let removed = self.tenants.write().unwrap().remove(id);
-        if let Some(t) = removed {
-            if let Some(dir) = &t.dir {
-                let _ = std::fs::remove_dir_all(dir);
-            }
-            true
-        } else {
-            false
+    /// `Ok(false)` is a tenant that was not there. A data directory that survives the delete is an
+    /// error: it answered 204 and the tenant comes back at the next restore.
+    pub fn remove_tenant(&self, id: &str) -> io::Result<bool> {
+        let Some(t) = self.tenants.write().unwrap().remove(id) else { return Ok(false) };
+        if let Some(dir) = &t.dir
+            && let Err(e) = std::fs::remove_dir_all(dir)
+            && e.kind() != io::ErrorKind::NotFound
+        {
+            return Err(e);
         }
+        Ok(true)
     }
 
     pub fn restore(&self) -> io::Result<usize> {
@@ -691,10 +697,10 @@ mod tests {
         let (base, repointed) = store.reload_base("theme").unwrap().unwrap();
 
         assert_eq!(repointed, vec!["acme".to_string()], "only tenants on that base are re-pointed");
-        assert_eq!(t.read_text(PAGE).as_deref(), Some("<h1>two</h1>\n"));
+        assert_eq!(t.read_text(PAGE).unwrap().as_deref(), Some("<h1>two</h1>\n"));
         assert_eq!(t.base().name, base.name);
         assert!(Arc::ptr_eq(&t.base(), &base), "the tenant holds the fresh base, not a copy of the old one");
-        assert_eq!(t.read_text("src/pages/mine.astro").as_deref(), Some("<h1>mine</h1>"), "the overlay survives a reload");
+        assert_eq!(t.read_text("src/pages/mine.astro").unwrap().as_deref(), Some("<h1>mine</h1>"), "the overlay survives a reload");
         assert!(t.version() > version, "an open preview reloads on the new version");
         assert_eq!(untouched.version(), other_version, "a tenant on another base is not disturbed");
         let event = events.try_recv().unwrap();
@@ -719,7 +725,7 @@ mod tests {
 
         seed(root.join("theme").join(PAGE), "<h1>two, and longer</h1>\n");
         assert_eq!(store.reload_changed_bases(), vec!["theme".to_string()]);
-        assert_eq!(t.read_text(PAGE).as_deref(), Some("<h1>two, and longer</h1>\n"));
+        assert_eq!(t.read_text(PAGE).unwrap().as_deref(), Some("<h1>two, and longer</h1>\n"));
         assert!(store.reload_changed_bases().is_empty(), "the reloaded base is the new stamp");
         std::fs::remove_dir_all(&root).unwrap();
     }
@@ -738,7 +744,7 @@ mod tests {
 
         assert!(b.tenants().is_empty(), "node b learned nothing from node a's write");
         let tb = b.tenant("acme").unwrap();
-        assert_eq!(tb.read_text(PAGE).as_deref(), Some("<h1>from a</h1>"), "the miss restored the tenant from the data dir");
+        assert_eq!(tb.read_text(PAGE).unwrap().as_deref(), Some("<h1>from a</h1>"), "the miss restored the tenant from the data dir");
         assert_eq!(b.tenants().len(), 1);
         assert!(Arc::ptr_eq(&tb, &b.tenant("acme").unwrap()), "a restored tenant is registered, not rebuilt per request");
         assert!(b.tenant("nobody").is_none());
@@ -747,7 +753,7 @@ mod tests {
         // the gap docs/multi-node.md names: node b holds the tenant now, and nothing tells it that
         // node a wrote again. Sticky routing per tenant is what keeps this from being reachable.
         ta.write(PAGE, b"<h1>from a, later</h1>".to_vec(), UpdateKind::Module).unwrap();
-        assert_eq!(tb.read_text(PAGE).as_deref(), Some("<h1>from a</h1>"));
+        assert_eq!(tb.read_text(PAGE).unwrap().as_deref(), Some("<h1>from a</h1>"));
         std::fs::remove_dir_all(&root).unwrap();
     }
 

--- a/src/transform/content.rs
+++ b/src/transform/content.rs
@@ -10,8 +10,25 @@ use pulldown_cmark::{Event, HeadingLevel, Options, Parser, Tag, TagEnd, html};
 use serde::Serialize;
 use serde_json::{Map, Value, json};
 
+use super::{BuildError, Diag};
 use crate::resolve::{join, normalize};
 use crate::store::Tenant;
+
+/// A collection that could not be built answers 500 with this, rather than an empty collection:
+/// a page rendered from no posts looks exactly like a page rendered from a tenant that has none.
+fn failed(file: &str, text: impl Into<String>, hint: &str) -> BuildError {
+    let diag = Diag { severity: "error".into(), text: text.into(), hint: hint.into(), file: file.to_string(), line: 0, column: 0 };
+    BuildError { status: 500, message: format!("{file}: {}", diag.text), diagnostics: vec![diag] }
+}
+
+fn read(tenant: &Tenant, path: &str) -> Result<Option<String>, BuildError> {
+    tenant.read_text(path).map_err(|e| failed(path, e.to_string(), ""))
+}
+
+/// The path came out of `Tenant::list`, so absent here means unreadable, not missing.
+fn read_listed(tenant: &Tenant, path: &str) -> Result<String, BuildError> {
+    read(tenant, path)?.ok_or_else(|| failed(path, "the tenant lists this file but it cannot be read", ""))
+}
 
 #[derive(Serialize, Clone)]
 pub struct Heading {
@@ -45,21 +62,28 @@ pub fn split_frontmatter(src: &str) -> (Option<&str>, &str) {
     (None, src)
 }
 
-pub fn yaml_to_json(yaml: &str) -> Value {
+/// Empty frontmatter is no data; frontmatter that does not parse, or that is not a mapping, is a
+/// file whose data could not be read — served as `{}` it renders a page with every field missing.
+pub fn yaml_to_json(yaml: &str) -> Result<Value, String> {
     if yaml.trim().is_empty() {
-        return Value::Object(Map::new());
+        return Ok(Value::Object(Map::new()));
     }
     match serde_yaml::from_str::<Value>(yaml) {
-        Ok(v @ Value::Object(_)) => v,
-        _ => Value::Object(Map::new()),
+        Ok(v @ Value::Object(_)) => Ok(v),
+        Ok(_) => Err("frontmatter is not a mapping of keys to values".into()),
+        Err(e) => Err(format!("frontmatter is not valid YAML: {e}")),
     }
 }
 
-pub fn parse_markdown(src: &str) -> Md {
+pub fn frontmatter(src: &str) -> Result<(Value, &str), String> {
     let (fm, body) = split_frontmatter(src);
-    let frontmatter = fm.map(yaml_to_json).unwrap_or_else(|| Value::Object(Map::new()));
+    Ok((fm.map(yaml_to_json).transpose()?.unwrap_or_else(|| Value::Object(Map::new())), body))
+}
+
+pub fn parse_markdown(src: &str) -> Result<Md, String> {
+    let (frontmatter, body) = frontmatter(src)?;
     let (html, headings) = render(body);
-    Md { frontmatter, body: body.to_string(), html, headings }
+    Ok(Md { frontmatter, body: body.to_string(), html, headings })
 }
 
 fn render(body: &str) -> (String, Vec<Heading>) {
@@ -113,57 +137,57 @@ pub fn slugify(text: &str) -> String {
     out.trim_end_matches('-').to_string()
 }
 
-pub fn collection_json(tenant: &Tenant, name: &str, max_config_bytes: usize) -> Value {
-    let def = config(tenant, max_config_bytes).remove(name).unwrap_or_default();
+pub fn collection_json(tenant: &Tenant, name: &str, max_config_bytes: usize) -> Result<Value, BuildError> {
+    let (config_path, mut defs) = config(tenant, max_config_bytes)?;
+    let def = defs.remove(name).unwrap_or_default();
+    let config_path = config_path.unwrap_or_else(|| CONFIG_PATHS[0].to_string());
     let entries = match &def.loader {
-        Some(Loader::Glob { patterns, base }) => glob_entries(tenant, name, patterns, base),
-        Some(Loader::File { path }) => file_entries(tenant, name, path),
-        None => dir_entries(tenant, name),
+        Some(Loader::Glob { patterns, base }) => glob_entries(tenant, name, patterns, base, &config_path)?,
+        Some(Loader::File { path }) => file_entries(tenant, name, path, &config_path)?,
+        None => dir_entries(tenant, name)?,
     };
-    json!({ "entries": entries, "dates": def.dates })
+    Ok(json!({ "entries": entries, "dates": def.dates }))
 }
 
-pub fn empty_collection() -> Value {
-    json!({ "entries": [], "dates": Value::Null })
-}
-
-fn dir_entries(tenant: &Tenant, name: &str) -> Vec<Value> {
+fn dir_entries(tenant: &Tenant, name: &str) -> Result<Vec<Value>, BuildError> {
     let prefix = format!("src/content/{name}/");
     let mut entries = Vec::new();
     for e in tenant.list() {
         let Some(id) = e.path.strip_prefix(&prefix).and_then(entry_id) else { continue };
-        push_file(tenant, name, &e.path, &id, &mut entries);
+        push_file(tenant, name, &e.path, &id, &mut entries)?;
     }
-    entries
+    Ok(entries)
 }
 
-fn glob_entries(tenant: &Tenant, name: &str, patterns: &[String], base: &str) -> Vec<Value> {
+fn glob_entries(tenant: &Tenant, name: &str, patterns: &[String], base: &str, config_path: &str) -> Result<Vec<Value>, BuildError> {
     let files: Vec<String> = tenant.list().into_iter().map(|e| e.path).collect();
+    let matched = glob_matches(&files, patterns, base).map_err(|e| failed(config_path, e, "check the collection's glob pattern"))?;
     let mut entries = Vec::new();
-    for (path, id) in glob_matches(&files, patterns, base) {
-        push_file(tenant, name, &path, &id, &mut entries);
+    for (path, id) in matched {
+        push_file(tenant, name, &path, &id, &mut entries)?;
     }
-    entries
+    Ok(entries)
 }
 
 /// The files a glob loader picks up, each with the id Astro derives from its path relative to `base`.
-fn glob_matches(files: &[String], patterns: &[String], base: &str) -> Vec<(String, String)> {
+/// A pattern that does not compile is refused: dropped, it silently narrows the collection.
+fn glob_matches(files: &[String], patterns: &[String], base: &str) -> Result<Vec<(String, String)>, String> {
     let (mut pos, mut neg) = (GlobSetBuilder::new(), GlobSetBuilder::new());
     for p in patterns {
         let (negated, p) = match p.strip_prefix('!') {
             Some(rest) => (true, rest),
             None => (false, p.as_str()),
         };
-        let Ok(g) = GlobBuilder::new(&join(base, p)).literal_separator(true).build() else { continue };
+        let g = GlobBuilder::new(&join(base, p)).literal_separator(true).build().map_err(|e| format!("pattern '{p}': {e}"))?;
         if negated { &mut neg } else { &mut pos }.add(g);
     }
-    let (Ok(pos), Ok(neg)): (Result<GlobSet, _>, Result<GlobSet, _>) = (pos.build(), neg.build()) else { return Vec::new() };
+    let (pos, neg): (GlobSet, GlobSet) = (pos.build().map_err(|e| e.to_string())?, neg.build().map_err(|e| e.to_string())?);
     let prefix = if base.is_empty() { String::new() } else { format!("{base}/") };
-    files
+    Ok(files
         .iter()
         .filter(|p| pos.is_match(p.as_str()) && !neg.is_match(p.as_str()))
         .filter_map(|p| Some((p.clone(), entry_id(p.strip_prefix(prefix.as_str())?)?)))
-        .collect()
+        .collect())
 }
 
 fn entry_id(relative: &str) -> Option<String> {
@@ -171,18 +195,20 @@ fn entry_id(relative: &str) -> Option<String> {
     Some(stem.to_ascii_lowercase())
 }
 
-fn file_entries(tenant: &Tenant, name: &str, path: &str) -> Vec<Value> {
-    let Some(text) = tenant.read_text(path) else { return Vec::new() };
+fn file_entries(tenant: &Tenant, name: &str, path: &str, config_path: &str) -> Result<Vec<Value>, BuildError> {
+    let Some(text) = read(tenant, path)? else {
+        return Err(failed(config_path, format!("the file() loader of '{name}' points at '{path}', which this tenant does not have"), ""));
+    };
     let parsed = match path.rsplit_once('.').map(|(_, ext)| ext) {
-        Some("yaml" | "yml") => serde_yaml::from_str::<Value>(&text).ok(),
-        _ => serde_json::from_str::<Value>(&text).ok(),
+        Some("yaml" | "yml") => serde_yaml::from_str::<Value>(&text).map_err(|e| failed(path, format!("invalid YAML: {e}"), ""))?,
+        _ => serde_json::from_str::<Value>(&text).map_err(|e| failed(path, format!("invalid JSON: {e}"), ""))?,
     };
     match parsed {
-        Some(Value::Array(items)) => {
-            items.into_iter().enumerate().map(|(i, item)| entry(&item_id(&item, i), name, item, None, None, path)).collect()
+        Value::Array(items) => {
+            Ok(items.into_iter().enumerate().map(|(i, item)| entry(&item_id(&item, i), name, item, None, None, path)).collect())
         }
-        Some(Value::Object(items)) => items.into_iter().map(|(id, item)| entry(&id, name, item, None, None, path)).collect(),
-        _ => Vec::new(),
+        Value::Object(items) => Ok(items.into_iter().map(|(id, item)| entry(&id, name, item, None, None, path)).collect()),
+        _ => Err(failed(path, "a file() loader needs an array of entries or an object keyed by id", "")),
     }
 }
 
@@ -195,31 +221,33 @@ fn item_id(item: &Value, index: usize) -> String {
     }
 }
 
-fn push_file(tenant: &Tenant, name: &str, path: &str, id: &str, entries: &mut Vec<Value>) {
-    let Some((_, ext)) = path.rsplit_once('.') else { return };
-    let Some(text) = tenant.read_text(path) else { return };
+fn push_file(tenant: &Tenant, name: &str, path: &str, id: &str, entries: &mut Vec<Value>) -> Result<(), BuildError> {
+    // An extension the reader has no format for is not an entry, the way it is not one to Astro.
+    let Some((_, ext)) = path.rsplit_once('.') else { return Ok(()) };
+    if !matches!(ext, "md" | "markdown" | "mdx" | "json" | "yaml" | "yml") {
+        return Ok(());
+    }
+    let text = read_listed(tenant, path)?;
     match ext {
         "md" | "markdown" => {
-            let md = parse_markdown(&text);
+            let md = parse_markdown(&text).map_err(|e| failed(path, e, ""))?;
             entries.push(entry(id, name, md.frontmatter, Some(&md.body), Some((md.html, md.headings)), path));
         }
         "mdx" => {
-            let (fm, body) = split_frontmatter(&text);
-            let data = fm.map(yaml_to_json).unwrap_or_else(|| Value::Object(Map::new()));
+            let (data, body) = frontmatter(&text).map_err(|e| failed(path, e, ""))?;
             entries.push(entry(id, name, data, Some(body.trim()), None, path));
         }
-        "json" => match serde_json::from_str::<Value>(&text) {
-            Ok(Value::Array(items)) => {
+        "json" => match serde_json::from_str::<Value>(&text).map_err(|e| failed(path, format!("invalid JSON: {e}"), ""))? {
+            Value::Array(items) => {
                 for (i, item) in items.into_iter().enumerate() {
                     entries.push(entry(&item_id(&item, i), name, item, None, None, path));
                 }
             }
-            Ok(v) => entries.push(entry(id, name, v, None, None, path)),
-            Err(_) => {}
+            v => entries.push(entry(id, name, v, None, None, path)),
         },
-        "yaml" | "yml" => entries.push(entry(id, name, yaml_to_json(&text), None, None, path)),
-        _ => {}
+        _ => entries.push(entry(id, name, yaml_to_json(&text).map_err(|e| failed(path, e, ""))?, None, None, path)),
     }
+    Ok(())
 }
 
 fn entry(id: &str, collection: &str, data: Value, body: Option<&str>, rendered: Option<(String, Vec<Heading>)>, path: &str) -> Value {
@@ -263,23 +291,37 @@ const CONFIG_PATHS: [&str; 6] = [
 ];
 
 /// The config goes to oxc, which recurses over it. This is the one parsed source the content route
-/// reaches without going through `Engine::build`, so the size and nesting caps are applied here;
-/// past either, it is left unparsed and the collection falls back to the directory layout, as it
-/// does when there is no config at all.
-pub fn config(tenant: &Tenant, max_bytes: usize) -> BTreeMap<String, Definition> {
-    CONFIG_PATHS
-        .iter()
-        .find_map(|p| tenant.read_text(p))
-        .filter(|src| src.len() <= max_bytes && super::nesting_depth(src.as_bytes()) <= super::MAX_NESTING_DEPTH)
-        .map(|src| parse_config(&src))
-        .unwrap_or_default()
+/// reaches without going through `Engine::build`, so the size and nesting caps are applied here.
+/// No config at all is the directory layout; a config the caps refuse, or one that does not parse,
+/// is a collection whose shape is unknown — falling back to the directory layout there answers with
+/// somebody else's entries, or none.
+pub fn config(tenant: &Tenant, max_bytes: usize) -> Result<(Option<String>, BTreeMap<String, Definition>), BuildError> {
+    let mut found = None;
+    for p in CONFIG_PATHS {
+        if let Some(src) = read(tenant, p)? {
+            found = Some((p, src));
+            break;
+        }
+    }
+    let Some((path, src)) = found else { return Ok((None, BTreeMap::new())) };
+    if src.len() > max_bytes {
+        let text = format!("content config is {} KiB, over the {} KiB limit", src.len() / 1024, max_bytes / 1024);
+        return Err(failed(path, text, "raise --max-source-kb, or split the file"));
+    }
+    let depth = super::nesting_depth(src.as_bytes());
+    if depth > super::MAX_NESTING_DEPTH {
+        let text = format!("content config nests {depth} deep, over the {} level limit", super::MAX_NESTING_DEPTH);
+        return Err(failed(path, text, ""));
+    }
+    let defs = parse_config(&src).map_err(|e| failed(path, e, ""))?;
+    Ok((Some(path.to_string()), defs))
 }
 
-pub fn parse_config(source: &str) -> BTreeMap<String, Definition> {
+pub fn parse_config(source: &str) -> Result<BTreeMap<String, Definition>, String> {
     let allocator = Allocator::default();
     let ret = JsParser::new(&allocator, source, SourceType::ts()).parse();
-    if !ret.errors.is_empty() {
-        return BTreeMap::new();
+    if let Some(e) = ret.errors.first() {
+        return Err(format!("content config does not parse: {}", e.message));
     }
     let mut bindings: BTreeMap<&str, &Expression> = BTreeMap::new();
     for stmt in &ret.program.body {
@@ -297,7 +339,9 @@ pub fn parse_config(source: &str) -> BTreeMap<String, Definition> {
             }
         }
     }
-    let Some(Expression::ObjectExpression(collections)) = bindings.get("collections").copied() else { return BTreeMap::new() };
+    // A `collections` the reader cannot see through — built by a call, awaited — is the documented
+    // fallback to the directory layout, not a failure to read the file.
+    let Some(Expression::ObjectExpression(collections)) = bindings.get("collections").copied() else { return Ok(BTreeMap::new()) };
     let mut out = BTreeMap::new();
     for (name, value) in props(collections) {
         let value = match value {
@@ -309,7 +353,7 @@ pub fn parse_config(source: &str) -> BTreeMap<String, Definition> {
         };
         out.insert(name.into_owned(), definition(value));
     }
-    out
+    Ok(out)
 }
 
 fn definition(expr: &Expression) -> Definition {
@@ -437,7 +481,11 @@ fn strings(expr: &Expression) -> Option<Vec<String>> {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+    use std::sync::Arc;
+
     use super::*;
+    use crate::store::{Base, Store, UpdateKind};
 
     #[test]
     fn splits_frontmatter() {
@@ -451,7 +499,7 @@ mod tests {
 
     #[test]
     fn renders_headings() {
-        let md = parse_markdown("---\ntitle: T\n---\n## Hello World\ntext");
+        let md = parse_markdown("---\ntitle: T\n---\n## Hello World\ntext").unwrap();
         assert_eq!(md.frontmatter["title"], "T");
         assert_eq!(md.headings[0].slug, "hello-world");
         assert!(md.html.contains("<h2>Hello World</h2>"));
@@ -480,7 +528,8 @@ const posts = defineCollection({
 
 export const collections = { posts };
 "#,
-        );
+        )
+        .unwrap();
         assert_eq!(cfg["posts"].loader, Some(glob(&["**/*.{md,mdx}"], "src/content/posts")));
         assert_eq!(cfg["posts"].dates.as_deref(), Some(["date", "updated", "meta.published"].map(String::from).as_slice()));
     }
@@ -496,7 +545,8 @@ const docs = defineCollection({ loader: glob({ base: `./src/docs`, pattern: ["**
 
 export const collections = { team, docs: docs };
 "#,
-        );
+        )
+        .unwrap();
         assert_eq!(cfg["team"].loader, Some(Loader::File { path: "src/content/team.json".into() }));
         assert_eq!(cfg["team"].dates, None);
         assert_eq!(cfg["docs"].loader, Some(glob(&["**/*.md", "!**/_*.md"], "src/docs")));
@@ -511,7 +561,8 @@ const authors = defineCollection({
 });
 export const collections = { authors };
 "#,
-        );
+        )
+        .unwrap();
         assert_eq!(cfg["authors"].loader, None);
         assert_eq!(cfg["authors"].dates.as_deref(), Some(["joined".to_string()].as_slice()));
     }
@@ -525,11 +576,19 @@ const base = process.env.CONTENT_DIR;
 const posts = defineCollection({ loader: glob({ pattern: patternsFor("posts"), base }), schema: buildSchema() });
 export const collections = { posts };
 "#,
-        );
+        )
+        .unwrap();
         assert_eq!(dynamic["posts"], Definition::default());
+        assert!(parse_config(r#"export const collections = await loadCollections();"#).unwrap().is_empty());
+    }
 
-        assert!(parse_config(r#"export const collections = await loadCollections();"#).is_empty());
-        assert!(parse_config("export const collections = {").is_empty());
+    /// Issue #48: a config the reader cannot see through falls back to the directory layout on
+    /// purpose; one that does not parse is a config nobody read, and the fallback then answers with
+    /// the wrong entries — or none — as if that were the tenant's own content.
+    #[test]
+    fn a_config_that_does_not_parse_is_an_error() {
+        let e = parse_config("export const collections = {").unwrap_err();
+        assert!(e.contains("does not parse"), "{e}");
     }
 
     #[test]
@@ -541,7 +600,7 @@ export const collections = { posts };
             .collect();
         let patterns = ["**/*.{md,mdx}".to_string(), "!**/_*.md".to_string()];
         assert_eq!(
-            glob_matches(&files, &patterns, "src/content/posts"),
+            glob_matches(&files, &patterns, "src/content/posts").unwrap(),
             vec![
                 ("src/content/posts/Hello World.md".to_string(), "hello world".to_string()),
                 ("src/content/posts/nested/Deep.md".to_string(), "nested/deep".to_string()),
@@ -552,6 +611,61 @@ export const collections = { posts };
     #[test]
     fn an_empty_base_matches_from_the_project_root() {
         let files = ["src/blog/a.md".to_string(), "src/blog/b.mdx".to_string()];
-        assert_eq!(glob_matches(&files, &["src/blog/*.md".to_string()], ""), vec![("src/blog/a.md".to_string(), "src/blog/a".to_string())]);
+        assert_eq!(
+            glob_matches(&files, &["src/blog/*.md".to_string()], "").unwrap(),
+            vec![("src/blog/a.md".to_string(), "src/blog/a".to_string())]
+        );
+    }
+
+    fn tenant(files: &[(&str, &str)]) -> Arc<Tenant> {
+        let store = Store::new(None, u64::MAX);
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("examples/starter");
+        store.add_base(Base::load("starter", &root).unwrap());
+        let t = store.create_tenant("t", "starter").unwrap();
+        for (path, body) in files {
+            t.write(path, body.as_bytes().to_vec(), UpdateKind::from_path(path)).unwrap();
+        }
+        t
+    }
+
+    const MAX: usize = 64 << 10;
+
+    #[test]
+    fn a_collection_that_builds_answers_with_its_entries() {
+        let out = collection_json(&tenant(&[]), "posts", MAX).unwrap();
+        assert!(!out["entries"].as_array().unwrap().is_empty());
+    }
+
+    /// Issue #48: each of these used to answer `{"entries": []}`, which renders as a tenant that
+    /// simply has no posts.
+    #[test]
+    fn a_collection_that_cannot_be_built_is_an_error() {
+        let broken_frontmatter = tenant(&[("src/content/posts/bad.md", "---\ntitle: \"unterminated\n---\nbody\n")]);
+        let e = collection_json(&broken_frontmatter, "posts", MAX).unwrap_err();
+        assert_eq!(e.status, 500);
+        assert!(e.message.contains("src/content/posts/bad.md") && e.message.contains("YAML"), "{}", e.message);
+        assert_eq!(e.diagnostics.len(), 1);
+
+        let bad_config = tenant(&[("src/content.config.ts", "export const collections = {")]);
+        let e = collection_json(&bad_config, "posts", MAX).unwrap_err();
+        assert!(e.message.contains("does not parse"), "{}", e.message);
+
+        let huge_config = tenant(&[("src/content.config.ts", &"// x\n".repeat(200))]);
+        let e = collection_json(&huge_config, "posts", 64).unwrap_err();
+        assert!(e.message.contains("over the") && e.message.contains("KiB limit"), "{}", e.message);
+
+        let missing_source = tenant(&[(
+            "src/content.config.ts",
+            "import { file } from \"astro/loaders\";\nexport const collections = { team: defineCollection({ loader: file(\"src/data/team.json\") }) };\n",
+        )]);
+        let e = collection_json(&missing_source, "team", MAX).unwrap_err();
+        assert!(e.message.contains("src/data/team.json"), "{}", e.message);
+    }
+
+    #[test]
+    fn an_entry_file_that_is_not_json_is_an_error() {
+        let t = tenant(&[("src/content/data/broken.json", "{ nope ")]);
+        let e = collection_json(&t, "data", MAX).unwrap_err();
+        assert!(e.message.contains("invalid JSON"), "{}", e.message);
     }
 }

--- a/src/transform/markdown.rs
+++ b/src/transform/markdown.rs
@@ -1,8 +1,11 @@
 use super::content::parse_markdown;
-use super::json_str;
+use super::{BuildError, Diag, json_str};
 
-pub fn page_module(path: &str, source: &str) -> String {
-    let md = parse_markdown(source);
+pub fn page_module(path: &str, source: &str) -> Result<String, BuildError> {
+    let md = parse_markdown(source).map_err(|text| {
+        let diag = Diag { severity: "error".into(), text: text.clone(), hint: String::new(), file: path.to_string(), line: 1, column: 1 };
+        BuildError::compile(format!("{path}: {text}"), vec![diag])
+    })?;
     let layout = md.frontmatter.get("layout").and_then(|l| l.as_str()).map(|s| s.to_string());
     let url = page_url(path);
     let mut code = String::with_capacity(md.html.len() + 1024);
@@ -28,7 +31,7 @@ pub fn page_module(path: &str, source: &str) -> String {
         "export default createComponent((result, props, slots) => Layout\n  ? render`${{renderComponent(result, \"Layout\", Layout, {{ frontmatter, headings, url, file, rawContent, compiledContent, ...props }}, {{ default: () => render`${{unescapeHTML(html)}}` }})}}`\n  : render`${{unescapeHTML(html)}}`, {});\n",
         json_str(path)
     ));
-    code
+    Ok(code)
 }
 
 pub(super) fn page_url(path: &str) -> String {

--- a/src/transform/mdx.rs
+++ b/src/transform/mdx.rs
@@ -22,7 +22,10 @@ pub struct Compiled {
 pub fn compile(path: &str, source: &str) -> Result<Compiled, BuildError> {
     let source = strip_leading_bom(source);
     let (fm, body) = split_frontmatter(source);
-    let frontmatter = fm.map(yaml_to_json).unwrap_or_else(|| Value::Object(Map::new()));
+    let frontmatter = match fm.map(yaml_to_json).transpose() {
+        Ok(fm) => fm.unwrap_or_else(|| Value::Object(Map::new())),
+        Err(reason) => return Err(error(path, &reason, 1, 1)),
+    };
     // Blank lines stand in for the frontmatter so positions in diagnostics match the file.
     let text = format!("{}{body}", "\n".repeat(source[..source.len() - body.len()].matches('\n').count()));
     let (mdast, errors) = satteri_pulldown_cmark::parse(&text, MDX_OPTIONS);

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -443,7 +443,10 @@ impl Engine {
     }
 
     pub fn build(&self, tenant: &Tenant, path: &str, kind: Kind) -> Result<Arc<Built>, BuildError> {
-        let data = tenant.read(path).ok_or_else(|| BuildError::not_found(path))?;
+        let data = tenant
+            .read(path)
+            .map_err(|e| BuildError::compile(format!("{path}: {e}"), vec![]))?
+            .ok_or_else(|| BuildError::not_found(path))?;
         let built = self.build_bytes(tenant, path, kind, &data)?;
         self.remember(tenant, path, kind, &built);
         Ok(built)
@@ -453,7 +456,7 @@ impl Engine {
     /// the bytes of a write before it lands is the compile the next module request would have paid
     /// for anyway.
     fn build_bytes(&self, tenant: &Tenant, path: &str, kind: Kind, data: &[u8]) -> Result<Arc<Built>, BuildError> {
-        let site = crate::resolve::tenant_site(tenant);
+        let site = crate::resolve::tenant_site(tenant).map_err(|e| BuildError::compile(e, vec![]))?;
         let mut h = Vec::with_capacity(data.len() + path.len() + 32);
         h.extend_from_slice(kind.tag().as_bytes());
         h.push(0);
@@ -596,7 +599,7 @@ impl Engine {
                     }
                     "vue" | "svelte" => Ok(Built::js(sfc_loader(&ext, path, &sfc::strip_types(&ext, path, &text())?))),
                     "json" => Ok(Built::js(format!("export default JSON.parse({});\n", json_str(&text())))),
-                    "md" => Ok(Built::scanned(markdown::page_module(path, &text()))),
+                    "md" => Ok(Built::scanned(markdown::page_module(path, &text())?)),
                     "mdx" => Ok(Built::scanned(mdx::page_module(path, &text())?)),
                     "png" | "jpg" | "jpeg" | "gif" | "webp" | "avif" | "svg" | "ico" | "bmp" | "tiff" => {
                         let (w, h) = if ext == "svg" {
@@ -749,7 +752,7 @@ mod tests {
     }
 
     fn served(engine: &Engine, tenant: &Tenant) -> String {
-        engine.serve(tenant, PAGE_PATH, Kind::Module, &Resolver::new(tenant, "https://esm.sh", 7)).unwrap().0
+        engine.serve(tenant, PAGE_PATH, Kind::Module, &Resolver::new(tenant, "https://esm.sh", 7).unwrap()).unwrap().0
     }
 
     const CAP: usize = 64 << 10;
@@ -894,14 +897,17 @@ mod tests {
     }
 
     /// `src/content.config.ts` goes to oxc from the content route, which does not go through `build`.
+    /// Issue #48: past either limit it is refused rather than read as no collections at all — a
+    /// config nobody parsed is not a tenant whose collections live in the default directory.
     #[test]
-    fn a_content_config_past_either_limit_is_not_parsed() {
+    fn a_content_config_past_either_limit_is_refused() {
         let good = "export const collections = { posts: defineCollection({}) };";
         let t = tenant_with("src/content.config.ts", good);
-        assert!(!crate::transform::content::config(&t, CAP).is_empty());
+        assert!(!crate::transform::content::config(&t, CAP).unwrap().1.is_empty());
         for source in [&"a".repeat(CAP + 1), &"[".repeat(MAX_NESTING_DEPTH + 1)] {
             let t = tenant_with("src/content.config.ts", source);
-            assert!(crate::transform::content::config(&t, CAP).is_empty());
+            let e = crate::transform::content::config(&t, CAP).unwrap_err();
+            assert!(e.message.contains("over the"), "{}", e.message);
         }
     }
 

--- a/src/transform/scss.rs
+++ b/src/transform/scss.rs
@@ -313,7 +313,7 @@ pub fn fingerprint(tenant: &Tenant) -> u64 {
     let mut buf = Vec::new();
     for e in tenant.list() {
         if is_sass_path(&e.path)
-            && let Some(bytes) = tenant.read(&e.path)
+            && let Ok(Some(bytes)) = tenant.read(&e.path)
         {
             buf.extend_from_slice(e.path.as_bytes());
             buf.push(0);


### PR DESCRIPTION
Closes #48

## The bug

`preview::content` turned a `spawn_blocking` join error — and, since the parser-stack work, a spawn failure — into `Value::Null` and an empty collection:

```rust
let out = out.ok().and_then(Result::ok).unwrap_or_else(content::empty_collection);
```

The page then rendered as if the tenant simply had no posts. Every way a collection can fail to build now answers **500** with the message and a diagnostic, and `assets/shims/astro-content.js` reads the body's `error` into the exception it throws, so the shell's error overlay renders it. Two tests cover the failure path: a handler test asserting the status, the `error` and the diagnostic, and unit tests in `content.rs` for each way the build can fail.

## The audit

Counted mechanically rather than by reading for code that looks wrong. **The wide sweep — `let _ =`, `unwrap_or_default()`, `unwrap_or(...)`, `.ok()`, `if let Ok(...)` with no else, and error arms producing empty or default content — found about 120 call sites in non-test code.** Nearly all of them turned out to be the same non-finding: `unwrap_or` over an `Option` from string or JSON navigation (`as_str`, `strip_prefix`, `rsplit_once`, `find`), which is not error handling at all. Narrowing to sites that actually discard a **typed error** on a request-answering path leaves **22**.

**The split is lopsided, and that is the finding: 14 swallowed failures, 8 deliberate fallbacks.** Every one of the 14 was a real "the operation could not be carried out and the caller is told nothing"; not one of the 8 was borderline. The class is real and it is small — which is why a ratchet can hold it.

### The 14 swallowed failures, now errors

| Where | It used to answer | Scenario |
|---|---|---|
| `preview::content` join / spawn failure | `{"entries": []}` | issue #48 |
| `content::config` past the size or nesting cap | the directory layout | a config nobody read served as a tenant that wrote no config — the same shape as the Sass bug #43 fixed |
| `content::parse_config` on a syntax error | the directory layout | a typo in `content.config.ts` moves a `glob({base: "src/data"})` collection to `src/content/<name>/`, which is empty |
| `glob_matches` on a pattern that does not compile | the pattern dropped | the collection silently narrows |
| `file_entries`: source absent, or invalid JSON/YAML | `[]` | the `file()` loader's own source |
| `push_file`: entry listed but unreadable, invalid JSON, frontmatter that is not a YAML mapping | the entry dropped, or `data: {}` | a post vanishes, or renders with every field missing |
| `Tenant::read` / `read_text` | 404 "not found" | a `FileData::Disk` entry is re-read on every access; "you do not have this file" is untrue |
| `Resolver::new`, `tenant_site`, `package_deps`, `renderers` | no aliases, `SITE: null`, no renderers | a trailing comma in `tsconfig.json` sends `@/lib/x` to the CDN as a package that does not exist; a broken `sandbox-lite.json` leaves `Astro.site` undefined under every canonical URL and RSS feed |
| `api::check` / `preview::check` join failure | `200 {"error": …}` | `shell.js` does `(await fetchJSON("/__sl/check")).diagnostics.filter(...)` inside a `try {} catch {}`, so the overlay showed no diagnostics at all |
| `api::sse` on a lagged broadcast receiver | the missed events dropped | 65 edits in a burst and the last one's reload never fires: the preview quietly stops following the tenant. Now sends the pathless update that already means "the whole tree changed" — which reloads rather than swapping CSS, the only safe thing to do about writes nobody saw |
| `Chats::list` / `load` / `delete`, `Store::remove_tenant` | a short list, "unknown chat", 204 | a data directory that survives a delete answers 204 and the tenant comes back at the next restore |
| `Chats::count` / `Chats::usage` (found on the rebase, see below) | `0` conversations, `0` bytes | a `chats/` directory that cannot be listed stops the #45 cap being enforced and understates `/api/stats`; both now go through one `chat_files` where only `NotFound` is an empty listing |
| `api::stats` | a gauge of zero | nothing downstream can tell a zero from the truth, so it answers 500 |
| `Reply::event` on tool arguments that do not parse | `input: {}` | the tool runs as if the model had called it with no arguments |

Plus `restore_overlay`: a `deleted.json` that does not parse now skips the tenant with a message instead of silently resurrecting every file it had deleted.

### The 8 deliberate fallbacks, left alone

They are the `TOLERATED` list in `src/silent_failures.rs`, each with its reason in the source: a chrome log read only to enrich a screenshot failure already being returned; two `tx.send` on an SSE channel whose receiver is gone because the client disconnected; the body and the JSON of an upstream response that has already failed; `/proc/self/status` off Linux; an `Option` for a tenant with no conversations; a broadcast with no subscribers; and the Sass census counter in `check`, whose file is compiled two lines later and reports the read failure there.

A missing `tsconfig.json` is still no aliases, a missing config is still the directory layout, and a `collections` the reader *read* and could not follow — a computed pattern, a custom loader, a schema built by a function — still falls back. That distinction is the whole point: the fallback is for a config that was read, not for one that was not.

## The ratchet

`src/silent_failures.rs` walks `src/**/*.rs`, skips each file from its first `#[cfg(test)]`, and flags any line naming both a genuinely fallible operation (`serde_json::from_`, `serde_yaml::from_`, `std::fs::`, `spawn_blocking`, `Result::ok`, `.read(`, `read_text(`, `.send(`, `.text()`) and a form that discards what it failed with.

**Measured before it was committed, as the rule requires.** The wide version flagged about 120 lines — so it was wrong somewhere, and the wrong part was `unwrap_or` over `Option`. The narrowed rule catches 22: the 14 fixed here and the 8 tolerated. A second test pins the rule itself against the exact line from the bug and against two `Option` navigations it must not flag. `TOLERATED` may only shrink — an entry that matches nothing fails the test, so a fix cannot leave a licence behind.

## What the rebases over #56, #49, #58 and #59 turned up

The branch was rebased over the CSS hot-swap (#56), the preview-token work (#49), the chat-windowing work (#58) and the base-reload work (#59). Every conflict was the two-changes-to-one-function kind and both intents are kept: `astro-content.js` throws the daemon's diagnostic *through* `slUrl`, `preview::page` builds the token query *after* `env_map` can fail, `Engine::build` propagates the read error into `build_bytes`, `Chats` keeps `is_chat_file` while returning `io::Result`, and `Store::restore` keeps #59's `read_tenant` helper with the `tenant.json` parse error propagated through it rather than read as null.

Checking the new code for new instances of this PR's own class, as asked:

- **`Engine::update_kind` (#56)** falls back to `UpdateKind::Module` when the speculative build fails. That is a **deliberate fallback**, not a swallow: a full reload is the conservative behaviour and it is what happened before #56, the write itself still succeeds, and the browser's next module request answers 500 with the diagnostic. Its doc comment already says so — "anything this cannot prove" reloads.
- **`live.js`'s `swap(d).then(swapped => …, reload)` (#56)** rejects to `reload` when a `<style>` module 500s. Same shape, same verdict — the reload re-renders and the overlay reports the compile error.
- **`shell.js` (#49)** changed which URL is fetched, not how failures are handled. `fetchJSON` still throws on `!r.ok` and `main().catch` still renders the overlay. No new instance.
- **`Store::reload_changed_bases` (#59)** prints and keeps the loaded copy when a base root cannot be walked. That is the correct shape for this class and its comment says so — "a base directory being replaced wholesale should not empty every tenant's site" — so no new instance. `Store::read_tenant`, the helper #59 factored out of `restore`, did carry the old `serde_json::from_slice(&meta).unwrap_or_default()` forward; read as null it reports a corrupt `tenant.json` as an unloaded base `''`, so the parse error is propagated instead. The ratchet flags that line, which is how the rebase did not quietly lose the fix.
- **`Chats::count` / `Chats::usage` (#58) is a new instance, and the ratchet did not catch it.** Both read `std::fs::read_dir(dir).into_iter().flatten().flatten()`: a directory that cannot be listed reads as a tenant with no conversations, which silently stops the #45 cap being enforced and understates `/api/stats`. I found it by reading the conflict, not by the rule. `Result::into_iter().flatten()` reads as iteration rather than as error handling, so it was not in `DISCARDS` — **it is now**, with a test pinning the exact line from #58 as one the rule must flag. That is the honest answer to "if the ratchet does not catch it, the rule needs widening": it did not, and it does now.

## Noticed, did not fix

- **`js::scan(code).unwrap_or_default()` — 3 sites** (`Built::scanned`, `preview::shim`). If oxc cannot reparse our own generated output, the module is served with its bare specifiers unresolved. The visitor does see a failure (the browser throws on the specifier), so it is not silent — but the diagnostic is lost, and it would be a daemon bug worth a 500. Left because making it fatal risks turning pages that work today into 500s with nothing to gain but a better message.
- **`astro.rs`: `Script::Inline(s.code.unwrap_or_default())` / `External(s.src.unwrap_or_default())`.** A hoisted script with no code becomes an empty one. Upstream's `Option` is always `Some` for its variant, so this is unreachable today — but it is unreachable by convention rather than by type.
- **`live.js`: `try { d = JSON.parse(e.data) } catch { return }`.** An SSE frame that does not parse is dropped, which is one missed reload. The daemon is the only writer, so it can only fire on a daemon bug — but it is the browser-side twin of the broadcast lag fixed here.
- **`scss::fingerprint` skips a Sass file it cannot read**, so the fingerprint does not change and a cache entry from when the file was readable is served. Arguably right; not obviously so.
- **`--data-dir` writes are not fsynced.** A crash between a 200 on `PUT /api/t/{id}/file/{path}` and the page cache flush loses the write with no one told. Out of scope for this change, but the same class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
