### PR TITLE
chat: window conversations, cap stored ones, and bound the screenshot tool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,9 @@ jobs:
           grep -qxF 'sandbox_lite_tenants 1' /tmp/metrics.txt
           grep -qxF '# TYPE sandbox_lite_cache_hits_total counter' /tmp/metrics.txt
           grep -qxF '# TYPE sandbox_lite_sass_runaway gauge' /tmp/metrics.txt
+          grep -qxF 'sandbox_lite_screenshots_running 0' /tmp/metrics.txt
+          grep -qxF '# TYPE sandbox_lite_screenshots_busy_total counter' /tmp/metrics.txt
+          curl -sf http://127.0.0.1:4399/api/stats | grep -q '"max_per_tenant"'
           grep -qxF '# TYPE sandbox_lite_compile_seconds histogram' /tmp/metrics.txt
           grep -qxF '# TYPE sandbox_lite_compiles_queued gauge' /tmp/metrics.txt
           # issue #47: the permit count is what bounds concurrent compiles, so it must never render as 0

--- a/README.md
+++ b/README.md
@@ -152,9 +152,22 @@ each tool call as they arrive. Conversations are kept per tenant under
 `<data-dir>/<id>/chats/` and are listed in the Chat tab's dropdown, so a
 customer can pick an old thread back up; the tool loop sees the earlier turns.
 
+A conversation does not grow without end. The last `--chat-window` turns
+(default 24) are replayed to the model in full; when a conversation passes that,
+everything older is folded into one summary — written once by the same API,
+stored with the conversation and sent as its opening turn from then on. Should
+that call fail, the turns stay stored and the window is applied to the request
+anyway. Conversations are outside the tenant quota, so `--chats-per-tenant`
+(default 50) is what bounds them: saving past it drops the tenant's least
+recently updated conversation.
+
 `--chrome PATH` adds a sixth tool, `screenshot`, which renders one page of the
 tenant's live preview in headless Chrome and hands the PNG back to the model,
-so it can look at the layout it just changed instead of guessing.
+so it can look at the layout it just changed instead of guessing. A browser
+costs more memory than every tenant on the daemon put together, so
+`--chrome-jobs` (default 1) of them run at once; a call that has not got a slot
+within 10 s is told the tool is busy rather than queueing, and one that overruns
+its 20 s deadline is killed and reaped before its profile directory goes.
 
 ### Flags
 
