### PR TITLE
bases: reload at runtime, an optional watcher, and multi-node notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,10 @@ jobs:
           curl -sf -H 'Host: ci.localhost' 'http://127.0.0.1:4399/__sl/m/src/pages/index.astro?v=1' | grep -q createComponent
           curl -sf -H 'Host: ci.localhost' 'http://127.0.0.1:4399/__sl/routes.json' | grep -q '"/blog/\[slug\]"'
           curl -sf -H 'Host: ci.localhost' 'http://127.0.0.1:4399/' | grep -q shell.js
+          # issue #16: a base reloads at runtime and re-points the tenants on it
+          curl -sf -X POST http://127.0.0.1:4399/api/bases/starter/reload | grep -qF '"tenants":["ci"]'
+          test 400 = "$(curl -s -o /dev/null -w '%{http_code}' -X POST -H 'content-type: application/json' \
+            -d '{"name":"outside","path":"/etc"}' http://127.0.0.1:4399/api/bases)"
           # issue #25: deeply nested source must answer rather than abort the daemon
           python3 -c "print('const x = ' + '['*20000)" > deep.ts
           python3 -c "print('<style>p{color:red}</style><script>console.log(1)</script>' + '<div>'*1000 + 'x' + '</div>'*1000)" > deep.astro

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -21,7 +21,8 @@ one per request from the `Host` header (lowercased, port stripped):
   (`preview::page`) for everything else. `require_preview_token` wraps all of
   it.
 - Any other host goes to the **editor/API router**: `/` (the editor page),
-  `/health`, `/metrics`, `/api/stats`, `/api/bases`, `/api/tenants`,
+  `/health`, `/metrics`, `/api/stats`, `/api/bases`,
+  `/api/bases/{name}/reload`, `/api/tenants`,
   `/api/tenants/{id}`, `/api/t/{id}/files`, `/api/t/{id}/file/{*path}`,
   `/api/t/{id}/events`, `/api/t/{id}/check`, `/api/t/{id}/chat`, with a 64 MiB
   body limit. `require_api_token` wraps all of it.
@@ -30,18 +31,21 @@ one per request from the `Host` header (lowercased, port stripped):
 
 ## Store: bases, overlays, versions (`src/store.rs`)
 
-A **base** is a project directory read once at startup (`Base::load`): every
-regular file, skipping `node_modules`, `.git`, `dist`, `.astro`, `.vercel`,
-`.netlify`, `.output`. Files up to 256 KiB are held in memory
-(`FileData::Mem`); larger ones stay on disk and are re-read on each access
-(`FileData::Disk`). Bases come from every sub-directory of `--bases` (default
-`./examples` when it exists) and from each `--base NAME=PATH`.
+A **base** is a project directory read at startup (`Base::load`): every regular
+file, skipping `node_modules`, `.git`, `dist`, `.astro`, `.vercel`, `.netlify`,
+`.output`. Files up to 256 KiB are held in memory (`FileData::Mem`); larger ones
+stay on disk and are re-read on each access (`FileData::Disk`). Bases come from
+every sub-directory of `--bases` (default `./examples` when it exists), from
+each `--base NAME=PATH`, and from `POST /api/bases` at run time. `Base::load`
+also records a `stamp`: a hash of the name, size and mtime of every file it
+took, in path order, which is what the watcher compares.
 
-A **tenant** is an `Arc<Base>` plus an overlay,
-`BTreeMap<String, Option<FileData>>`: `Some` is a file the tenant added or
-changed, `None` is a tombstone hiding a base file. `Tenant::data` consults the
-overlay first, so a tombstone makes the base file disappear; `Tenant::list`
-merges both views and flags overlay entries as `modified`. Two tenants on the
+A **tenant** is an `Arc<Base>` — behind an `RwLock` so a reload can swap it —
+plus an overlay, `BTreeMap<String, Option<FileData>>`: `Some` is a file the
+tenant added or changed, `None` is a tombstone hiding a base file.
+`Tenant::data` consults the overlay first, so a tombstone makes the base file
+disappear; `Tenant::list` merges both views and flags overlay entries as
+`modified`. Two tenants on the
 same base share the base's memory; a tenant costs its overlay.
 
 Each tenant has a **version**, a `u64` of milliseconds since the epoch at
@@ -69,7 +73,26 @@ With a `--data-dir`, the overlay is persisted as
 and `<data-dir>/<id>/deleted.json` (the tombstones). Every write goes to disk;
 files over 256 KiB are then kept only there. `Store::restore` rebuilds tenants
 at startup with a fresh version and skips any whose base is not loaded.
-`--no-persist` keeps everything in memory.
+`Store::tenant` falls back to the same read on a miss, so a tenant another
+daemon created under a shared `--data-dir` is restored the first time this one
+is asked for it; a tenant already in memory is never re-read, which is the
+limit `docs/multi-node.md` sets out. `--no-persist` keeps everything in memory.
+
+### Reloading a base
+
+`Store::reload_base` re-reads a base from its own root, swaps the new
+`Arc<Base>` into the store, and points every tenant on it at the same `Arc`
+(`Tenant::set_base`, a `RwLock<Arc<Base>>`). Each of those tenants is bumped and
+gets one `update` event, so open previews reload; overlays are untouched, so an
+edited file still wins over the new base copy. The transform cache needs no
+invalidation, being content-addressed: a changed file hashes to a new key.
+
+`POST /api/bases/{name}/reload` calls it on the blocking pool.
+`--watch-bases N` runs `Store::reload_changed_bases` every N seconds, also on
+the blocking pool: one `stamp(root)` walk per base, and a reload only where the
+stamp moved. The walk is the same function `Base::load` uses, so it skips
+exactly what a load skips. A rewrite that changes neither the size nor the
+mtime is invisible to it.
 
 ### Export and import (`src/http/archive.rs`)
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ its 20 s deadline is killed and reaped before its profile directory goes.
 --domain NAME        tenants are served at http://<id>.NAME:PORT/ (default localhost)
 --bases DIR          directory whose sub-directories are base projects
 --base NAME=PATH     add one base project (repeatable)