@@ -174,14 +187,18 @@ so it can look at the layout it just changed instead of guessing.
 --api-token TOKEN    require `Authorization: Bearer TOKEN` (or `?token=`) on /api/*
 --preview-secret S   tenant hosts require a per-tenant token derived from S
 --chrome PATH        chrome or chromium binary for the chat's screenshot tool (default: off)
+--chrome-jobs N      screenshots that may run at once (default 1)
+--chat-window N      turns of a conversation replayed to the model in full (default 24)
+--chats-per-tenant N conversations a tenant may keep (default 50)
 --tenant-quota-mb N  edited files a tenant may hold, in MiB (default 64)
 --cookie-samesite lax|none
                      SameSite of the preview cookie; none also sets Secure (default lax)
 ```
 
 `SANDBOX_LITE_API_TOKEN`, `SANDBOX_LITE_PREVIEW_SECRET`,
-`SANDBOX_LITE_TENANT_QUOTA_MB`, `SANDBOX_LITE_MAX_COMPILES` and
-`SANDBOX_LITE_CHROME` are read as defaults for those flags, and
+`SANDBOX_LITE_TENANT_QUOTA_MB`, `SANDBOX_LITE_MAX_COMPILES`,
+`SANDBOX_LITE_CHROME`, `SANDBOX_LITE_CHROME_JOBS`, `SANDBOX_LITE_CHAT_WINDOW`
+and `SANDBOX_LITE_CHATS_PER_TENANT` are read as defaults for those flags, and
 `SANDBOX_LITE_ANTHROPIC_BASE` points the chat at another Messages API
 endpoint (default `https://api.anthropic.com`). With a
 preview secret set, `/api/tenants` returns each tenant's `preview_token`;
@@ -228,7 +245,7 @@ Editor host (`localhost`):
 | Method | Path | |
 |---|---|---|
 | GET | `/metrics` | Prometheus text format: gauges, cache and request counters, compile-latency histograms |
-| GET | `/api/stats` | RSS, tenant count, cache stats, module requests and compile totals |
+| GET | `/api/stats` | RSS, tenant count, cache stats, what the chats directory holds, screenshots in flight, module requests and compile totals |
 | GET/POST | `/api/tenants` | list / create `{id, base}` |
 | DELETE | `/api/tenants/{id}` | remove tenant and its edits |
 | POST | `/api/tenants/{id}/import` | tar.gz body → overlay; `?replace=1` drops the edits it does not carry |
@@ -262,7 +279,8 @@ curl -fsS -X POST --data-binary @acme.tar.gz localhost:4321/api/tenants/acme-cop
 `sandbox_lite_tenants`, `sandbox_lite_overlay_bytes`, `sandbox_lite_cache_*`,
 `sandbox_lite_sse_subscribers`, `sandbox_lite_rss_bytes`,
 `sandbox_lite_uptime_seconds`, one series per base, `sandbox_lite_sass_*`
-(running, runaway, timeouts, refusals),
+(running, runaway, timeouts, refusals), `sandbox_lite_screenshots_*` (running,
+calls told the tool was busy, browsers killed on their deadline),
 `sandbox_lite_module_requests_total{kind,status}` and
 `sandbox_lite_compile_seconds{kind}` — a histogram of what a transform-cache
 miss costs, so `histogram_quantile(0.99, …)` answers "how slow is a cold

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -146,6 +146,18 @@ credentials on the API side.
   a write that would take the tenant's edited files past it is refused with
   `413` before anything reaches disk or memory, and the chat `write_file` tool
   gets the same error. Rewriting a file is charged only for the difference.
+- **Conversations** are outside that quota, so they have their own two limits:
+  `--chats-per-tenant` (default 50) drops a tenant's least recently updated
+  conversation when a save would take it past the cap, and `--chat-window`
+  (default 24) is how many turns of one conversation reach the model — older
+  turns are folded into a stored summary, and are cut from the request even
+  when that summary could not be written. `/api/stats` reports what the chats
+  directory holds across every tenant.
+- **The screenshot tool** runs `--chrome-jobs` browsers at once (default 1).
+  A call that waits 10 s without a slot is answered "busy" rather than queued,
+  and one whose browser overruns its 20 s deadline is killed and reaped before
+  its profile directory and PNG are removed. `sandbox_lite_screenshots_*`
+  counts what is running, what was refused and what was killed.
 
 The daemon sets no CORS, CSP, `X-Frame-Options` or `Referrer-Policy` headers.
 Cross-origin reads between tenant hosts are blocked by the browser's
@@ -173,7 +185,8 @@ that router answers `401` unless the request carries
 - The editor page keeps the token in `localStorage` (`sl_api_token`) on the
   editor origin.
 - It gates spending: every `POST /api/t/{id}/chat` can make up to 16 calls to
-  the Anthropic API with the daemon's `ANTHROPIC_API_KEY`.
+  the Anthropic API with the daemon's `ANTHROPIC_API_KEY`, and one more when
+  the conversation has to be summarized.
 - It is the only thing gating `POST /api/tenants/{id}/import`, which writes a
   whole file tree into a tenant in one request, and
   `GET /api/t/{id}/export`, which returns one.
@@ -244,8 +257,10 @@ editor stores the API token in `localStorage` and embeds tenant previews in an
   every tool result — the file listing, the contents of any file the model
   reads (up to 200 KiB per file, any path in the tenant), and `check`
   diagnostics. `write_file` and `delete_file` take effect on the tenant
-  immediately, without confirmation. Without the key the endpoint answers
-  `503` and nothing is sent.
+  immediately, without confirmation. A conversation that has passed
+  `--chat-window` costs one further call, which sends the turns being folded
+  away and takes back the summary that replaces them. Without the key the
+  endpoint answers `503` and nothing is sent.
 - **CDN, in the visitor's browser.** Bare imports (`react`, `dayjs`) resolve to
   `--cdn` (default `https://esm.sh`) with the version range from
   `package.json`; React and Preact client entrypoints come from the same CDN.

--- a/assets/editor.html
+++ b/assets/editor.html
@@ -233,6 +233,7 @@ async function openChat(id) {
   if (!id) return;
   try {
     const c = await api("GET", `/api/t/${state.tenant}/chats/${encodeURIComponent(id)}`);
+    if (c.summary) addMsg("sys", "earlier in this conversation: " + c.summary);
     for (const m of c.messages) addMsg(m.role === "user" ? "user" : "ai", m.text, (m.tools || []).map(chipLabel));
   } catch (e) { addMsg("sys", "cannot open that conversation: " + e.message); }
 }

--- a/src/http/ai.rs
+++ b/src/http/ai.rs
@@ -11,10 +11,10 @@ use axum::extract::{Path, State as AxState};
 use axum::http::{HeaderMap, StatusCode, header};
 use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::process::Command;
-use tokio::sync::mpsc;
+use tokio::sync::{Semaphore, mpsc};
 use tokio_stream::StreamExt;
 use tokio_stream::wrappers::ReceiverStream;
 
@@ -31,6 +31,23 @@ const SHOT_TIMEOUT: Duration = Duration::from_secs(20);
 const VIRTUAL_TIME: Duration = Duration::from_secs(8);
 const SHOT_SIZE: &str = "1280,900";
 const MAX_SHOT: usize = 4 << 20;
+
+/// Screenshots that may run at once. One headless Chrome costs more memory than every tenant on
+/// the daemon put together, so the default is the smallest number that still works.
+pub const DEFAULT_CHROME_JOBS: usize = 1;
+/// How long a screenshot waits for a free slot before telling the model the tool is busy. Short
+/// enough that the model gets an answer rather than a stalled tool call.
+const SHOT_WAIT: Duration = Duration::from_secs(10);
+
+/// Tokens the summary of a compacted conversation may use, and what one of its turns contributes
+/// to the transcript the summary is written from. Both bound a request whose whole point is that
+/// the conversation was already too long to send.
+const SUMMARY_TOKENS: u32 = 512;
+const SUMMARY_TURN_CHARS: usize = 1000;
+const SUMMARY_TRANSCRIPT: usize = 24 << 10;
+const SUMMARY_PROMPT: &str = "You compress the earlier part of a conversation between a customer and an assistant that edits their website. \
+Reply with a short summary — a few sentences, no preamble — of what the customer asked for, what was changed and what is still open, \
+so the assistant can carry on without the full transcript.";
 
 #[derive(Deserialize)]
 pub struct ChatMsg {
@@ -157,6 +174,52 @@ fn shot_path(raw: &str) -> Option<String> {
     Some(if raw.starts_with('/') { raw.to_string() } else { format!("/{raw}") })
 }
 
+#[derive(Serialize, Clone, Copy)]
+pub struct ShotStats {
+    pub running: usize,
+    pub limit: usize,
+    pub busy: u64,
+    pub timeouts: u64,
+}
+
+/// The screenshot tool, bounded. Each call spawns a browser with its own profile directory, so
+/// only `jobs` of them run at once and a call that cannot get a slot within `wait` tells the model
+/// the tool is busy rather than queueing behind an unbounded number of browsers.
+pub struct Shots {
+    permits: Semaphore,
+    jobs: usize,
+    wait: Duration,
+    deadline: Duration,
+    busy: AtomicU64,
+    timeouts: AtomicU64,
+}
+
+impl Default for Shots {
+    fn default() -> Shots {
+        Shots::new(DEFAULT_CHROME_JOBS)
+    }
+}
+
+impl Shots {
+    pub fn new(jobs: usize) -> Shots {
+        Shots::with(jobs, SHOT_WAIT, SHOT_TIMEOUT)
+    }
+
+    fn with(jobs: usize, wait: Duration, deadline: Duration) -> Shots {
+        let jobs = jobs.max(1);
+        Shots { permits: Semaphore::new(jobs), jobs, wait, deadline, busy: AtomicU64::new(0), timeouts: AtomicU64::new(0) }
+    }
+
+    pub fn stats(&self) -> ShotStats {
+        ShotStats {
+            running: self.jobs.saturating_sub(self.permits.available_permits()),
+            limit: self.jobs,
+            busy: self.busy.load(Ordering::Relaxed),
+            timeouts: self.timeouts.load(Ordering::Relaxed),
+        }
+    }
+}
+
 async fn screenshot(st: &AppState, t: &Tenant, input: &Value) -> ToolOut {
     let Some(chrome) = st.chrome.clone() else {
         return ToolOut::text("error: the screenshot tool is not configured; the daemon was started without --chrome");
@@ -164,13 +227,37 @@ async fn screenshot(st: &AppState, t: &Tenant, input: &Value) -> ToolOut {
     let Some(path) = shot_path(input.get("path").and_then(|p| p.as_str()).unwrap_or("/")) else {
         return ToolOut::text("error: bad path; pass a site path such as /blog");
     };
+    let permit = match tokio::time::timeout(st.shots.wait, st.shots.permits.acquire()).await {
+        Ok(Ok(permit)) => permit,
+        Ok(Err(e)) => return ToolOut::text(format!("error: the screenshot tool is closed: {e}")),
+        Err(_) => {
+            st.shots.busy.fetch_add(1, Ordering::Relaxed);
+            let (jobs, waited) = (st.shots.jobs, st.shots.wait.as_secs());
+            return ToolOut::text(format!(
+                "error: the screenshot tool is busy; {jobs} may run at once and none finished within {waited}s. Try again in a moment."
+            ));
+        }
+    };
+    let out = shoot(st, &chrome, t, &path).await;
+    drop(permit);
+    out
+}
+
+async fn shoot(st: &AppState, chrome: &std::path::Path, t: &Tenant, path: &str) -> ToolOut {
     let scratch = match Scratch::new() {
         Ok(s) => s,
         Err(e) => return ToolOut::text(format!("error: cannot create a temporary directory: {e}")),
     };
     let png = scratch.dir.join("shot.png");
-    let url = preview_url_path(st, &t.id, &path);
-    let child = Command::new(&chrome)
+    // chrome's stderr goes to a file in the profile rather than a pipe: nothing has to drain it
+    // while the browser runs, and it is removed with everything else
+    let log = scratch.dir.join("chrome.log");
+    let errors = match std::fs::File::create(&log) {
+        Ok(f) => f,
+        Err(e) => return ToolOut::text(format!("error: cannot create a temporary file: {e}")),
+    };
+    let url = preview_url_path(st, &t.id, path);
+    let child = Command::new(chrome)
         .arg("--headless=new")
         .arg("--disable-gpu")
         .arg("--no-sandbox")
@@ -184,21 +271,27 @@ async fn screenshot(st: &AppState, t: &Tenant, input: &Value) -> ToolOut {
         .arg(format!("{url}{}sl_shot=1", if url.contains('?') { '&' } else { '?' }))
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::piped())
+        .stderr(Stdio::from(errors))
         .kill_on_drop(true)
         .spawn();
-    let child = match child {
+    let mut child = match child {
         Ok(c) => c,
         Err(e) => return ToolOut::text(format!("error: cannot run {}: {e}", chrome.display())),
     };
-    let finished = match tokio::time::timeout(SHOT_TIMEOUT, child.wait_with_output()).await {
-        Ok(Ok(o)) => o,
+    let status = match tokio::time::timeout(st.shots.deadline, child.wait()).await {
+        Ok(Ok(status)) => status,
         Ok(Err(e)) => return ToolOut::text(format!("error: chrome failed: {e}")),
-        Err(_) => return ToolOut::text(format!("error: chrome did not finish within {}s", SHOT_TIMEOUT.as_secs())),
+        Err(_) => {
+            st.shots.timeouts.fetch_add(1, Ordering::Relaxed);
+            // killed and reaped here rather than left to `kill_on_drop`, so that nothing is still
+            // writing into the profile directory when `Scratch` removes it
+            let _ = child.kill().await;
+            return ToolOut::text(format!("error: chrome did not finish within {}s", st.shots.deadline.as_secs()));
+        }
     };
     let Ok(bytes) = std::fs::read(&png) else {
-        let stderr = String::from_utf8_lossy(&finished.stderr);
-        return ToolOut::text(format!("error: chrome wrote no screenshot ({}): {}", finished.status, summarize(&stderr)));
+        let stderr = std::fs::read_to_string(&log).unwrap_or_default();
+        return ToolOut::text(format!("error: chrome wrote no screenshot ({status}): {}", summarize(&stderr)));
     };
     if bytes.len() > MAX_SHOT {
         return ToolOut::text(format!("error: the screenshot is {} bytes, more than the {MAX_SHOT} byte limit", bytes.len()));
@@ -229,7 +322,9 @@ impl Scratch {
 
 impl Drop for Scratch {
     fn drop(&mut self) {
-        let _ = std::fs::remove_dir_all(&self.dir);
+        if let Err(e) = std::fs::remove_dir_all(&self.dir) {
+            eprintln!("cannot remove the screenshot directory {}: {e}", self.dir.display());
+        }
     }
 }
 
@@ -363,10 +458,76 @@ async fn converse(st: &State, t: &Arc<Tenant>, key: &str, mut messages: Vec<Valu
     Ok(Answer { text, changes, iterations, tools: tools_used })
 }
 
+/// The turns past the window, as one transcript for the summarizer. Newest first while the budget
+/// is spent, so what survives the cut is the part closest to the conversation still going on.
+fn transcript(previous: &str, turns: &[Turn]) -> String {
+    let mut budget = SUMMARY_TRANSCRIPT;
+    let mut lines: Vec<String> = Vec::new();
+    for turn in turns.iter().rev().filter(|t| !t.text.trim().is_empty()) {
+        let line = format!("{}: {}", turn.role, turn.text.chars().take(SUMMARY_TURN_CHARS).collect::<String>());
+        let Some(left) = budget.checked_sub(line.len()) else { break };
+        budget = left;
+        lines.push(line);
+    }
+    lines.reverse();
+    match previous.trim() {
+        "" => lines.join("\n\n"),
+        earlier => format!("Summary of what came before this transcript:\n{earlier}\n\nTranscript:\n{}", lines.join("\n\n")),
+    }
+}
+
+/// Folds everything past the window into the conversation's stored summary, with one call to the
+/// same API. It runs when a conversation crosses the window and not on the turns between, so the
+/// summary is written roughly once every half window rather than once per turn. A summary the API
+/// will not write is not fatal: the turns stay stored, and `for_model` cuts them out of the
+/// request instead.
+async fn compact(st: &State, key: &str, conv: &mut Conversation) {
+    let drop = conv.overflow(st.chats.window());
+    if drop == 0 {
+        return;
+    }
+    let prompt = transcript(&conv.summary, &conv.messages[..drop]);
+    match summarize_conversation(st, key, prompt).await {
+        Some(summary) => conv.compact(drop, summary),
+        None => eprintln!("chat {}: cannot summarize the {drop} oldest turns; they are left out of the request instead", conv.id),
+    }
+}
+
+async fn summarize_conversation(st: &State, key: &str, prompt: String) -> Option<String> {
+    let body = json!({
+        "model": st.model,
+        "max_tokens": SUMMARY_TOKENS,
+        "system": SUMMARY_PROMPT,
+        "messages": [{ "role": "user", "content": prompt }],
+    });
+    let resp = reqwest::Client::new()
+        .post(format!("{}/v1/messages", st.api_base))
+        .header("x-api-key", key)
+        .header("anthropic-version", "2023-06-01")
+        .json(&body)
+        .send()
+        .await
+        .ok()?;
+    if !resp.status().is_success() {
+        return None;
+    }
+    let reply: Value = resp.json().await.ok()?;
+    let text = reply["content"]
+        .as_array()?
+        .iter()
+        .filter(|block| block["type"] == "text")
+        .filter_map(|block| block["text"].as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let text = text.trim().to_string();
+    (!text.is_empty()).then_some(text)
+}
+
 /// Runs one request end to end and records it. The value is the `done` payload, which is also the
 /// JSON body of the non-streaming reply.
 async fn run(st: State, t: Arc<Tenant>, key: String, req: ChatReq, mut conv: Conversation, out: Emitter) -> Result<Value, Fail> {
-    let mut messages = conv.for_model();
+    compact(&st, &key, &mut conv).await;
+    let mut messages = conv.for_model(st.chats.window());
     messages.extend(req.messages.iter().map(|m| json!({ "role": m.role, "content": m.content })));
     let answer = converse(&st, &t, &key, messages, &out).await?;
     for m in &req.messages {
@@ -466,7 +627,14 @@ mod tests {
         ])
     }
 
-    /// Replays `turns` in order and records every request body it was sent.
+    /// What the stub answers a summarize request with; the tool loop never asks for one.
+    const STUB_SUMMARY: &str = "The customer asked for a green headline and got one.";
+    /// A turn carrying this makes the stub refuse to summarize it.
+    const REFUSE: &str = "(unsummarizable)";
+
+    /// Replays `turns` in order and records every request body it was sent. A request that did not
+    /// ask for a stream is the summarizer's: it is answered as one plain message and does not
+    /// consume a turn, unless what it was asked to summarize says to refuse.
     async fn upstream(turns: Vec<String>) -> (String, Arc<Mutex<Vec<Value>>>) {
         let seen = Arc::new(Mutex::new(Vec::new()));
         let recorder = seen.clone();
@@ -475,13 +643,22 @@ mod tests {
             post(move |Json(body): Json<Value>| {
                 let (recorder, turns) = (recorder.clone(), turns.clone());
                 async move {
+                    let streaming = body["stream"] == true;
+                    let refuse = !streaming && body["messages"][0]["content"].as_str().is_some_and(|p| p.contains(REFUSE));
                     let n = {
                         let mut seen = recorder.lock().unwrap();
                         seen.push(body);
-                        seen.len()
+                        seen.iter().filter(|b| b["stream"] == true).count()
                     };
+                    if refuse {
+                        return (StatusCode::SERVICE_UNAVAILABLE, Json(json!({ "error": "no" }))).into_response();
+                    }
+                    if !streaming {
+                        let reply = json!({ "content": [{ "type": "text", "text": STUB_SUMMARY }] });
+                        return ([(header::CONTENT_TYPE, "application/json")], reply.to_string()).into_response();
+                    }
                     let body = turns.get(n - 1).cloned().unwrap_or_else(|| turn_with_text("(unexpected extra turn)"));
-                    ([(header::CONTENT_TYPE, "text/event-stream")], body)
+                    ([(header::CONTENT_TYPE, "text/event-stream")], body).into_response()
                 }
             }),
         );
@@ -504,6 +681,10 @@ mod tests {
     }
 
     async fn fixture(turns: Vec<String>, persist: bool) -> Fixture {
+        fixture_with(turns, persist, None, Shots::default()).await
+    }
+
+    async fn fixture_with(turns: Vec<String>, persist: bool, chrome: Option<PathBuf>, shots: Shots) -> Fixture {
         static SEQ: AtomicU64 = AtomicU64::new(0);
         let root = std::env::temp_dir().join(format!("sandbox-lite-chat-{}-{}", std::process::id(), SEQ.fetch_add(1, Ordering::Relaxed)));
         let (base_dir, data_dir) = (root.join("base"), root.join("data"));
@@ -528,7 +709,8 @@ mod tests {
             api_token: None,
             preview_secret: None,
             cookie_samesite: super::super::SameSite::Lax,
-            chrome: None,
+            chrome,
+            shots,
             started: Instant::now(),
         });
         Fixture { st, seen, root }
@@ -682,6 +864,7 @@ mod tests {
             preview_secret: None,
             cookie_samesite: super::super::SameSite::Lax,
             chrome: None,
+            shots: super::super::ai::Shots::default(),
             started: Instant::now(),
         });
         broken.store.add_base(Base::load("test", &f.root.join("base")).unwrap());
@@ -700,6 +883,195 @@ mod tests {
         }
         assert_eq!(base64(&[0xff, 0xff, 0xff]), "////");
         assert_eq!(base64(&[0, 0, 0]), "AAAA");
+    }
+
+    /// Issue #45: replaying every stored turn grows the request until the model's context is the
+    /// limit. Past the window the older turns become one summary, written by the same API.
+    #[tokio::test]
+    async fn a_conversation_past_the_window_is_summarized_once_and_the_summary_is_stored() {
+        let f = fixture(vec![turn_with_text("First."), turn_with_text("Second.")], true).await;
+        let t = f.st.store.tenant("acme").unwrap();
+        let window = f.st.chats.window();
+        let mut old = Conversation::new("old".into());
+        for i in 0..window * 2 {
+            old.push(Turn { role: if i % 2 == 0 { "user" } else { "assistant" }.into(), text: format!("turn {i}"), tools: Vec::new() });
+        }
+        f.st.chats.save(&t, &old).unwrap();
+        let dropped = old.overflow(window);
+
+        let (status, _) = post_chat(&f.st, None, ask("carry on", Some("old"))).await;
+        assert_eq!(status, StatusCode::OK);
+
+        let stored = f.st.chats.load(&t, "old").unwrap();
+        assert_eq!(stored.summary, STUB_SUMMARY);
+        assert_eq!(stored.messages.len(), window * 2 - dropped + 2, "the window, plus this request's two turns");
+        assert_eq!(stored.messages[0].text, format!("turn {dropped}"));
+
+        let seen = f.seen.lock().unwrap();
+        assert_eq!(seen.len(), 2, "one summarize call and one turn of the tool loop");
+        assert!(seen[0]["stream"].is_null(), "the summarizer does not stream: {}", seen[0]);
+        assert_eq!(seen[0]["messages"].as_array().unwrap().len(), 1);
+        let prompt = seen[0]["messages"][0]["content"].as_str().unwrap();
+        assert!(prompt.contains("turn 0") && prompt.contains(&format!("turn {}", dropped - 1)), "{prompt}");
+        assert!(!prompt.contains(&format!("turn {dropped}")), "the turns that stay are not summarized: {prompt}");
+
+        let sent = seen[1]["messages"].as_array().unwrap();
+        // the summary joins the user turn that follows it, so this is the turns left plus the new message
+        assert_eq!(sent.len(), window * 2 - dropped + 1);
+        assert!(sent[0]["content"].as_str().unwrap().contains(STUB_SUMMARY), "{}", sent[0]);
+        assert_eq!(sent[sent.len() - 1], json!({"role":"user","content":"carry on"}));
+    }
+
+    /// The summary is written once, when the conversation crosses the window — not on the turns
+    /// after it, when replaying it again would cost a call per message.
+    #[tokio::test]
+    async fn the_summary_is_not_rewritten_on_every_turn() {
+        let f = fixture(vec![turn_with_text("First."), turn_with_text("Second."), turn_with_text("Third.")], false).await;
+        let t = f.st.store.tenant("acme").unwrap();
+        let mut old = Conversation::new("old".into());
+        for i in 0..f.st.chats.window() + 1 {
+            old.push(Turn { role: if i % 2 == 0 { "user" } else { "assistant" }.into(), text: format!("turn {i}"), tools: Vec::new() });
+        }
+        f.st.chats.save(&t, &old).unwrap();
+        for _ in 0..3 {
+            assert_eq!(post_chat(&f.st, None, ask("more", Some("old"))).await.0, StatusCode::OK);
+        }
+        let summarize_calls = f.seen.lock().unwrap().iter().filter(|b| b["stream"].is_null()).count();
+        assert_eq!(summarize_calls, 1, "three requests, one summary");
+    }
+
+    /// A summary the API will not write must not lose the turns it was meant to replace — and the
+    /// request has to be bounded anyway, so `for_model` cuts them out instead.
+    #[tokio::test]
+    async fn a_summary_the_api_refuses_leaves_the_turns_stored_and_out_of_the_request() {
+        let f = fixture(vec![turn_with_text("Fine.")], false).await;
+        let t = f.st.store.tenant("acme").unwrap();
+        let window = f.st.chats.window();
+        let mut old = Conversation::new("old".into());
+        for i in 0..window * 4 {
+            let role = if i % 2 == 0 { "user" } else { "assistant" };
+            old.push(Turn { role: role.into(), text: format!("{REFUSE} turn {i}"), tools: Vec::new() });
+        }
+        f.st.chats.save(&t, &old).unwrap();
+
+        let (status, _) = post_chat(&f.st, None, ask("carry on", Some("old"))).await;
+        assert_eq!(status, StatusCode::OK, "a summary that cannot be written is not a failed request");
+
+        let stored = f.st.chats.load(&t, "old").unwrap();
+        assert_eq!(stored.summary, "");
+        assert_eq!(stored.messages.len(), window * 4 + 2, "no turn is dropped without a summary to stand for it");
+        let seen = f.seen.lock().unwrap();
+        assert_eq!(seen[1]["messages"].as_array().unwrap().len(), window + 1, "the request is bounded by the window regardless");
+    }
+
+    /// A stand-in for chrome: it records the profile directory it was handed, sleeps, and writes
+    /// the file it was told to screenshot. Chrome itself is not on the machine that runs these,
+    /// and what the limiter has to bound is exactly this — a process that takes time and leaves a
+    /// profile directory behind.
+    #[cfg(unix)]
+    struct Stub {
+        dir: PathBuf,
+        bin: PathBuf,
+        report: PathBuf,
+    }
+
+    #[cfg(unix)]
+    impl Stub {
+        fn new(sleep: &str, write_png: bool) -> Stub {
+            use std::os::unix::fs::PermissionsExt;
+            static SEQ: AtomicU64 = AtomicU64::new(0);
+            let dir =
+                std::env::temp_dir().join(format!("sandbox-lite-stub-{}-{}", std::process::id(), SEQ.fetch_add(1, Ordering::Relaxed)));
+            std::fs::create_dir_all(&dir).unwrap();
+            let (bin, report) = (dir.join("chrome"), dir.join("profiles"));
+            let png = if write_png { "echo PNGSTUB > \"$out\"" } else { ":" };
+            let script = format!(
+                "#!/bin/sh\nfor arg in \"$@\"; do\n  case \"$arg\" in\n    --user-data-dir=*) echo \"${{arg#--user-data-dir=}}\" >> \"{}\" ;;\n    --screenshot=*) out=\"${{arg#--screenshot=}}\" ;;\n  esac\ndone\nsleep {sleep}\n{png}\n",
+                report.display()
+            );
+            std::fs::write(&bin, script).unwrap();
+            std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+            Stub { dir, bin, report }
+        }
+
+        /// Every profile directory the stub was started with, in order.
+        fn profiles(&self) -> Vec<PathBuf> {
+            std::fs::read_to_string(&self.report).unwrap_or_default().lines().map(PathBuf::from).collect()
+        }
+    }
+
+    #[cfg(unix)]
+    impl Drop for Stub {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+
+    /// Issue #46: N concurrent chats used to spawn N browsers.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn only_so_many_screenshots_run_at_once_and_the_rest_are_told_to_try_again() {
+        let stub = Stub::new("0.6", true);
+        let shots = Shots::with(1, Duration::from_millis(150), Duration::from_secs(20));
+        let f = fixture_with(Vec::new(), false, Some(stub.bin.clone()), shots).await;
+        let t = f.st.store.tenant("acme").unwrap();
+        let input = json!({ "path": "/" });
+        let (first, second) = tokio::join!(screenshot(&f.st, &t, &input), screenshot(&f.st, &t, &input));
+
+        let answers = [first.summary, second.summary];
+        assert!(answers.iter().any(|a| a.starts_with("screenshot of /")), "{answers:?}");
+        assert!(answers.iter().any(|a| a.contains("the screenshot tool is busy")), "{answers:?}");
+        let stats = f.st.shots.stats();
+        assert_eq!((stats.busy, stats.running, stats.limit), (1, 0, 1));
+        assert_eq!(stub.profiles().len(), 1, "the refused call never started a browser");
+        for dir in stub.profiles() {
+            assert!(!dir.exists(), "{} was left behind", dir.display());
+        }
+    }
+
+    /// The profile directory and the PNG go with the value, and the browser is killed and reaped
+    /// before they do, so nothing is still writing into the directory when it is removed.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_screenshot_that_overruns_its_deadline_is_killed_and_leaves_nothing_behind() {
+        let stub = Stub::new("5", false);
+        let shots = Shots::with(1, Duration::from_secs(1), Duration::from_millis(250));
+        let f = fixture_with(Vec::new(), false, Some(stub.bin.clone()), shots).await;
+        let t = f.st.store.tenant("acme").unwrap();
+        let started = Instant::now();
+        let out = screenshot(&f.st, &t, &json!({ "path": "/blog" })).await;
+
+        assert!(out.summary.contains("did not finish within"), "{}", out.summary);
+        assert!(started.elapsed() < Duration::from_secs(4), "{:?}", started.elapsed());
+        let stats = f.st.shots.stats();
+        assert_eq!((stats.timeouts, stats.running), (1, 0));
+        let profiles = stub.profiles();
+        assert_eq!(profiles.len(), 1);
+        assert!(!profiles[0].exists(), "{} outlived the browser", profiles[0].display());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_browser_that_writes_no_png_reports_what_it_said_and_still_cleans_up() {
+        let stub = Stub::new("0", false);
+        let f = fixture_with(Vec::new(), false, Some(stub.bin.clone()), Shots::default()).await;
+        let t = f.st.store.tenant("acme").unwrap();
+        let out = screenshot(&f.st, &t, &json!({ "path": "/" })).await;
+        assert!(out.summary.starts_with("error: chrome wrote no screenshot"), "{}", out.summary);
+        assert!(!stub.profiles()[0].exists());
+    }
+
+    #[test]
+    fn the_summarizer_transcript_keeps_the_newest_turns_it_can_afford() {
+        let turns: Vec<Turn> =
+            (0..500).map(|i| Turn { role: "user".into(), text: format!("turn {i} ").repeat(200), tools: Vec::new() }).collect();
+        let out = transcript("what came before", &turns);
+        assert!(out.len() <= SUMMARY_TRANSCRIPT + "what came before".len() + 256, "{}", out.len());
+        assert!(out.starts_with("Summary of what came before this transcript:\nwhat came before"), "{out}");
+        assert!(out.contains("turn 499"), "the newest turns survive the cut");
+        assert!(!out.contains("turn 0 "), "the oldest do not");
+        assert_eq!(transcript("", &turns[..1]).lines().count(), 1);
+        assert_eq!(transcript("", &[]), "");
     }
 
     #[test]

--- a/src/http/api.rs
+++ b/src/http/api.rs
@@ -71,6 +71,18 @@ fn module_stats(st: &AppState) -> Vec<Value> {
         .collect()
 }
 
+/// Conversations and the bytes they hold across every tenant. They are outside the tenant quota,
+/// so `overlay_bytes` does not see them and this is the only place the chats directory is counted.
+fn chat_stats(st: &AppState) -> Value {
+    let (conversations, bytes) = st.store.tenants().iter().map(|t| st.chats.usage(t)).fold((0, 0), |(n, b), (cn, cb)| (n + cn, b + cb));
+    json!({
+        "conversations": conversations,
+        "bytes": bytes,
+        "max_per_tenant": st.chats.cap(),
+        "window_turns": st.chats.window(),
+    })
+}
+
 pub async fn stats(AxState(st): AxState<State>) -> Json<Value> {
     let tenants = st.store.tenants();
     let overlay_bytes: u64 = tenants.iter().map(|t| t.overlay_stats().1).sum();
@@ -85,6 +97,8 @@ pub async fn stats(AxState(st): AxState<State>) -> Json<Value> {
         "cache": st.engine.stats(),
         "sass": st.engine.sass_stats(),
         "compiles": st.engine.compile_stats(),
+        "chats": chat_stats(&st),
+        "screenshots": st.shots.stats(),
         "modules": module_stats(&st),
         "ai": st.api_key.is_some(),
         "preview_auth": st.preview_secret.is_some(),
@@ -100,6 +114,7 @@ fn snapshot(st: &AppState) -> Snapshot {
     let cache = st.engine.stats();
     let sass = st.engine.sass_stats();
     let compiles = st.engine.compile_stats();
+    let shots = st.shots.stats();
     Snapshot {
         uptime_seconds: st.started.elapsed().as_secs(),
         rss_bytes: rss_kb().map(|kb| kb * 1024),
@@ -119,6 +134,9 @@ fn snapshot(st: &AppState) -> Snapshot {
         compiles_queued: compiles.queued as u64,
         compiles_limit: compiles.limit as u64,
         compiles_refused: compiles.refused,
+        shots_running: shots.running as u64,
+        shots_busy: shots.busy,
+        shots_timeouts: shots.timeouts,
         requests: st.metrics.requests(),
         compile: st.metrics.compiles(),
     }

--- a/src/http/archive.rs
+++ b/src/http/archive.rs
@@ -235,6 +235,7 @@ mod tests {
             preview_secret: None,
             cookie_samesite: crate::http::SameSite::Lax,
             chrome: None,
+            shots: crate::http::ai::Shots::default(),
             started: Instant::now(),
         });
         Fixture { app: crate::http::app(state.clone()), state, root }

--- a/src/http/chats.rs
+++ b/src/http/chats.rs
@@ -1,6 +1,8 @@
 //! Conversations, one JSON file per chat under `<data-dir>/<tenant>/chats/`, or in memory with
 //! `--no-persist`. They are not site files: they never go through the tenant overlay, so they are
-//! invisible to the preview, to `/api/t/{id}/files` and to the tenant quota.
+//! invisible to the preview, to `/api/t/{id}/files` and to the tenant quota. What bounds them
+//! instead is here: a window of turns per conversation, with everything older folded into a
+//! stored summary, and a cap on how many conversations one tenant keeps.
 
 use std::collections::{BTreeMap, HashMap};
 use std::io;
@@ -21,6 +23,18 @@ use super::api::{err, tenant_or_404};
 use crate::store::{Tenant, valid_id};
 
 const TITLE_CHARS: usize = 80;
+
+/// Turns of a conversation replayed to the model in full. Everything older is folded into
+/// `Conversation::summary`, so the request stops growing with the conversation.
+pub const DEFAULT_WINDOW_TURNS: usize = 24;
+/// Conversations one tenant may keep. They do not count against the tenant quota, so this is the
+/// only thing bounding what the chats directory holds.
+pub const DEFAULT_MAX_CHATS: usize = 50;
+/// The summary is prompt text on every later turn, so it is capped like one.
+const MAX_SUMMARY_CHARS: usize = 2000;
+/// How the summary reaches the model: as the opening user turn, which is also the shape
+/// `for_model` needs, since the API wants a user message first.
+const SUMMARY_PREFIX: &str = "Summary of the earlier part of this conversation: ";
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct ToolCall {
@@ -43,13 +57,17 @@ pub struct Conversation {
     pub created: u64,
     pub updated: u64,
     pub title: String,
+    /// What the turns dropped by `compact` said. Absent from a conversation that never grew
+    /// past the window, and from every conversation stored before there was a window.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub summary: String,
     pub messages: Vec<Turn>,
 }
 
 impl Conversation {
     pub fn new(id: String) -> Conversation {
         let now = now_millis();
-        Conversation { id, created: now, updated: now, title: String::new(), messages: Vec::new() }
+        Conversation { id, created: now, updated: now, title: String::new(), summary: String::new(), messages: Vec::new() }
     }
 
     pub fn push(&mut self, turn: Turn) {
@@ -60,13 +78,23 @@ impl Conversation {
         self.updated = now_millis();
     }
 
-    /// The stored turns as Messages API input. Tool calls stay behind as a record for the editor;
-    /// what they did is already in the tenant's files. Empty turns are dropped and same-role
-    /// neighbours joined, because the API refuses empty content and two messages in a row from
-    /// the same role.
-    pub fn for_model(&self) -> Vec<Value> {
+    /// The stored turns as Messages API input: the summary of what came before, then the last
+    /// `keep` turns and no more. Tool calls stay behind as a record for the editor; what they did
+    /// is already in the tenant's files. Empty turns are dropped and same-role neighbours joined,
+    /// because the API refuses empty content and two messages in a row from the same role.
+    ///
+    /// `compact` normally keeps the conversation inside the window, so nothing is cut here. The
+    /// cut is what bounds the request when it could not: a summary the API refused to write, or a
+    /// conversation stored before the window existed.
+    pub fn for_model(&self, keep: usize) -> Vec<Value> {
+        let start = self.messages.len().saturating_sub(keep.max(1));
+        let head = (!self.summary.is_empty()).then(|| Turn {
+            role: "user".into(),
+            text: format!("{SUMMARY_PREFIX}{}", self.summary),
+            tools: Vec::new(),
+        });
         let mut out: Vec<(String, String)> = Vec::new();
-        for turn in self.messages.iter().filter(|t| !t.text.trim().is_empty()) {
+        for turn in head.iter().chain(&self.messages[start..]).filter(|t| !t.text.trim().is_empty()) {
             if out.last().is_some_and(|(role, _)| *role == turn.role) {
                 if let Some((_, text)) = out.last_mut() {
                     text.push_str("\n\n");
@@ -79,18 +107,71 @@ impl Conversation {
         out.into_iter().map(|(role, content)| json!({ "role": role, "content": content })).collect()
     }
 
-    fn summary(&self) -> Value {
-        json!({ "id": self.id, "title": self.title, "created": self.created, "updated": self.updated, "turns": self.messages.len() })
+    /// How many of the oldest turns the summary should swallow, and zero while the conversation
+    /// is inside the window. Past it the window is emptied to half, so the summary is written
+    /// once every `keep / 2` turns rather than once per turn.
+    pub fn overflow(&self, keep: usize) -> usize {
+        let keep = keep.max(2);
+        if self.messages.len() <= keep { 0 } else { self.messages.len() - keep / 2 }
+    }
+
+    /// Replaces the oldest `drop` turns with `summary`, which the caller wrote from them and from
+    /// the summary before it.
+    pub fn compact(&mut self, drop: usize, summary: String) {
+        let drop = drop.min(self.messages.len());
+        if drop == 0 {
+            return;
+        }
+        self.messages.drain(..drop);
+        self.summary = summary.chars().take(MAX_SUMMARY_CHARS).collect::<String>().trim().to_string();
+    }
+
+    fn brief(&self) -> Value {
+        json!({
+            "id": self.id,
+            "title": self.title,
+            "created": self.created,
+            "updated": self.updated,
+            "turns": self.messages.len(),
+            "summarized": !self.summary.is_empty(),
+        })
     }
 }
 
+/// The ids to remove so that at most `cap` conversations remain, least recently updated first.
+/// `keep` is the conversation the save was for and is never evicted, however old it looks.
+pub fn evictable(newest_first: &[Conversation], cap: usize, keep: &str) -> Vec<String> {
+    let over = newest_first.len().saturating_sub(cap.max(1));
+    newest_first.iter().rev().filter(|c| c.id != keep).take(over).map(|c| c.id.clone()).collect()
+}
+
 /// Disk is the store when the tenant has a data directory; the map holds everything otherwise.
-#[derive(Default)]
 pub struct Chats {
     mem: RwLock<HashMap<String, BTreeMap<String, Conversation>>>,
+    cap: usize,
+    window: usize,
+}
+
+impl Default for Chats {
+    fn default() -> Chats {
+        Chats::new(DEFAULT_MAX_CHATS, DEFAULT_WINDOW_TURNS)
+    }
 }
 
 impl Chats {
+    pub fn new(cap: usize, window: usize) -> Chats {
+        Chats { mem: RwLock::new(HashMap::new()), cap: cap.max(1), window: window.max(2) }
+    }
+
+    /// Turns `for_model` replays in full; see `DEFAULT_WINDOW_TURNS`.
+    pub fn window(&self) -> usize {
+        self.window
+    }
+
+    pub fn cap(&self) -> usize {
+        self.cap
+    }
+
     pub fn load(&self, t: &Tenant, id: &str) -> Option<Conversation> {
         if !valid_id(id) {
             return None;
@@ -105,12 +186,48 @@ impl Chats {
         match dir(t) {
             Some(dir) => {
                 std::fs::create_dir_all(&dir)?;
-                std::fs::write(dir.join(format!("{}.json", chat.id)), serde_json::to_vec(chat)?)
+                std::fs::write(dir.join(format!("{}.json", chat.id)), serde_json::to_vec(chat)?)?;
             }
             None => {
                 self.mem.write().unwrap().entry(t.id.clone()).or_default().insert(chat.id.clone(), chat.clone());
-                Ok(())
             }
+        }
+        self.evict(t, &chat.id);
+        Ok(())
+    }
+
+    /// Brings the tenant back under the cap after a save. The count is taken first because it
+    /// costs one `read_dir`, where choosing what to drop costs a parse of every conversation.
+    fn evict(&self, t: &Tenant, saved: &str) {
+        if self.count(t) <= self.cap {
+            return;
+        }
+        for id in evictable(&self.list(t), self.cap, saved) {
+            self.delete(t, &id);
+        }
+    }
+
+    fn count(&self, t: &Tenant) -> usize {
+        match dir(t) {
+            Some(dir) => std::fs::read_dir(dir).into_iter().flatten().flatten().filter(is_chat_file).count(),
+            None => self.mem.read().unwrap().get(&t.id).map_or(0, BTreeMap::len),
+        }
+    }
+
+    /// What the tenant's conversations hold: the size of the files under `<data-dir>/<id>/chats/`,
+    /// or what the in-memory ones would serialize to.
+    pub fn usage(&self, t: &Tenant) -> (usize, u64) {
+        match dir(t) {
+            Some(dir) => std::fs::read_dir(dir)
+                .into_iter()
+                .flatten()
+                .flatten()
+                .filter(is_chat_file)
+                .filter_map(|e| e.metadata().ok())
+                .fold((0, 0), |(n, bytes), m| (n + 1, bytes + m.len())),
+            None => self.mem.read().unwrap().get(&t.id).map_or((0, 0), |m| {
+                m.values().fold((0, 0), |(n, bytes), c| (n + 1, bytes + serde_json::to_vec(c).map_or(0, |v| v.len() as u64)))
+            }),
         }
     }
 
@@ -121,7 +238,7 @@ impl Chats {
                 .into_iter()
                 .flatten()
                 .flatten()
-                .filter(|e| e.file_name().to_string_lossy().ends_with(".json"))
+                .filter(is_chat_file)
                 .filter_map(|e| serde_json::from_slice(&std::fs::read(e.path()).ok()?).ok())
                 .collect(),
             None => self.mem.read().unwrap().get(&t.id).map(|m| m.values().cloned().collect()).unwrap_or_default(),
@@ -150,6 +267,10 @@ fn dir(t: &Tenant) -> Option<PathBuf> {
     t.dir().map(|d| d.join("chats"))
 }
 
+fn is_chat_file(e: &std::fs::DirEntry) -> bool {
+    e.file_name().to_string_lossy().ends_with(".json")
+}
+
 fn now_millis() -> u64 {
     SystemTime::now().duration_since(UNIX_EPOCH).map(|d| d.as_millis() as u64).unwrap_or(1)
 }
@@ -172,7 +293,7 @@ pub async fn list(AxState(st): AxState<State>, AxPath(id): AxPath<String>) -> Re
         Ok(t) => t,
         Err(r) => return r,
     };
-    Json(json!({ "chats": st.chats.list(&t).iter().map(Conversation::summary).collect::<Vec<_>>() })).into_response()
+    Json(json!({ "chats": st.chats.list(&t).iter().map(Conversation::brief).collect::<Vec<_>>() })).into_response()
 }
 
 pub async fn get(AxState(st): AxState<State>, AxPath((id, chat)): AxPath<(String, String)>) -> Response {
@@ -196,11 +317,24 @@ pub async fn remove(AxState(st): AxState<State>, AxPath((id, chat)): AxPath<(Str
 
 #[cfg(test)]
 mod tests {
-    use super::{Conversation, Turn, new_id};
+    use super::{Chats, Conversation, DEFAULT_WINDOW_TURNS, SUMMARY_PREFIX, Turn, evictable, new_id};
+    use crate::store::{Base, Store, Tenant};
     use serde_json::json;
+    use std::path::{Path, PathBuf};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, Ordering};
 
     fn turn(role: &str, text: &str) -> Turn {
         Turn { role: role.into(), text: text.into(), tools: Vec::new() }
+    }
+
+    /// `count` turns, alternating, so `messages[i]` is identifiable by its text.
+    fn conversation(id: &str, count: usize) -> Conversation {
+        let mut c = Conversation::new(id.into());
+        for i in 0..count {
+            c.push(turn(if i % 2 == 0 { "user" } else { "assistant" }, &format!("turn {i}")));
+        }
+        c
     }
 
     #[test]
@@ -211,7 +345,7 @@ mod tests {
             c.push(t);
         }
         assert_eq!(
-            c.for_model(),
+            c.for_model(DEFAULT_WINDOW_TURNS),
             vec![
                 json!({"role":"user","content":"one"}),
                 json!({"role":"assistant","content":"two"}),
@@ -237,5 +371,119 @@ mod tests {
         sorted.sort();
         sorted.dedup();
         assert_eq!(sorted.len(), ids.len());
+    }
+
+    /// Issue #45: the request has to stop growing with the conversation.
+    #[test]
+    fn the_window_opens_only_once_the_conversation_passes_it() {
+        for turns in 0..=8 {
+            assert_eq!(conversation("c", turns).overflow(8), 0, "{turns} turns are inside a window of 8");
+        }
+        assert_eq!(conversation("c", 9).overflow(8), 5, "9 turns drop to half the window");
+        assert_eq!(conversation("c", 10).overflow(8), 6);
+        assert_eq!(conversation("c", 10_000).overflow(8), 9996, "a conversation from before the window is cut in one go");
+        // half a window of headroom, so the summary is written once every four turns, not every turn
+        let mut c = conversation("c", 9);
+        c.compact(c.overflow(8), "earlier".into());
+        assert_eq!(c.messages.len(), 4);
+        assert_eq!(c.overflow(8), 0);
+    }
+
+    #[test]
+    fn compacting_replaces_the_oldest_turns_with_the_summary() {
+        let mut c = conversation("c", 6);
+        c.compact(c.overflow(4), "they asked for a green headline".into());
+        assert_eq!(c.summary, "they asked for a green headline");
+        assert_eq!(c.messages.iter().map(|t| t.text.clone()).collect::<Vec<_>>(), ["turn 4", "turn 5"]);
+        assert_eq!(c.title, "turn 0", "the title survives the turn it was taken from");
+        assert_eq!(
+            c.for_model(4),
+            vec![
+                json!({"role":"user","content":format!("{SUMMARY_PREFIX}they asked for a green headline\n\nturn 4")}),
+                json!({"role":"assistant","content":"turn 5"}),
+            ],
+            "the summary opens the request as a user turn, joined to the user turn that follows it"
+        );
+    }
+
+    /// The summary is written by the API, and the API can be down. `for_model` still has to bound
+    /// the request, so it cuts what `compact` could not.
+    #[test]
+    fn for_model_never_sends_more_than_the_window() {
+        let mut c = conversation("c", 100);
+        let sent = c.for_model(6);
+        assert_eq!(sent.len(), 6);
+        assert_eq!(sent[0], json!({"role":"user","content":"turn 94"}));
+        assert_eq!(sent[5], json!({"role":"assistant","content":"turn 99"}));
+        c.summary = "earlier".into();
+        assert_eq!(c.for_model(0).len(), 2, "a window of zero is the summary and one turn, not a slice out of bounds");
+    }
+
+    #[test]
+    fn a_compacted_conversation_round_trips_through_json() {
+        let mut c = conversation("c", 6);
+        c.compact(c.overflow(4), "x".repeat(super::MAX_SUMMARY_CHARS + 100));
+        assert_eq!(c.summary.chars().count(), super::MAX_SUMMARY_CHARS);
+        let back: Conversation = serde_json::from_slice(&serde_json::to_vec(&c).unwrap()).unwrap();
+        assert_eq!(back.summary, c.summary);
+        assert_eq!(back.messages.len(), 2);
+
+        let old = json!({"id":"c","created":1,"updated":2,"title":"t","messages":[]});
+        let parsed: Conversation = serde_json::from_value(old).unwrap();
+        assert_eq!(parsed.summary, "", "a conversation stored before the window still loads");
+    }
+
+    #[test]
+    fn eviction_takes_the_least_recently_updated_and_never_the_one_just_saved() {
+        let mut list: Vec<Conversation> = (0..5).map(|i| conversation(&format!("c{i}"), 1)).collect();
+        for (i, c) in list.iter_mut().enumerate() {
+            c.updated = 100 - i as u64;
+        }
+        // `list` is newest first, the order `Chats::list` returns
+        assert_eq!(evictable(&list, 3, "c0"), vec!["c4".to_string(), "c3".to_string()]);
+        assert_eq!(evictable(&list, 5, "c0"), Vec::<String>::new());
+        assert_eq!(evictable(&list, 9, "c0"), Vec::<String>::new());
+        assert_eq!(evictable(&list, 3, "c4"), vec!["c3".to_string(), "c2".to_string()], "the saved one is skipped, two others go");
+        assert_eq!(evictable(&list, 0, "c0"), vec!["c4".to_string(), "c3".to_string(), "c2".to_string(), "c1".to_string()]);
+    }
+
+    fn tenant(persist: bool) -> (Arc<Tenant>, PathBuf) {
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let root = std::env::temp_dir().join(format!("sandbox-lite-chats-{}-{}", std::process::id(), SEQ.fetch_add(1, Ordering::Relaxed)));
+        std::fs::create_dir_all(&root).unwrap();
+        let store = Store::new(persist.then(|| root.clone()), u64::MAX);
+        let base = Path::new(env!("CARGO_MANIFEST_DIR")).join("examples/starter");
+        store.add_base(Base::load("starter", &base).unwrap());
+        (store.create_tenant("acme", "starter").unwrap(), root)
+    }
+
+    /// Issue #45: conversations do not count against the tenant quota, so the cap is what keeps a
+    /// tenant from accumulating chat files without end.
+    #[test]
+    fn saving_past_the_cap_drops_the_oldest_conversation() {
+        for persist in [true, false] {
+            let (t, root) = tenant(persist);
+            let chats = Chats::new(3, 8);
+            for i in 0..6 {
+                let mut c = conversation(&format!("c{i}"), 2);
+                c.updated = 1000 + i as u64;
+                chats.save(&t, &c).unwrap();
+                assert!(chats.list(&t).len() <= 3, "persist={persist}, after {i}");
+            }
+            let left: Vec<String> = chats.list(&t).into_iter().map(|c| c.id).collect();
+            assert_eq!(left, ["c5", "c4", "c3"], "persist={persist}");
+            assert!(chats.load(&t, "c0").is_none(), "persist={persist}");
+            let (count, bytes) = chats.usage(&t);
+            assert_eq!(count, 3, "persist={persist}");
+            assert!(bytes > 0, "persist={persist}");
+            let _ = std::fs::remove_dir_all(&root);
+        }
+    }
+
+    #[test]
+    fn usage_is_zero_for_a_tenant_that_has_never_chatted() {
+        let (t, root) = tenant(true);
+        assert_eq!(Chats::default().usage(&t), (0, 0));
+        let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -43,6 +43,7 @@ pub struct AppState {
     pub preview_secret: Option<String>,
     pub cookie_samesite: SameSite,
     pub chrome: Option<PathBuf>,
+    pub shots: ai::Shots,
     pub started: Instant,
 }
 
@@ -294,6 +295,7 @@ mod tests {
             preview_secret: None,
             cookie_samesite: SameSite::Lax,
             chrome: None,
+            shots: super::ai::Shots::default(),
             started: Instant::now(),
         }))
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,14 +30,24 @@ struct Args {
     tenant_quota_mb: u64,
     cookie_samesite: http::SameSite,
     chrome: Option<PathBuf>,
+    chrome_jobs: usize,
+    chat_window: usize,
+    chats_per_tenant: usize,
 }
 
 fn usage() -> ! {
     eprintln!(
-        "sandbox-lite {}\n\nUsage: sandbox-lite [options]\n       sandbox-lite check [--json] DIR...   compile every source file of an Astro project and print diagnostics + a feature census\n\n  --listen ADDR        bind address (default 127.0.0.1:4321)\n  --domain NAME        preview domain; tenants are served at http://<id>.NAME:PORT/ (default localhost)\n  --bases DIR          directory whose sub-directories are base projects (default ./examples if present)\n  --base NAME=PATH     add one base project (repeatable)\n  --data-dir DIR       where tenant edits are persisted (default ./data)\n  --no-persist         keep tenant edits in memory only\n  --cdn URL            where bare npm imports are fetched from in the browser (default https://esm.sh)\n  --cache-mb N         transform cache budget in MiB (default 64)\n  --max-source-kb N    largest .astro/.ts/.js/.mdx/.scss file the compilers accept, in KiB (default 64)\n  --sass-timeout-ms N  deadline for one Sass compile, after which the request fails (default 5000)\n  --max-compiles N     compiles that may run at once; one that waits too long for a slot is refused with 503 (default: one per core)\n  --model NAME         Claude model for the built-in chat (default claude-fable-5-1)\n  --api-token TOKEN    require `Authorization: Bearer TOKEN` (or ?token=) on /api/*\n  --preview-secret S   tenant hosts need a per-tenant token derived from S (the API hands it out)\n  --chrome PATH        chrome or chromium binary for the chat's screenshot tool (default: off)\n  --tenant-quota-mb N  edited files a tenant may hold, in MiB; a write past it is refused with 413 (default 64)\n  --cookie-samesite lax|none\n                       SameSite of the preview cookie; none also sets Secure (default lax)\n\nEnvironment: ANTHROPIC_API_KEY enables the chat endpoint; SANDBOX_LITE_API_TOKEN, SANDBOX_LITE_PREVIEW_SECRET, SANDBOX_LITE_TENANT_QUOTA_MB, SANDBOX_LITE_MAX_COMPILES and SANDBOX_LITE_CHROME are read as defaults for those flags; SANDBOX_LITE_ANTHROPIC_BASE points the chat at another Messages API endpoint (default https://api.anthropic.com).",
-        env!("CARGO_PKG_VERSION")
+        "sandbox-lite {}\n\nUsage: sandbox-lite [options]\n       sandbox-lite check [--json] DIR...   compile every source file of an Astro project and print diagnostics + a feature census\n\n  --listen ADDR        bind address (default 127.0.0.1:4321)\n  --domain NAME        preview domain; tenants are served at http://<id>.NAME:PORT/ (default localhost)\n  --bases DIR          directory whose sub-directories are base projects (default ./examples if present)\n  --base NAME=PATH     add one base project (repeatable)\n  --data-dir DIR       where tenant edits are persisted (default ./data)\n  --no-persist         keep tenant edits in memory only\n  --cdn URL            where bare npm imports are fetched from in the browser (default https://esm.sh)\n  --cache-mb N         transform cache budget in MiB (default 64)\n  --max-source-kb N    largest .astro/.ts/.js/.mdx/.scss file the compilers accept, in KiB (default 64)\n  --sass-timeout-ms N  deadline for one Sass compile, after which the request fails (default 5000)\n  --max-compiles N     compiles that may run at once; one that waits too long for a slot is refused with 503 (default: one per core)\n  --model NAME         Claude model for the built-in chat (default claude-fable-5-1)\n  --api-token TOKEN    require `Authorization: Bearer TOKEN` (or ?token=) on /api/*\n  --preview-secret S   tenant hosts need a per-tenant token derived from S (the API hands it out)\n  --chrome PATH        chrome or chromium binary for the chat's screenshot tool (default: off)\n  --chrome-jobs N      screenshots that may run at once; a call that waits longer than 10s is told the tool is busy (default {})\n  --chat-window N      turns of a conversation replayed to the model in full; older ones are folded into a stored summary (default {})\n  --chats-per-tenant N conversations a tenant may keep; saving past it drops the least recently updated (default {})\n  --tenant-quota-mb N  edited files a tenant may hold, in MiB; a write past it is refused with 413 (default 64)\n  --cookie-samesite lax|none\n                       SameSite of the preview cookie; none also sets Secure (default lax)\n\nEnvironment: ANTHROPIC_API_KEY enables the chat endpoint; SANDBOX_LITE_API_TOKEN, SANDBOX_LITE_PREVIEW_SECRET, SANDBOX_LITE_TENANT_QUOTA_MB, SANDBOX_LITE_MAX_COMPILES, SANDBOX_LITE_CHROME, SANDBOX_LITE_CHROME_JOBS, SANDBOX_LITE_CHAT_WINDOW and SANDBOX_LITE_CHATS_PER_TENANT are read as defaults for those flags; SANDBOX_LITE_ANTHROPIC_BASE points the chat at another Messages API endpoint (default https://api.anthropic.com).",
+        env!("CARGO_PKG_VERSION"),
+        http::ai::DEFAULT_CHROME_JOBS,
+        http::chats::DEFAULT_WINDOW_TURNS,
+        http::chats::DEFAULT_MAX_CHATS
     );
     std::process::exit(2)
+}
+
+fn env_usize(name: &str, default: usize) -> usize {
+    std::env::var(name).ok().filter(|v| !v.is_empty()).map_or(default, |v| v.parse().unwrap_or_else(|_| usage()))
 }
 
 fn parse_args() -> Args {
@@ -64,6 +74,9 @@ fn parse_args() -> Args {
             .map_or(64, |v| v.parse().unwrap_or_else(|_| usage())),
         cookie_samesite: http::SameSite::Lax,
         chrome: std::env::var("SANDBOX_LITE_CHROME").ok().filter(|v| !v.is_empty()).map(PathBuf::from),
+        chrome_jobs: env_usize("SANDBOX_LITE_CHROME_JOBS", http::ai::DEFAULT_CHROME_JOBS),
+        chat_window: env_usize("SANDBOX_LITE_CHAT_WINDOW", http::chats::DEFAULT_WINDOW_TURNS),
+        chats_per_tenant: env_usize("SANDBOX_LITE_CHATS_PER_TENANT", http::chats::DEFAULT_MAX_CHATS),
     };
     let mut it = std::env::args().skip(1);
     while let Some(a) = it.next() {
@@ -90,6 +103,9 @@ fn parse_args() -> Args {
             "--tenant-quota-mb" => args.tenant_quota_mb = value().parse().unwrap_or_else(|_| usage()),
             "--cookie-samesite" => args.cookie_samesite = value().parse().unwrap_or_else(|_| usage()),
             "--chrome" => args.chrome = Some(PathBuf::from(value())),
+            "--chrome-jobs" => args.chrome_jobs = value().parse().unwrap_or_else(|_| usage()),
+            "--chat-window" => args.chat_window = value().parse().unwrap_or_else(|_| usage()),
+            "--chats-per-tenant" => args.chats_per_tenant = value().parse().unwrap_or_else(|_| usage()),
             "-h" | "--help" => usage(),
             _ => usage(),
         }
@@ -170,7 +186,7 @@ async fn main() {
             metrics.clone(),
         ),
         metrics,
-        chats: http::chats::Chats::default(),
+        chats: http::chats::Chats::new(args.chats_per_tenant, args.chat_window),
         domain: args.domain.clone(),
         port,
         model: args.model.clone(),
@@ -183,6 +199,7 @@ async fn main() {
         preview_secret: args.preview_secret.clone(),
         cookie_samesite: args.cookie_samesite,
         chrome: args.chrome.clone(),
+        shots: http::ai::Shots::new(args.chrome_jobs),
         started: Instant::now(),
     });
     let listener = match tokio::net::TcpListener::bind(&args.listen).await {
@@ -198,7 +215,7 @@ async fn main() {
         args.domain,
         if state.api_key.is_some() { format!("enabled ({})", state.model) } else { "disabled (set ANTHROPIC_API_KEY)".to_string() },
         match &state.chrome {
-            Some(path) => format!("via {}", path.display()),
+            Some(path) => format!("via {} ({} at a time)", path.display(), args.chrome_jobs),
             None => "off (set --chrome)".to_string(),
         },
         if state.api_token.is_some() { "required" } else { "off" },

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -122,6 +122,9 @@ pub struct Snapshot {
     pub compiles_queued: u64,
     pub compiles_limit: u64,
     pub compiles_refused: u64,
+    pub shots_running: u64,
+    pub shots_busy: u64,
+    pub shots_timeouts: u64,
     pub requests: [[u64; STATUSES.len()]; KINDS.len()],
     pub compile: [HistogramSnapshot; KINDS.len()],
 }
@@ -194,6 +197,22 @@ pub fn render(s: &Snapshot) -> String {
         "counter",
         "Compiles refused with 503 after waiting for a permit.",
         s.compiles_refused,
+    );
+
+    scalar(&mut out, "sandbox_lite_screenshots_running", "gauge", "Headless Chrome screenshots in flight.", s.shots_running);
+    scalar(
+        &mut out,
+        "sandbox_lite_screenshots_busy_total",
+        "counter",
+        "Screenshot tool calls answered 'busy' because every slot was taken for the whole wait.",
+        s.shots_busy,
+    );
+    scalar(
+        &mut out,
+        "sandbox_lite_screenshots_timeouts_total",
+        "counter",
+        "Screenshots whose browser overran its deadline and was killed.",
+        s.shots_timeouts,
     );
 
     family(&mut out, "sandbox_lite_module_requests_total", "counter", "Requests answered by the preview module endpoint.");
@@ -287,6 +306,9 @@ mod tests {
             compiles_queued: 5,
             compiles_limit: 8,
             compiles_refused: 6,
+            shots_running: 1,
+            shots_busy: 5,
+            shots_timeouts: 6,
             requests: m.requests(),
             compile: m.compiles(),
         };
@@ -353,6 +375,15 @@ sandbox_lite_compiles_limit 8
 # HELP sandbox_lite_compiles_refused_total Compiles refused with 503 after waiting for a permit.
 # TYPE sandbox_lite_compiles_refused_total counter
 sandbox_lite_compiles_refused_total 6
+# HELP sandbox_lite_screenshots_running Headless Chrome screenshots in flight.
+# TYPE sandbox_lite_screenshots_running gauge
+sandbox_lite_screenshots_running 1
+# HELP sandbox_lite_screenshots_busy_total Screenshot tool calls answered 'busy' because every slot was taken for the whole wait.
+# TYPE sandbox_lite_screenshots_busy_total counter
+sandbox_lite_screenshots_busy_total 5
+# HELP sandbox_lite_screenshots_timeouts_total Screenshots whose browser overran its deadline and was killed.
+# TYPE sandbox_lite_screenshots_timeouts_total counter
+sandbox_lite_screenshots_timeouts_total 6
 # HELP sandbox_lite_module_requests_total Requests answered by the preview module endpoint.
 # TYPE sandbox_lite_module_requests_total counter
 sandbox_lite_module_requests_total{kind="module",status="200"} 3
@@ -458,6 +489,9 @@ sandbox_lite_compile_seconds_count{kind="url"} 0
             compiles_queued: 0,
             compiles_limit: 1,
             compiles_refused: 0,
+            shots_running: 0,
+            shots_busy: 0,
+            shots_timeouts: 0,
             requests: m.requests(),
             compile: m.compiles(),
         };


### PR DESCRIPTION
Closes #45

Closes #46

The chat from #39 has no limits on either side of it. Both are in one PR because
both are the chat's missing bounds and they share the flag and stats plumbing.

## #45 — conversations grew without bound

`for_model` replayed every stored turn, so one conversation grew the request
until the model's context was the limit, and nothing capped how many
conversations a tenant kept — they are deliberately outside the tenant quota, so
nothing else was going to.

- **A window.** A conversation sends the last `--chat-window` turns (default 24)
  in full. When it passes the window, everything older is folded into one
  summary — written once by the same Messages API, capped at 2000 characters,
  stored on the conversation and sent from then on as its opening user turn.
  Compaction empties the window to half, so the summary is written about once
  every twelve turns rather than once per turn.
- **When that call fails**, nothing is dropped: the turns stay stored and
  `for_model` cuts them out of the request instead. So the request is bounded
  whether or not a summary exists, and that also covers conversations stored
  before this change.
- **A per-tenant cap.** `--chats-per-tenant` (default 50): a save past it drops
  the tenant's least recently updated conversation, never the one just saved.
  The count is read with one `read_dir`; only a tenant actually over the cap
  pays for parsing to decide what goes.
- **`/api/stats`** gains `chats: {conversations, bytes, max_per_tenant,
  window_turns}` — the chats directory across every tenant, which
  `overlay_bytes` cannot see.
- The editor shows a stored summary above the turns that remain, so a customer
  is not left wondering where the head of the thread went.

## #46 — the screenshot tool spawned unbounded browsers

Every call spawned Chrome with a fresh profile and no limit, so N concurrent
chats meant N browsers on a daemon that otherwise costs ~12 kB per tenant.

- **A semaphore.** `--chrome-jobs` (default 1) run at once. A call that has not
  got a slot within 10 s is told `the screenshot tool is busy … try again in a
  moment` — an answer the model can act on, rather than a queue with no end.
- **Cleanup on the deadline.** The wait is now `child.wait()` with the browser's
  stderr redirected to a file inside the profile directory, rather than
  `wait_with_output()` on a pipe, which consumes the child and so cannot be
  killed and awaited. On the deadline the browser is killed *and reaped* before
  `Scratch` removes the directory, so nothing is still writing into it when it
  goes; a removal that fails now says so instead of being swallowed.
- **`/api/stats`** gains `screenshots: {running, limit, busy, timeouts}`, and
  `/metrics` gains `sandbox_lite_screenshots_running`,
  `sandbox_lite_screenshots_busy_total` and
  `sandbox_lite_screenshots_timeouts_total`.

## Flags

| flag | env | default |
|---|---|---|
| `--chat-window N` | `SANDBOX_LITE_CHAT_WINDOW` | 24 |
| `--chats-per-tenant N` | `SANDBOX_LITE_CHATS_PER_TENANT` | 50 |
| `--chrome-jobs N` | `SANDBOX_LITE_CHROME_JOBS` | 1 |

README flags table, environment list, `/api/stats` and `/metrics` sections and
SECURITY.md are updated with them; SECURITY.md's "up to 16 calls to the
Anthropic API per request" now says the summarizer can add one.

## Proof

There is no `ANTHROPIC_API_KEY` in CI, so the proof is tests:

- `overflow`, `compact`, `for_model` and `evictable` are pure functions of
  stored state and are tested directly — including a 10 000-turn conversation
  from before the window, a summary that would overflow the cap, and the old
  on-disk JSON shape still deserializing.
- The tool loop's stub upstream now answers a non-streaming request as the
  summarizer's, so the end-to-end tests assert that a long conversation is
  summarized **once**, that the summary is stored and reaches the next request,
  that three later requests add no further summarize calls, and that a summary
  the API refuses leaves every turn stored while still bounding the request to
  the window.
- The screenshot limiter is tested against a shell script that sleeps and writes
  a file where Chrome would be: two concurrent calls, one screenshot and one
  "busy"; a browser that overruns its deadline, with the profile directory it
  reports asserted gone afterwards.
- The smoke test greps the two new metric families and `/api/stats` for the cap.

CI on this branch:
https://github.com/productdevbook/sandbox-lite/actions/runs/34057574620 — green,
both jobs (fmt, clippy `-D warnings`, tests, `check`, release build, smoke,
`bench/mem.sh`, Playwright).

## Noticed, did not fix

- One conversation's *file* is still unbounded on disk: the window bounds the
  request, and compaction drops turns, but nothing caps a single turn's text
  (only the 64 MiB body limit does), so a determined caller can grow one chat
  file. The cap counts conversations, not bytes.
- If the SSE client disconnects mid-screenshot the whole future is dropped, and
  `Scratch::drop` then races `kill_on_drop`, which SIGKILLs the browser but
  cannot be awaited from a `Drop`. The deadline path — what #46 asked for — is
  handled; cancellation is best-effort.
- Killing the browser does not kill the helper processes Chrome forks. They
  normally exit with it; a process group would make that certain.
- `for_model` output plus the caller's new message can put two `user` messages
  in a row if the last stored assistant turn was empty (a pre-existing hole in
  the #39 code, not touched here).
- `/api/stats` now walks every tenant's chats directory on each request. It is
  an admin endpoint, but it is no longer O(1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