+--watch-bases N      re-read a base project when its files change, polled every N seconds (default: off)
 --data-dir DIR       where tenant edits are persisted (default ./data)
 --no-persist         keep edits in memory only
 --cdn URL            where bare npm imports resolve in the browser (default https://esm.sh)
@@ -253,6 +254,8 @@ Editor host (`localhost`):
 |---|---|---|
 | GET | `/metrics` | Prometheus text format: gauges, cache and request counters, compile-latency histograms |
 | GET | `/api/stats` | RSS, tenant count, cache stats, what the chats directory holds, screenshots in flight, module requests and compile totals |
+| GET/POST | `/api/bases` | list / add `{name, path}`; the path must be inside `--bases` when that flag is set |
+| POST | `/api/bases/{name}/reload` | re-read the base from disk and re-point every tenant on it |
 | GET/POST | `/api/tenants` | list / create `{id, base}` |
 | DELETE | `/api/tenants/{id}` | remove tenant and its edits |
 | POST | `/api/tenants/{id}/import` | tar.gz body → overlay; `?replace=1` drops the edits it does not carry |
@@ -312,6 +315,39 @@ Tenant host (`<id>.<domain>`):
 | `/__sl/events` | same SSE stream as the API; the page swaps CSS or reloads itself on it |
 | anything under `public/` | served directly |
 
+## Updating a base project
+
+Base projects are read into memory at startup, so a theme fix on disk does not
+reach the tenants built on it by itself. Two ways to make it:
+
+```sh
+curl -fsS -X POST localhost:4321/api/bases/starter/reload
+# {"name":"starter","files":24,"bytes":38104,"root":"/srv/themes/starter","tenants":["acme","bakery"]}
+
+sandbox-lite --bases /srv/themes --watch-bases 5   # or poll for it
+```
+
+Either one re-walks the base directory, swaps the result in, and re-points
+every tenant on that base — each of which gets a version bump and one `update`
+event, so open previews reload. A tenant's own edits are untouched: the overlay
+still wins over the base copy of a file it has edited, and an edit over a file
+the reload deleted stays visible. The transform cache needs no invalidation,
+being keyed by content: a changed file simply hashes to a new key.
+
+`--watch-bases N` polls each base root every N seconds, comparing the name,
+size and mtime of every file `Base::load` would take — one walk per base per
+interval, no inotify, no new dependency. A rewrite that keeps both the size and
+the mtime is not noticed; the reload endpoint is the escape hatch for that.
+
+`POST /api/bases {"name","path"}` adds a base to a running daemon. With
+`--bases` set the path must resolve inside that directory; without it, any
+readable directory on the host will do — the API token is the only gate, so
+this is an operator surface. See `SECURITY.md`.
+
+Bases and reloads are per process. Running more than one daemon behind a load
+balancer with a shared `--data-dir` — what each node does and does not see, and
+the two configurations that work — is [`docs/multi-node.md`](docs/multi-node.md).
+
 ## How a page renders
 
 1. `GET http://acme.localhost:4321/blog/hello-world` → the daemon answers with a
@@ -369,6 +405,7 @@ examples/vue           a TypeScript Vue SFC compiled in the browser and hydrated
 examples/svelte        the same for a Svelte 5 component
 scripts/build-runtime.sh   regenerates assets/astro.js and assets/astro-jsx.js for a new Astro version
 bench/mem.sh           the memory measurement above
+docs/multi-node.md     two daemons behind a load balancer over one --data-dir: what each node sees, and the routing that works
 e2e/                   Playwright suite for the browser side: every example page, endpoints, live reload, hydration, the error overlay
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,8 +40,9 @@ and parses JSON/YAML; the resulting JavaScript runs in the visitor's browser on
 the tenant origin, using Astro's own runtime bundled as `/__sl/astro.js`.
 
 Whoever can call `/api/*` owns every tenant: create, delete, read and write any
-file, drive the chat endpoint. There are no users, roles or per-tenant
-credentials on the API side.
+file, drive the chat endpoint. They also decide what the daemon reads off the
+host as a base project, bounded only by `--bases` (below). There are no users,
+roles or per-tenant credentials on the API side.
 
 ## What the daemon enforces
 
@@ -54,9 +55,22 @@ credentials on the API side.
   cannot leave it.
 - **Tenant ids** are validated by `valid_id` (same rule as the host label) and
   are used as directory names under `--data-dir`.
-- **Base projects** are read once at startup. `node_modules`, `.git`, `dist`,
-  `.astro`, `.vercel`, `.netlify` and `.output` are skipped, and so is anything
-  that is not a regular file or directory (symbolic links are not followed).
+- **Base projects** are read at startup, and again on
+  `POST /api/bases/{name}/reload` or a `--watch-bases` tick. `node_modules`,
+  `.git`, `dist`, `.astro`, `.vercel`, `.netlify` and `.output` are skipped,
+  and so is anything that is not a regular file or directory (symbolic links
+  are not followed) — by the reload and the poll exactly as by the first read,
+  since all three walk the same function.
+- **Adding a base at runtime** (`POST /api/bases` with `{"name", "path"}`) is
+  an operator-only surface behind `--api-token`, and nothing else gates it.
+  The name must pass `valid_id`. The path is canonicalized, must be a
+  directory, and must resolve inside `--bases` when that flag is set — which
+  refuses a symbolic link out of it, since the link is resolved before the
+  check. **Without `--bases` there is no containment at all**: any directory
+  the daemon's user can read becomes a base, and every file in it is then
+  served to whoever can open a preview on a tenant created from it (see
+  "Tenant files are public to anyone who can open the preview"). Set `--bases`
+  on any daemon whose API is reachable by anything but your own backend.
 - **Request bodies** on the editor/API router are capped at 64 MiB
   (`DefaultBodyLimit`). No tenant-host handler reads a request body.
 - **Compiled source** is bounded three ways before it reaches oxc,
@@ -195,6 +209,9 @@ that router answers `401` unless the request carries
 - It is the only thing gating `POST /api/tenants/{id}/import`, which writes a
   whole file tree into a tenant in one request, and
   `GET /api/t/{id}/export`, which returns one.
+- It is the only thing gating `POST /api/bases`, which reads a directory of
+  the host into memory, and `POST /api/bases/{name}/reload`, which re-reads
+  one and makes every tenant on it reload.
 - It does nothing for tenant hosts.
 
 ### `--preview-secret S` (`require_preview_token`, `src/http/mod.rs`)
@@ -321,7 +338,8 @@ editor stores the API token in `localStorage` and embeds tenant previews in an
 1. Previews on their own registrable domain; wildcard DNS for it; `--domain`
    set to that name.
 2. Editor and `/api/*` reachable only from your backend, on a hostname the
-   proxy does not expose; `--api-token` set as well.
+   proxy does not expose; `--api-token` set as well; `--bases` set, so a base
+   added over the API cannot come from anywhere else on the host.
 3. `--preview-secret` set; links built from `preview_token` with your scheme
    and host; the TLS proxy sends `x-forwarded-proto: https` so the cookie is
    `Secure`.

--- a/docs/multi-node.md
+++ b/docs/multi-node.md
@@ -1,0 +1,122 @@
+# Several daemons behind a load balancer
+
+Two sandbox-lite processes can share one `--data-dir` on NFS, EFS or an S3
+mount. What follows is what actually happens when they do, and the two
+configurations that work today. Every claim is about the code in `src/` as it
+is; where it says "does not", that is a limit, not a plan.
+
+## What a daemon holds in memory
+
+A daemon is not a stateless front end over the data directory. Each one holds:
+
+- **Base projects**, read from disk at startup (`Base::load`) and re-read only
+  on `POST /api/bases/{name}/reload` or a `--watch-bases` tick. Each daemon
+  reads its own copy; nothing is shared.
+- **Tenants**, each an `Arc<Base>` plus an overlay
+  (`BTreeMap<String, Option<FileData>>`) built from `<data-dir>/<id>/files` and
+  `deleted.json` at startup (`Store::restore`), or on the first lookup that
+  misses (below). After that the overlay is the daemon's own copy: it is
+  written through to disk, and never re-read.
+- **A version per tenant**, milliseconds since the epoch, bumped on every
+  write. It is not persisted: a restart, or a restore on another node, produces
+  a fresh one.
+- **An SSE channel per tenant** (`tokio::sync::broadcast`, 64 slots) that only
+  that daemon's own writes publish to.
+
+So with two daemons, A and B, sharing `--data-dir`:
+
+| | What happens |
+|---|---|
+| `PUT /api/t/acme/file/src/pages/index.astro` on A | A's overlay and `<data-dir>/acme/files/…` both change. B's overlay does not. |
+| A preview open against B | B still serves its own copy of the file, at its own version. It gets no event, so it does not reload. |
+| `GET /api/t/acme/files` on B | B's view: the files it knows about, at B's version. |
+| A tenant created on A, then a request for it on B | B has no such tenant in memory, so it restores one from `<data-dir>/acme` and serves it (`Store::tenant`). |
+| A writes again after B has restored | B does not see it. The restore happens once, on the miss. |
+| `DELETE /api/tenants/acme` on A | The directory goes; B keeps serving the tenant it already holds in memory. |
+| `POST /api/bases/theme/reload` on A | Only A re-reads the base. B keeps the copy it loaded. |
+| `/api/stats`, `/metrics` on B | B's own tenants, cache and subscribers. Neither number is a cluster total. |
+
+The version being per node also means a browser that moves from A to B
+mid-session gets a lower `?v=` than it had. That is harmless — the daemon never
+reads the value, it only busts the browser cache — but the two nodes' numbers
+are not comparable, and neither is a total.
+
+Nothing here is corruption: writes go through the tenant's write lock on the
+node that serves them, and each file write is a whole-file `std::fs::write`.
+Two nodes writing the same file at the same time is last-writer-wins on the shared
+filesystem, with each node's memory holding what it wrote. The problem is
+staleness, not tearing.
+
+## Configuration 1: sticky routing by tenant host
+
+Route on the `Host` header — `acme.preview.example.com` always to the same
+node — and every write for a tenant lands on the node that serves it. This is
+the configuration to use.
+
+```nginx
+# hash on the first label of the preview host, so one tenant is always one node
+map $host $tenant { ~^(?<label>[^.]+)\.preview\.example\.com$ $label; default $host; }
+
+upstream previews {
+    hash $tenant consistent;
+    server 10.0.0.1:4321;
+    server 10.0.0.2:4321;
+}
+
+server {
+    server_name ~^[^.]+\.preview\.example\.com$;
+    location / { proxy_pass http://previews; proxy_set_header Host $host; }
+}
+```
+
+The editor and `/api/*` answer on every host that is *not* a tenant host
+(`SECURITY.md`), so they need the same treatment: an API call about `acme` must
+reach the node serving `acme`. Route `/api/t/{id}/…` and
+`/api/tenants/{id}/…` by that `{id}` with the same hash, and the writes and the
+preview stay on one node.
+
+What still bites:
+
+- **A node coming or going reshuffles the hash.** With `hash … consistent` only
+  a share of tenants move, and a moved tenant is restored from the data
+  directory on its new node — with whatever the old node had already written to
+  disk, which is everything it acknowledged. What is lost is the version and
+  the open SSE connections: previews reconnect and reload.
+- **Two nodes can end up holding the same tenant** if routing changes twice, or
+  if an API call is routed by a different key than the preview. Then the two
+  memories diverge silently. Restarting one node is the cure; there is nothing
+  in the daemon that detects it.
+- **`POST /api/bases` and `POST /api/bases/{name}/reload` are per node.** Call
+  them on every node, or give every node `--watch-bases N` over a shared base
+  directory.
+
+## Configuration 2: one node per base
+
+Give each daemon its own `--bases` (or its own `--base NAME=PATH`) and route by
+base rather than by tenant: node A serves the `shop` theme, node B the `blog`
+theme. A tenant's base is in `<data-dir>/<id>/tenant.json`, and a node skips
+any tenant whose base it has not loaded — at startup with a message, and on a
+lookup miss silently — so the tenants of another node's bases are simply not
+served, which is what you want here.
+
+This is how to scale a catalogue of themes past what one process should hold in
+memory: two daemons, disjoint base sets, one data directory, and the routing
+decision made where the tenant is created.
+
+## What would be needed for real multi-node
+
+Not implemented, listed so nobody has to rediscover it:
+
+1. **Invalidation.** A node must learn that another node wrote to a tenant it
+   holds — a message bus, or a version file in the tenant directory that a
+   reader checks and, when it is ahead, re-reads the overlay from disk.
+2. **A shared version.** Persisting the version per tenant, and taking the
+   maximum across nodes, so `?v=` and the `hello` event mean the same thing
+   everywhere.
+3. **SSE fan-out across nodes.** Today `live.js` reloads only on the events of
+   the node holding its connection.
+4. **Base coordination.** One reload call, or one watcher, that every node
+   follows.
+
+Until then: route stickily, keep one tenant on one node, and treat
+`--data-dir` as durability rather than as shared state.

--- a/src/http/ai.rs
+++ b/src/http/ai.rs
@@ -88,7 +88,8 @@ content collections in src/content, styles in src/styles, static files in public
 Work in small, complete steps: read the files you will change first, write whole files back, then call check_site and fix every error it reports. \
 Do not invent npm packages; only plain Astro components, TypeScript and CSS are available. \
 Answer in the customer's language, briefly, and describe what you changed.",
-        t.id, t.base.name
+        t.id,
+        t.base().name
     )
 }
 

--- a/src/http/api.rs
+++ b/src/http/api.rs
@@ -14,7 +14,7 @@ use tokio_stream::{Stream, StreamExt};
 
 use super::{AppState, State, mime};
 use crate::metrics::{BaseSize, KINDS, STATUSES, Snapshot, render};
-use crate::store::{Tenant, WriteError, clean_path};
+use crate::store::{Base, Tenant, WriteError, clean_path, valid_id};
 use crate::transform::{Kind, is_source};
 
 pub async fn editor() -> Html<&'static str> {
@@ -147,17 +147,62 @@ pub async fn metrics(AxState(st): AxState<State>) -> Response {
     ([(header::CONTENT_TYPE, "text/plain; version=0.0.4; charset=utf-8"), (header::CACHE_CONTROL, "no-store")], body).into_response()
 }
 
+fn base_json(b: &Base) -> Value {
+    json!({ "name": b.name, "files": b.file_count(), "bytes": b.bytes(), "root": b.root })
+}
+
 pub async fn bases(AxState(st): AxState<State>) -> Json<Value> {
-    Json(Value::Array(
-        st.store.bases().iter().map(|b| json!({ "name": b.name, "files": b.file_count(), "bytes": b.bytes(), "root": b.root })).collect(),
-    ))
+    Json(Value::Array(st.store.bases().iter().map(|b| base_json(b)).collect()))
+}
+
+#[derive(Deserialize)]
+pub struct AddBaseReq {
+    name: String,
+    path: String,
+}
+
+/// Adds a base project from a directory on the host. Operator-only: with `--bases` set the path
+/// must resolve inside it, and without it any readable directory will do — see SECURITY.md.
+pub async fn add_base(AxState(st): AxState<State>, Json(req): Json<AddBaseReq>) -> Response {
+    if !valid_id(&req.name) {
+        return err(StatusCode::BAD_REQUEST, "base name must be lowercase letters, digits and dashes");
+    }
+    if st.store.base(&req.name).is_some() {
+        return err(StatusCode::CONFLICT, format!("base '{}' already exists; reload it instead", req.name));
+    }
+    let root = match st.store.base_root(std::path::Path::new(&req.path)) {
+        Ok(root) => root,
+        Err(e) => return err(StatusCode::BAD_REQUEST, e),
+    };
+    let name = req.name.clone();
+    let loaded = tokio::task::spawn_blocking(move || Base::load(&name, &root)).await;
+    match loaded {
+        Ok(Ok(base)) => (StatusCode::CREATED, Json(base_json(&st.store.add_base(base)))).into_response(),
+        Ok(Err(e)) => err(StatusCode::BAD_REQUEST, format!("cannot load base '{}': {e}", req.name)),
+        Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
+    }
+}
+
+/// Re-reads one base and re-points every tenant on it, each of which gets an `update` event.
+pub async fn reload_base(AxState(st): AxState<State>, Path(name): Path<String>) -> Response {
+    let (st2, n) = (st.clone(), name.clone());
+    match tokio::task::spawn_blocking(move || st2.store.reload_base(&n)).await {
+        Ok(Ok(Some((base, tenants)))) => {
+            let mut body = base_json(&base);
+            body["tenants"] = json!(tenants);
+            Json(body).into_response()
+        }
+        Ok(Ok(None)) => err(StatusCode::NOT_FOUND, format!("unknown base '{name}'")),
+        Ok(Err(e)) => err(StatusCode::INTERNAL_SERVER_ERROR, format!("cannot reload base '{name}': {e}")),
+        Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
+    }
 }
 
 fn tenant_json(st: &AppState, t: &Tenant) -> Value {
     let (files, bytes) = t.overlay_stats();
     json!({
         "id": t.id,
-        "base": t.base.name,
+        "base": t.base().name,
         "version": t.version(),
         "overlay_files": files,
         "overlay_bytes": bytes,

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -117,7 +117,8 @@ pub fn app(state: State) -> Router {
         .route("/health", get(api::health))
         .route("/metrics", get(api::metrics))
         .route("/api/stats", get(api::stats))
-        .route("/api/bases", get(api::bases))
+        .route("/api/bases", get(api::bases).post(api::add_base))
+        .route("/api/bases/{name}/reload", post(api::reload_base))
         .route("/api/tenants", get(api::tenants).post(api::create_tenant))
         .route("/api/tenants/{id}", delete(api::delete_tenant))
         .route("/api/tenants/{id}/import", post(archive::import))
@@ -299,6 +300,7 @@ pub fn mime(path: &str) -> &'static str {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
     use std::sync::Arc;
     use std::time::Instant;
 
@@ -307,15 +309,15 @@ mod tests {
     use axum::http::{HeaderName, Request, StatusCode};
     use tower::ServiceExt;
 
-    use super::{AppState, SameSite, app, chats, constant_time_eq, preview_token, tenant_from_host};
+    use super::{AppState, SameSite, State, app, chats, constant_time_eq, preview_token, tenant_from_host};
     use crate::metrics::Metrics;
     use crate::store::Store;
     use crate::transform::{Config, Engine};
 
-    fn baseless_app(api_token: Option<&str>, preview_secret: Option<&str>) -> axum::Router {
+    fn state_for(store: Store, api_token: Option<&str>, preview_secret: Option<&str>) -> State {
         let metrics = Arc::new(Metrics::default());
-        app(Arc::new(AppState {
-            store: Store::new(None, u64::MAX),
+        Arc::new(AppState {
+            store,
             engine: Engine::new(Config { cache_bytes: 1 << 20, ..Config::default() }, metrics.clone()),
             metrics,
             chats: chats::Chats::default(),
@@ -330,7 +332,11 @@ mod tests {
             chrome: None,
             shots: super::ai::Shots::default(),
             started: Instant::now(),
-        }))
+        })
+    }
+
+    fn baseless_app(api_token: Option<&str>, preview_secret: Option<&str>) -> axum::Router {
+        app(state_for(Store::new(None, u64::MAX), api_token, preview_secret))
     }
 
     async fn get(app: &axum::Router, uri: &str, bearer: Option<&str>) -> (StatusCode, String) {
@@ -342,6 +348,45 @@ mod tests {
         let status = res.status();
         let body = axum::body::to_bytes(res.into_body(), usize::MAX).await.unwrap();
         (status, String::from_utf8_lossy(&body).into_owned())
+    }
+
+    async fn post(app: &axum::Router, uri: &str, body: &str) -> (StatusCode, String) {
+        let req = Request::builder().method("POST").uri(uri).header("content-type", "application/json");
+        let res = app.clone().oneshot(req.body(Body::from(body.to_string())).unwrap()).await.unwrap();
+        let status = res.status();
+        let body = axum::body::to_bytes(res.into_body(), usize::MAX).await.unwrap();
+        (status, String::from_utf8_lossy(&body).into_owned())
+    }
+
+    #[tokio::test]
+    async fn bases_are_added_and_reloaded_over_the_api() {
+        let root = std::env::temp_dir().join(format!("sandbox-lite-api-bases-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let page = root.join("bases/theme/src/pages/index.astro");
+        std::fs::create_dir_all(page.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(root.join("outside")).unwrap();
+        std::fs::write(&page, "<h1>one</h1>\n").unwrap();
+        let store = Store::new(None, 1 << 20).with_bases_dir(Some(root.join("bases")));
+        let state = state_for(store, None, None);
+        let app = app(state.clone());
+        let add = |path: PathBuf| format!(r#"{{"name":"theme","path":{}}}"#, serde_json::to_string(&path).unwrap());
+
+        assert_eq!(post(&app, "/api/bases", &add(root.join("outside"))).await.0, StatusCode::BAD_REQUEST);
+        let (status, body) = post(&app, "/api/bases", &add(root.join("bases/theme"))).await;
+        assert_eq!(status, StatusCode::CREATED, "{body}");
+        assert!(body.contains(r#""files":1"#), "{body}");
+        assert_eq!(post(&app, "/api/bases", &add(root.join("bases/theme"))).await.0, StatusCode::CONFLICT);
+
+        let t = state.store.create_tenant("acme", "theme").unwrap();
+        let version = t.version();
+        std::fs::write(&page, "<h1>two</h1>\n").unwrap();
+        let (status, body) = post(&app, "/api/bases/theme/reload", "").await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert!(body.contains(r#""tenants":["acme"]"#), "{body}");
+        assert_eq!(t.read_text("src/pages/index.astro").as_deref(), Some("<h1>two</h1>\n"));
+        assert!(t.version() > version);
+        assert_eq!(post(&app, "/api/bases/nope/reload", "").await.0, StatusCode::NOT_FOUND);
+        std::fs::remove_dir_all(&root).unwrap();
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ struct Args {
     data_dir: Option<PathBuf>,
     bases: Vec<(String, PathBuf)>,
     bases_dir: Option<PathBuf>,
+    watch_bases: u64,
     domain: String,
     cdn: String,
     cache_mb: usize,
@@ -37,7 +38,7 @@ struct Args {
 
 fn usage() -> ! {
     eprintln!(
-        "sandbox-lite {}\n\nUsage: sandbox-lite [options]\n       sandbox-lite check [--json] DIR...   compile every source file of an Astro project and print diagnostics + a feature census\n\n  --listen ADDR        bind address (default 127.0.0.1:4321)\n  --domain NAME        preview domain; tenants are served at http://<id>.NAME:PORT/ (default localhost)\n  --bases DIR          directory whose sub-directories are base projects (default ./examples if present)\n  --base NAME=PATH     add one base project (repeatable)\n  --data-dir DIR       where tenant edits are persisted (default ./data)\n  --no-persist         keep tenant edits in memory only\n  --cdn URL            where bare npm imports are fetched from in the browser (default https://esm.sh)\n  --cache-mb N         transform cache budget in MiB (default 64)\n  --max-source-kb N    largest .astro/.ts/.js/.mdx/.scss file the compilers accept, in KiB (default 64)\n  --sass-timeout-ms N  deadline for one Sass compile, after which the request fails (default 5000)\n  --max-compiles N     compiles that may run at once; one that waits too long for a slot is refused with 503 (default: one per core)\n  --model NAME         Claude model for the built-in chat (default claude-fable-5-1)\n  --api-token TOKEN    require `Authorization: Bearer TOKEN` (or ?token=) on /api/*\n  --preview-secret S   tenant hosts need a per-tenant token derived from S (the API hands it out)\n  --chrome PATH        chrome or chromium binary for the chat's screenshot tool (default: off)\n  --chrome-jobs N      screenshots that may run at once; a call that waits longer than 10s is told the tool is busy (default {})\n  --chat-window N      turns of a conversation replayed to the model in full; older ones are folded into a stored summary (default {})\n  --chats-per-tenant N conversations a tenant may keep; saving past it drops the least recently updated (default {})\n  --tenant-quota-mb N  edited files a tenant may hold, in MiB; a write past it is refused with 413 (default 64)\n  --cookie-samesite lax|none\n                       SameSite of the preview cookie; none also sets Secure. With --preview-secret the\n                       default is none, because a framed preview is cross-site and a browser\n                       drops a Lax cookie there; otherwise lax\n\nEnvironment: ANTHROPIC_API_KEY enables the chat endpoint; SANDBOX_LITE_API_TOKEN, SANDBOX_LITE_PREVIEW_SECRET, SANDBOX_LITE_TENANT_QUOTA_MB, SANDBOX_LITE_MAX_COMPILES, SANDBOX_LITE_CHROME, SANDBOX_LITE_CHROME_JOBS, SANDBOX_LITE_CHAT_WINDOW and SANDBOX_LITE_CHATS_PER_TENANT are read as defaults for those flags; SANDBOX_LITE_ANTHROPIC_BASE points the chat at another Messages API endpoint (default https://api.anthropic.com).",
+        "sandbox-lite {}\n\nUsage: sandbox-lite [options]\n       sandbox-lite check [--json] DIR...   compile every source file of an Astro project and print diagnostics + a feature census\n\n  --listen ADDR        bind address (default 127.0.0.1:4321)\n  --domain NAME        preview domain; tenants are served at http://<id>.NAME:PORT/ (default localhost)\n  --bases DIR          directory whose sub-directories are base projects (default ./examples if present)\n  --base NAME=PATH     add one base project (repeatable)\n  --watch-bases N      re-read every base project when its files change, polled every N seconds (default: off)\n  --data-dir DIR       where tenant edits are persisted (default ./data)\n  --no-persist         keep tenant edits in memory only\n  --cdn URL            where bare npm imports are fetched from in the browser (default https://esm.sh)\n  --cache-mb N         transform cache budget in MiB (default 64)\n  --max-source-kb N    largest .astro/.ts/.js/.mdx/.scss file the compilers accept, in KiB (default 64)\n  --sass-timeout-ms N  deadline for one Sass compile, after which the request fails (default 5000)\n  --max-compiles N     compiles that may run at once; one that waits too long for a slot is refused with 503 (default: one per core)\n  --model NAME         Claude model for the built-in chat (default claude-fable-5-1)\n  --api-token TOKEN    require `Authorization: Bearer TOKEN` (or ?token=) on /api/*\n  --preview-secret S   tenant hosts need a per-tenant token derived from S (the API hands it out)\n  --chrome PATH        chrome or chromium binary for the chat's screenshot tool (default: off)\n  --chrome-jobs N      screenshots that may run at once; a call that waits longer than 10s is told the tool is busy (default {})\n  --chat-window N      turns of a conversation replayed to the model in full; older ones are folded into a stored summary (default {})\n  --chats-per-tenant N conversations a tenant may keep; saving past it drops the least recently updated (default {})\n  --tenant-quota-mb N  edited files a tenant may hold, in MiB; a write past it is refused with 413 (default 64)\n  --cookie-samesite lax|none\n                       SameSite of the preview cookie; none also sets Secure. With --preview-secret the\n                       default is none, because a framed preview is cross-site and a browser\n                       drops a Lax cookie there; otherwise lax\n\nEnvironment: ANTHROPIC_API_KEY enables the chat endpoint; SANDBOX_LITE_API_TOKEN, SANDBOX_LITE_PREVIEW_SECRET, SANDBOX_LITE_TENANT_QUOTA_MB, SANDBOX_LITE_MAX_COMPILES, SANDBOX_LITE_CHROME, SANDBOX_LITE_CHROME_JOBS, SANDBOX_LITE_CHAT_WINDOW and SANDBOX_LITE_CHATS_PER_TENANT are read as defaults for those flags; SANDBOX_LITE_ANTHROPIC_BASE points the chat at another Messages API endpoint (default https://api.anthropic.com).",
         env!("CARGO_PKG_VERSION"),
         http::ai::DEFAULT_CHROME_JOBS,
         http::chats::DEFAULT_WINDOW_TURNS,
@@ -56,6 +57,7 @@ fn parse_args() -> Args {
         data_dir: Some(PathBuf::from("data")),
         bases: Vec::new(),
         bases_dir: None,
+        watch_bases: 0,
         domain: "localhost".into(),
         cdn: "https://esm.sh".into(),
         cache_mb: 64,
@@ -85,6 +87,7 @@ fn parse_args() -> Args {
             "--listen" => args.listen = value(),
             "--domain" => args.domain = value().to_ascii_lowercase(),
             "--bases" => args.bases_dir = Some(PathBuf::from(value())),
+            "--watch-bases" => args.watch_bases = value().parse().unwrap_or_else(|_| usage()),
             "--base" => {
                 let v = value();
                 let Some((name, path)) = v.split_once('=') else { usage() };
@@ -133,7 +136,8 @@ async fn main() {
         check_command(&argv[1..]);
     }
     let args = parse_args();
-    let store = store::Store::new(args.data_dir.clone(), args.tenant_quota_mb.saturating_mul(1 << 20));
+    let store =
+        store::Store::new(args.data_dir.clone(), args.tenant_quota_mb.saturating_mul(1 << 20)).with_bases_dir(args.bases_dir.clone());
     let mut bases = args.bases.clone();
     if let Some(dir) = &args.bases_dir {
         match std::fs::read_dir(dir) {
@@ -221,8 +225,34 @@ async fn main() {
         if state.api_token.is_some() { "required" } else { "off" },
         if state.preview_secret.is_some() { "required" } else { "off" }
     );
+    if args.watch_bases > 0 {
+        eprintln!("  watch:   base projects re-read when they change, polled every {}s", args.watch_bases);
+        spawn_base_watcher(state.clone(), Duration::from_secs(args.watch_bases));
+    }
     let app = http::app(state);
     http::serve(listener, app, shutdown_signal()).await;
+}
+
+/// Polls every base root on an interval and reloads the ones whose files changed. One walk per
+/// base per tick, on the blocking pool: the walk stats every file the base holds.
+fn spawn_base_watcher(state: Arc<http::AppState>, period: Duration) {
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(period);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        ticker.tick().await;
+        loop {
+            ticker.tick().await;
+            let state = state.clone();
+            match tokio::task::spawn_blocking(move || state.store.reload_changed_bases()).await {
+                Ok(names) => {
+                    for name in names {
+                        eprintln!("watch: reloaded base {name}");
+                    }
+                }
+                Err(e) => eprintln!("watch: {e}"),
+            }
+        }
+    });
 }
 
 async fn shutdown_signal() {

--- a/src/store.rs
+++ b/src/store.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, RwLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use tokio::sync::broadcast;
+use xxhash_rust::xxh3::xxh3_64;
 
 const INLINE_LIMIT: u64 = 256 * 1024;
 const SKIP_DIRS: &[&str] = &["node_modules", ".git", "dist", ".astro", ".vercel", ".netlify", ".output"];
@@ -32,8 +33,7 @@ impl FileData {
         }
     }
 
-    fn from_disk(path: &Path) -> io::Result<FileData> {
-        let len = std::fs::metadata(path)?.len();
+    fn from_file(path: &Path, len: u64) -> io::Result<FileData> {
         if len <= INLINE_LIMIT { Ok(FileData::Mem(std::fs::read(path)?.into())) } else { Ok(FileData::Disk(path.to_path_buf(), len)) }
     }
 }
@@ -41,6 +41,8 @@ impl FileData {
 pub struct Base {
     pub name: String,
     pub root: PathBuf,
+    /// What `stamp(root)` returned for the tree this base was read from; a poll compares it.
+    pub stamp: u64,
     files: BTreeMap<String, FileData>,
 }
 
@@ -48,8 +50,13 @@ impl Base {
     pub fn load(name: &str, root: &Path) -> io::Result<Base> {
         let root = root.canonicalize()?;
         let mut files = BTreeMap::new();
-        walk(&root, &root, &mut files, true)?;
-        Ok(Base { name: name.to_string(), root, files })
+        let mut stamps = BTreeMap::new();
+        walk(&root, &root, true, &mut |rel: String, path: &Path, md: &std::fs::Metadata| {
+            stamps.insert(rel.clone(), file_stamp(md));
+            files.insert(rel, FileData::from_file(path, md.len())?);
+            Ok(())
+        })?;
+        Ok(Base { name: name.to_string(), root, stamp: hash_stamps(&stamps), files })
     }
 
     pub fn get(&self, path: &str) -> Option<&FileData> {
@@ -65,24 +72,54 @@ impl Base {
     }
 }
 
+type Visit<'a> = &'a mut dyn FnMut(String, &Path, &std::fs::Metadata) -> io::Result<()>;
+
 /// Base projects skip build output and dependencies; a tenant's own overlay must come back whole.
-fn walk(root: &Path, dir: &Path, out: &mut BTreeMap<String, FileData>, skip_build_dirs: bool) -> io::Result<()> {
+/// `DirEntry::metadata` does not follow symbolic links, so a link is neither descended nor taken.
+fn walk(root: &Path, dir: &Path, skip_build_dirs: bool, visit: Visit<'_>) -> io::Result<()> {
     for entry in std::fs::read_dir(dir)? {
         let entry = entry?;
         let path = entry.path();
         let name = entry.file_name().to_string_lossy().into_owned();
-        let ft = entry.file_type()?;
-        if ft.is_dir() {
+        let md = entry.metadata()?;
+        if md.is_dir() {
             if skip_build_dirs && SKIP_DIRS.contains(&name.as_str()) {
                 continue;
             }
-            walk(root, &path, out, skip_build_dirs)?;
-        } else if ft.is_file() {
+            walk(root, &path, skip_build_dirs, &mut *visit)?;
+        } else if md.is_file() {
             let rel = path.strip_prefix(root).unwrap().to_string_lossy().replace('\\', "/");
-            out.insert(rel, FileData::from_disk(&path)?);
+            visit(rel, &path, &md)?;
         }
     }
     Ok(())
+}
+
+fn file_stamp(md: &std::fs::Metadata) -> (u128, u64) {
+    let mtime = md.modified().ok().and_then(|t| t.duration_since(UNIX_EPOCH).ok()).map_or(0, |d| d.as_nanos());
+    (mtime, md.len())
+}
+
+fn hash_stamps(stamps: &BTreeMap<String, (u128, u64)>) -> u64 {
+    let mut buf = Vec::with_capacity(stamps.len() * 32);
+    for (path, (mtime, len)) in stamps {
+        buf.extend_from_slice(path.as_bytes());
+        buf.push(0);
+        buf.extend_from_slice(&mtime.to_le_bytes());
+        buf.extend_from_slice(&len.to_le_bytes());
+    }
+    xxh3_64(&buf)
+}
+
+/// The name, mtime and size of every file `Base::load` would take, hashed in path order. Two walks
+/// of an unchanged tree agree; a rewrite that keeps both the size and the mtime does not show up.
+pub fn stamp(root: &Path) -> io::Result<u64> {
+    let mut stamps = BTreeMap::new();
+    walk(root, root, true, &mut |rel: String, _: &Path, md: &std::fs::Metadata| {
+        stamps.insert(rel, file_stamp(md));
+        Ok(())
+    })?;
+    Ok(hash_stamps(&stamps))
 }
 
 pub fn clean_path(raw: &str) -> Option<String> {
@@ -175,7 +212,7 @@ impl From<io::Error> for WriteError {
 
 pub struct Tenant {
     pub id: String,
-    pub base: Arc<Base>,
+    base: RwLock<Arc<Base>>,
     overlay: RwLock<BTreeMap<String, Option<FileData>>>,
     version: AtomicU64,
     pub events: broadcast::Sender<String>,
@@ -199,7 +236,28 @@ pub struct Applied {
 impl Tenant {
     fn new(id: String, base: Arc<Base>, dir: Option<PathBuf>, quota: u64) -> Tenant {
         let (events, _) = broadcast::channel(64);
-        Tenant { id, base, overlay: RwLock::new(BTreeMap::new()), version: AtomicU64::new(now_millis()), events, dir, quota }
+        Tenant {
+            id,
+            base: RwLock::new(base),
+            overlay: RwLock::new(BTreeMap::new()),
+            version: AtomicU64::new(now_millis()),
+            events,
+            dir,
+            quota,
+        }
+    }
+
+    pub fn base(&self) -> Arc<Base> {
+        self.base.read().unwrap().clone()
+    }
+
+    /// Points the tenant at a freshly loaded copy of its base and tells its previews to reload: the
+    /// overlay is untouched, so an edited file still wins over the new base copy.
+    pub fn set_base(&self, base: Arc<Base>) -> u64 {
+        *self.base.write().unwrap() = base;
+        // Every file in the tenant may have changed underneath, so the preview reloads rather
+        // than swapping a stylesheet.
+        self.bump("update", "", UpdateKind::Module)
     }
 
     pub fn version(&self) -> u64 {
@@ -216,7 +274,7 @@ impl Tenant {
         match overlay.get(path) {
             Some(Some(d)) => Some(d.clone()),
             Some(None) => None,
-            None => self.base.get(path).cloned(),
+            None => self.base.read().unwrap().get(path).cloned(),
         }
     }
 
@@ -234,7 +292,8 @@ impl Tenant {
 
     pub fn list(&self) -> Vec<Entry> {
         let overlay = self.overlay.read().unwrap();
-        let mut out: BTreeMap<String, (u64, bool)> = self.base.files.iter().map(|(p, d)| (p.clone(), (d.size(), false))).collect();
+        let base = self.base.read().unwrap();
+        let mut out: BTreeMap<String, (u64, bool)> = base.files.iter().map(|(p, d)| (p.clone(), (d.size(), false))).collect();
         for (p, d) in overlay.iter() {
             match d {
                 Some(d) => {
@@ -280,7 +339,7 @@ impl Tenant {
         let mut next: BTreeMap<String, Option<FileData>> =
             overlay.iter().filter(|(p, d)| keep(p, d)).map(|(p, d)| (p.clone(), d.clone())).collect();
         for path in deleted.iter().filter(|p| !incoming.contains(p.as_str())) {
-            match self.base.get(path) {
+            match self.base.read().unwrap().get(path) {
                 Some(_) => next.insert(path.clone(), None),
                 None => next.remove(path),
             };
@@ -333,7 +392,7 @@ impl Tenant {
     pub fn delete(&self, path: &str) -> io::Result<u64> {
         {
             let mut overlay = self.overlay.write().unwrap();
-            if self.base.get(path).is_some() {
+            if self.base.read().unwrap().get(path).is_some() {
                 overlay.insert(path.to_string(), None);
             } else {
                 overlay.remove(path);
@@ -389,7 +448,10 @@ impl Tenant {
         let files = dir.join("files");
         let mut loaded = BTreeMap::new();
         if files.is_dir() {
-            walk(&files, &files, &mut loaded, false)?;
+            walk(&files, &files, false, &mut |rel: String, path: &Path, md: &std::fs::Metadata| {
+                loaded.insert(rel, FileData::from_file(path, md.len())?);
+                Ok(())
+            })?;
         }
         let mut overlay = self.overlay.write().unwrap();
         for (p, d) in loaded {
@@ -413,16 +475,77 @@ pub struct Store {
     bases: RwLock<HashMap<String, Arc<Base>>>,
     tenants: RwLock<HashMap<String, Arc<Tenant>>>,
     data_dir: Option<PathBuf>,
+    bases_dir: Option<PathBuf>,
     tenant_quota: u64,
 }
 
 impl Store {
     pub fn new(data_dir: Option<PathBuf>, tenant_quota: u64) -> Store {
-        Store { bases: RwLock::new(HashMap::new()), tenants: RwLock::new(HashMap::new()), data_dir, tenant_quota }
+        Store { bases: RwLock::new(HashMap::new()), tenants: RwLock::new(HashMap::new()), data_dir, bases_dir: None, tenant_quota }
     }
 
-    pub fn add_base(&self, base: Base) {
-        self.bases.write().unwrap().insert(base.name.clone(), Arc::new(base));
+    /// `--bases`: the directory a base added through the API must live under.
+    pub fn with_bases_dir(mut self, dir: Option<PathBuf>) -> Store {
+        self.bases_dir = dir;
+        self
+    }
+
+    pub fn add_base(&self, base: Base) -> Arc<Base> {
+        let base = Arc::new(base);
+        self.bases.write().unwrap().insert(base.name.clone(), base.clone());
+        base
+    }
+
+    /// Where `POST /api/bases` may read a project from. With `--bases` set the path must resolve
+    /// inside it — canonicalized first, so a symbolic link out of the directory is refused too.
+    /// Without the flag any readable directory on the host is allowed, which is why the route is
+    /// operator-only (see SECURITY.md).
+    pub fn base_root(&self, path: &Path) -> Result<PathBuf, String> {
+        let root = path.canonicalize().map_err(|e| format!("{}: {e}", path.display()))?;
+        if !root.is_dir() {
+            return Err(format!("{} is not a directory", root.display()));
+        }
+        if let Some(dir) = &self.bases_dir {
+            let dir = dir.canonicalize().map_err(|e| format!("{}: {e}", dir.display()))?;
+            if !root.starts_with(&dir) {
+                return Err(format!("path must be inside --bases ({})", dir.display()));
+            }
+        }
+        Ok(root)
+    }
+
+    /// Re-reads a base from its own root and points every tenant on it at the result. Each of those
+    /// tenants gets a version bump and one `update` event, so open previews reload; the transform
+    /// cache needs nothing, being keyed by content. `None` means there is no such base.
+    pub fn reload_base(&self, name: &str) -> io::Result<Option<(Arc<Base>, Vec<String>)>> {
+        let Some(old) = self.base(name) else { return Ok(None) };
+        let fresh = self.add_base(Base::load(name, &old.root)?);
+        let mut repointed = Vec::new();
+        for t in self.tenants() {
+            if t.base().name == name {
+                t.set_base(fresh.clone());
+                repointed.push(t.id.clone());
+            }
+        }
+        Ok(Some((fresh, repointed)))
+    }
+
+    /// One walk per base, comparing `stamp` against what the loaded copy was read from; the names
+    /// reloaded come back. Reading a root fails loudly and leaves the loaded copy in place — a base
+    /// directory being replaced wholesale should not empty every tenant's site.
+    pub fn reload_changed_bases(&self) -> Vec<String> {
+        let mut reloaded = Vec::new();
+        for base in self.bases() {
+            match stamp(&base.root) {
+                Ok(s) if s == base.stamp => continue,
+                Ok(_) => match self.reload_base(&base.name) {
+                    Ok(_) => reloaded.push(base.name.clone()),
+                    Err(e) => eprintln!("watch: cannot reload base {}: {e}", base.name),
+                },
+                Err(e) => eprintln!("watch: cannot read base {} at {}: {e}", base.name, base.root.display()),
+            }
+        }
+        reloaded
     }
 
     pub fn base(&self, name: &str) -> Option<Arc<Base>> {
@@ -440,7 +563,9 @@ impl Store {
             return Err("tenant id must be lowercase letters, digits and dashes".into());
         }
         let base = self.base(base_name).ok_or_else(|| format!("unknown base '{base_name}'"))?;
-        if self.tenants.read().unwrap().contains_key(id) {
+        // `tenant` rather than the map: a tenant another node created under the same --data-dir
+        // exists, and creating over its directory would hide the files already in it
+        if self.tenant(id).is_some() {
             return Err(format!("tenant '{id}' already exists"));
         }
         let dir = self.data_dir.as_ref().map(|d| d.join(id));
@@ -454,8 +579,33 @@ impl Store {
         Ok(tenant)
     }
 
+    /// A miss falls back to `--data-dir`: with two daemons sharing one, a tenant created on the
+    /// other node is not in this node's map until something asks for it. What this does not do is
+    /// refresh a tenant already in memory — it never sees the other node's later writes
+    /// (`docs/multi-node.md`).
     pub fn tenant(&self, id: &str) -> Option<Arc<Tenant>> {
-        self.tenants.read().unwrap().get(id).cloned()
+        if let Some(t) = self.tenants.read().unwrap().get(id).cloned() {
+            return Some(t);
+        }
+        let restored = Arc::new(self.read_tenant(id).ok()?);
+        Some(self.tenants.write().unwrap().entry(id.to_string()).or_insert(restored).clone())
+    }
+
+    /// Builds a tenant from `<data-dir>/<id>` without registering it. Every reason it cannot —
+    /// no `--data-dir`, no such directory, a base this node has not loaded — is an `Err`.
+    fn read_tenant(&self, id: &str) -> Result<Tenant, String> {
+        let data_dir = self.data_dir.as_ref().ok_or("no --data-dir")?;
+        if !valid_id(id) {
+            return Err(format!("'{id}' is not a valid tenant id"));
+        }
+        let dir = data_dir.join(id);
+        let meta = std::fs::read(dir.join("tenant.json")).map_err(|e| format!("tenant.json: {e}"))?;
+        let meta: serde_json::Value = serde_json::from_slice(&meta).unwrap_or_default();
+        let base_name = meta.get("base").and_then(|b| b.as_str()).unwrap_or("");
+        let base = self.base(base_name).ok_or_else(|| format!("base '{base_name}' is not loaded"))?;
+        let tenant = Tenant::new(id.to_string(), base, Some(dir.clone()), self.tenant_quota);
+        tenant.restore_overlay(&dir).map_err(|e| e.to_string())?;
+        Ok(tenant)
     }
 
     pub fn tenants(&self) -> Vec<Arc<Tenant>> {
@@ -485,23 +635,17 @@ impl Store {
         let mut n = 0;
         for entry in std::fs::read_dir(data_dir)? {
             let entry = entry?;
-            let dir = entry.path();
-            let Ok(meta) = std::fs::read(dir.join("tenant.json")) else { continue };
-            let meta: serde_json::Value = serde_json::from_slice(&meta).unwrap_or_default();
-            let id = entry.file_name().to_string_lossy().into_owned();
-            if !valid_id(&id) {
-                eprintln!("data dir entry '{id}' is not a valid tenant id, skipping");
+            if !entry.path().join("tenant.json").is_file() {
                 continue;
             }
-            let base_name = meta.get("base").and_then(|b| b.as_str()).unwrap_or("");
-            let Some(base) = self.base(base_name) else {
-                eprintln!("tenant {id}: base '{base_name}' is not loaded, skipping");
-                continue;
-            };
-            let tenant = Tenant::new(id.clone(), base, Some(dir.clone()), self.tenant_quota);
-            tenant.restore_overlay(&dir)?;
-            self.tenants.write().unwrap().insert(id, Arc::new(tenant));
-            n += 1;
+            let id = entry.file_name().to_string_lossy().into_owned();
+            match self.read_tenant(&id) {
+                Ok(tenant) => {
+                    self.tenants.write().unwrap().insert(id, Arc::new(tenant));
+                    n += 1;
+                }
+                Err(e) => eprintln!("data dir entry '{id}': {e}, skipping"),
+            }
         }
         Ok(n)
     }
@@ -512,8 +656,121 @@ mod tests {
     use super::*;
 
     fn tenant(quota: u64, dir: Option<PathBuf>) -> Tenant {
-        let base = Base { name: "b".into(), root: PathBuf::from("."), files: BTreeMap::new() };
+        let base = Base { name: "b".into(), root: PathBuf::from("."), stamp: 0, files: BTreeMap::new() };
         Tenant::new("t".into(), Arc::new(base), dir, quota)
+    }
+
+    fn temp(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("sandbox-lite-{name}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn seed(path: PathBuf, body: &str) {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(path, body).unwrap();
+    }
+
+    const PAGE: &str = "src/pages/index.astro";
+
+    #[test]
+    fn reload_re_points_every_tenant_on_the_base() {
+        let root = temp("reload");
+        seed(root.join("theme").join(PAGE), "<h1>one</h1>\n");
+        let store = Store::new(None, 1 << 20);
+        store.add_base(Base::load("theme", &root.join("theme")).unwrap());
+        store.add_base(Base::load("other", &root.join("theme")).unwrap());
+        let t = store.create_tenant("acme", "theme").unwrap();
+        let untouched = store.create_tenant("bakery", "other").unwrap();
+        t.write("src/pages/mine.astro", b"<h1>mine</h1>".to_vec(), UpdateKind::Module).unwrap();
+        let (version, other_version) = (t.version(), untouched.version());
+        let mut events = t.events.subscribe();
+
+        seed(root.join("theme").join(PAGE), "<h1>two</h1>\n");
+        let (base, repointed) = store.reload_base("theme").unwrap().unwrap();
+
+        assert_eq!(repointed, vec!["acme".to_string()], "only tenants on that base are re-pointed");
+        assert_eq!(t.read_text(PAGE).as_deref(), Some("<h1>two</h1>\n"));
+        assert_eq!(t.base().name, base.name);
+        assert!(Arc::ptr_eq(&t.base(), &base), "the tenant holds the fresh base, not a copy of the old one");
+        assert_eq!(t.read_text("src/pages/mine.astro").as_deref(), Some("<h1>mine</h1>"), "the overlay survives a reload");
+        assert!(t.version() > version, "an open preview reloads on the new version");
+        assert_eq!(untouched.version(), other_version, "a tenant on another base is not disturbed");
+        let event = events.try_recv().unwrap();
+        assert!(event.contains(r#""type":"update""#), "{event}");
+        assert!(events.try_recv().is_err(), "one event per tenant per reload");
+        assert!(store.reload_base("nope").unwrap().is_none());
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn the_watcher_notices_a_changed_file_and_ignores_skipped_directories() {
+        let root = temp("watch");
+        seed(root.join("theme").join(PAGE), "<h1>one</h1>\n");
+        let store = Store::new(None, 1 << 20);
+        store.add_base(Base::load("theme", &root.join("theme")).unwrap());
+        let t = store.create_tenant("acme", "theme").unwrap();
+        assert!(store.reload_changed_bases().is_empty(), "an untouched tree is not reloaded");
+
+        seed(root.join("theme/node_modules/pkg/index.js"), "export const x = 1;\n");
+        seed(root.join("theme/dist/index.html"), "<html></html>\n");
+        assert!(store.reload_changed_bases().is_empty(), "what Base::load skips, the poll skips");
+
+        seed(root.join("theme").join(PAGE), "<h1>two, and longer</h1>\n");
+        assert_eq!(store.reload_changed_bases(), vec!["theme".to_string()]);
+        assert_eq!(t.read_text(PAGE).as_deref(), Some("<h1>two, and longer</h1>\n"));
+        assert!(store.reload_changed_bases().is_empty(), "the reloaded base is the new stamp");
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    /// Two `Store`s over one `--data-dir` are the two daemons of `docs/multi-node.md`.
+    #[test]
+    fn a_tenant_created_on_one_node_is_served_by_the_other() {
+        let root = temp("multi-node");
+        seed(root.join("theme").join(PAGE), "<h1>base</h1>\n");
+        let base = || Base::load("theme", &root.join("theme")).unwrap();
+        let (a, b) = (Store::new(Some(root.join("data")), 1 << 20), Store::new(Some(root.join("data")), 1 << 20));
+        a.add_base(base());
+        b.add_base(base());
+        let ta = a.create_tenant("acme", "theme").unwrap();
+        ta.write(PAGE, b"<h1>from a</h1>".to_vec(), UpdateKind::Module).unwrap();
+
+        assert!(b.tenants().is_empty(), "node b learned nothing from node a's write");
+        let tb = b.tenant("acme").unwrap();
+        assert_eq!(tb.read_text(PAGE).as_deref(), Some("<h1>from a</h1>"), "the miss restored the tenant from the data dir");
+        assert_eq!(b.tenants().len(), 1);
+        assert!(Arc::ptr_eq(&tb, &b.tenant("acme").unwrap()), "a restored tenant is registered, not rebuilt per request");
+        assert!(b.tenant("nobody").is_none());
+        assert!(b.create_tenant("acme", "theme").is_err(), "creating over another node's tenant would hide its files");
+
+        // the gap docs/multi-node.md names: node b holds the tenant now, and nothing tells it that
+        // node a wrote again. Sticky routing per tenant is what keeps this from being reachable.
+        ta.write(PAGE, b"<h1>from a, later</h1>".to_vec(), UpdateKind::Module).unwrap();
+        assert_eq!(tb.read_text(PAGE).as_deref(), Some("<h1>from a</h1>"));
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn a_base_added_at_runtime_stays_inside_bases() {
+        let root = temp("base-root");
+        std::fs::create_dir_all(root.join("bases/theme")).unwrap();
+        std::fs::create_dir_all(root.join("elsewhere")).unwrap();
+        seed(root.join("bases/notadir"), "x");
+        let store = Store::new(None, 0).with_bases_dir(Some(root.join("bases")));
+
+        assert_eq!(store.base_root(&root.join("bases/theme")).unwrap(), root.join("bases/theme").canonicalize().unwrap());
+        assert!(store.base_root(&root.join("elsewhere")).is_err(), "outside --bases");
+        assert!(store.base_root(&root.join("bases/../elsewhere")).is_err(), "a traversal out of --bases");
+        assert!(store.base_root(&root.join("bases/missing")).is_err(), "no such directory");
+        assert!(store.base_root(&root.join("bases/notadir")).is_err(), "a file is not a base");
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(root.join("elsewhere"), root.join("bases/link")).unwrap();
+            assert!(store.base_root(&root.join("bases/link")).is_err(), "a symlink out of --bases is resolved and refused");
+        }
+        assert!(Store::new(None, 0).base_root(&root.join("elsewhere")).is_ok(), "without --bases any directory is allowed");
+        std::fs::remove_dir_all(&root).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
Closes #16

Base projects were read once at startup, so a theme fix on disk reached no tenant until the daemon was restarted. This adds a reload path, an optional watcher, and the multi-node documentation the issue asked for — plus the one code change that makes the sticky configuration actually work.

## `POST /api/bases/{name}/reload`

Re-walks the base directory, swaps the new `Arc<Base>` into the store, and re-points every tenant on it. `Tenant::base` becomes an `RwLock<Arc<Base>>`; each affected tenant is bumped and emits one SSE `update`, so open previews reload. Overlays are untouched — an edited file still wins over the new base copy — and the content-addressed transform cache needs no invalidation, since a changed file simply hashes to a new key. The response names the tenants that were re-pointed:

```
$ curl -fsS -X POST localhost:4321/api/bases/starter/reload
{"name":"starter","files":24,"bytes":38104,"root":"/srv/themes/starter","tenants":["acme","bakery"]}
```

## `POST /api/bases {"name","path"}`

Adds a base to a running daemon. The name must pass `valid_id`; the path is canonicalized, must be a directory, and must resolve inside `--bases` when that flag is set — so a symlink out of it is refused, because the link is resolved before the check. Without the flag any readable directory on the host will do. `SECURITY.md` now says plainly that this is an operator-only surface behind `--api-token`, that unset `--bases` means no containment at all, and that a base's files reach anyone who can open a preview on a tenant made from it. `--bases` is added to the deployment checklist.

An existing name is refused with `409` rather than silently shadowed: re-pointing tenants is what reload is for.

## `--watch-bases N`

Polls each base root every N seconds and reloads what changed. One walk per base per interval, comparing a hash of the name, size and mtime of every file `Base::load` would take. No new dependency — the hash is xxh3, already in `Cargo.lock`; no inotify.

`walk` now takes a visitor, so `Base::load`, the overlay restore and the poll are one function: the poll cannot drift from the load over which directories it skips, and the load no longer stats each file twice. A rewrite that changes neither the size nor the mtime is invisible to the poll — the reload endpoint is the escape hatch, and both README and SECURITY.md say so.

## Restore on a tenant miss

`Store::tenant` falls back to `<data-dir>/<id>` when the id is not in memory, so a tenant created on node A is served by node B under a shared `--data-dir`. `create_tenant` now uses the same lookup for its duplicate check, so it can no longer create over a tenant directory another node wrote — which would have left that node's files on disk but invisible in the new overlay. `Store::restore` and the miss path share one `read_tenant`.

**What is still wrong**, and is documented rather than fixed: a tenant *already in memory* never sees the other node's writes. The restore happens once, on the miss. There is no invalidation, the version is per node and not persisted, and SSE fan-out reaches only the node holding the connection. That is why the docs say to route stickily and keep one tenant on one node. The test asserts the stale read, so the day someone fixes it, the test says so.

## `docs/multi-node.md`

What two daemons over one `--data-dir` actually do, per operation, in a table; why it is staleness rather than corruption; then the two configurations that work today — sticky routing by tenant host (with an nginx `hash … consistent` example and what still bites) and one node per base — and a short list of what real multi-node would need.

## Tests

- `reload_re_points_every_tenant_on_the_base` — content, `Arc::ptr_eq` on the fresh base, the surviving overlay, the version bump, exactly one event, and a tenant on another base left alone.
- `the_watcher_notices_a_changed_file_and_ignores_skipped_directories` — an untouched tree is not reloaded, a file written under `node_modules`/`dist` is not a change, a changed page is.
- `a_tenant_created_on_one_node_is_served_by_the_other` — two `Store`s over one directory: the restore on miss, the registration, the refused re-creation, and the stale read that documents the gap.
- `a_base_added_at_runtime_stays_inside_bases` — outside, traversal, missing, a file, a symlink out of `--bases`, and the unset-flag case.
- `bases_are_added_and_reloaded_over_the_api` — both routes through the real router, including `400`, `409` and `404`.
- The CI smoke test now reloads `starter` on the live binary and asserts the tenant list, and asserts `/etc` is refused as a base path.

## CI

Green on this branch: run [34057583462](https://github.com/productdevbook/sandbox-lite/actions/runs/34057583462) — `test` and `e2e` both success (fmt, clippy `-D warnings`, 130 tests, release build, `check`, smoke test, `bench/mem.sh`, Playwright).

## Noticed, did not fix

- A request for an unknown tenant on a tenant host now costs one `read` of `<data-dir>/<id>/tenant.json` per request, unauthenticated when `--preview-secret` is off. It is one failed open on a validated id, but it is a new per-request syscall on a 404 path.
- `--watch-bases` logs `watch: cannot read base …` on every tick if a base root is removed while the daemon runs. Correct, and noisy at 5-second intervals.
- The watcher can reload a base while it is being written: a `git checkout` of a theme mid-tick loads a half-written tree, and the next tick loads the finished one. Nothing is corrupted, but a preview may reload twice and briefly render an inconsistent tree.
- `Store::restore` used to fail startup on an unreadable overlay directory; it now prints and skips that tenant like any other unusable entry.
- `/api/stats` and `/metrics` count only the tenants a node holds in memory, which under restore-on-miss grows as tenants are asked for. The number was never a cluster total and is now less stable per node.
- The editor page has no reload button; the endpoint is curl-only for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
