### PR TITLE
docs: make every claim true of the code again

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,10 +22,13 @@ one per request from the `Host` header (lowercased, port stripped):
   it.
 - Any other host goes to the **editor/API router**: `/` (the editor page),
   `/health`, `/metrics`, `/api/stats`, `/api/bases`,
-  `/api/bases/{name}/reload`, `/api/tenants`,
-  `/api/tenants/{id}`, `/api/t/{id}/files`, `/api/t/{id}/file/{*path}`,
-  `/api/t/{id}/events`, `/api/t/{id}/check`, `/api/t/{id}/chat`, with a 64 MiB
-  body limit. `require_api_token` wraps all of it.
+  `/api/bases/{name}/reload`, `/api/tenants`, `/api/tenants/{id}`,
+  `/api/tenants/{id}/import`, `/api/t/{id}/files`, `/api/t/{id}/export`,
+  `/api/t/{id}/file/{*path}`, `/api/t/{id}/events`, `/api/t/{id}/check`,
+  `/api/t/{id}/chat`, `/api/t/{id}/chats` and `/api/t/{id}/chats/{chat}`, with
+  a 64 MiB body limit. `require_api_token` wraps all of it, so that whole list
+  is the `--api-token` surface — `import` and `export` included, which move
+  whole file trees.
 
 `SECURITY.md` describes the two middlewares.
 
@@ -121,12 +124,16 @@ exact.
 
 1. **Shell.** No route matches, so `preview::page` (`src/http/preview.rs`)
    runs. It percent-decodes the path, and if `public/<path>` exists in the
-   tenant it serves that file. Otherwise it answers `assets/shell.html` with
-   `%TENANT%`, `%VERSION%` (the tenant's version), `%ASSETS%` (a hash of
-   `astro.js`, `shell.js`, `live.js`) and `%ENV%` filled in, `Cache-Control:
-   no-store`. `%ENV%` is `import.meta.env`: `DEV`, `PROD`, `MODE`, `SSR`,
-   `BASE_URL`, `SITE` (from `sandbox-lite.json`), and the `PUBLIC_*` lines of
-   the tenant's `.env`.
+   tenant it serves that file — unless the path is private (`is_private_path`:
+   any segment starting with `.`, `.well-known` excepted), which is also what
+   keeps `/__sl/m/` and `/__sl/raw/` off a tenant's dotfiles. Otherwise it
+   answers `assets/shell.html` with `%TENANT%`, `%VERSION%` (the tenant's
+   version), `%ASSETS%` (a hash of `astro.js`, `shell.js`, `live.js`),
+   `%TOKEN%`/`%TOKENQ%` (the preview token, empty without `--preview-secret`)
+   and `%ENV%` filled in, `Cache-Control: no-store`. `%ENV%` is
+   `import.meta.env`: `DEV`, `PROD`, `MODE`, `SSR`, `BASE_URL`, `SITE` (from
+   `sandbox-lite.json`), `ASSETS_PREFIX`, and the `PUBLIC_*` lines of the
+   tenant's `.env`.
 2. **Scripts.** The shell loads `/__sl/live.js` and `/__sl/shell.js`
    (`no-cache`, ETag = the assets hash). `live.js` opens an `EventSource` on
    `/__sl/events`.
@@ -177,7 +184,10 @@ exact.
    `cookies`, `locals`. No renderers are registered for it: nothing renders.
 8. **Document.** A `3xx` with `Location` becomes `location.replace`. A response
    that is not `text/html` (an endpoint's XML, JSON or text) is shown escaped in
-   a `<pre>` under its status and content-type, JSON pretty-printed.
+   a `<pre>` under its status and content-type, JSON pretty-printed. A `4xx` or
+   `5xx` with an empty body becomes an error overlay naming the status rather
+   than a blank page, so a failed render never looks like a site with nothing
+   on it (#48).
    Otherwise every CSS string that modules registered in
    `globalThis.__sl_css` becomes a `<style data-sl=key>` (with
    `type="text/tailwindcss"` when it contains `@import "tailwindcss"` or
@@ -251,8 +261,12 @@ before creating the blob: `vue`/`svelte` specifiers become CDN URLs, relative
 ones are resolved against the component's own `/__sl/m/…` URL. The CDN URLs are
 substituted into the loader shim by `preview::shim` (`%VUE%`, `%VUE_COMPILER%`,
 `%SVELTE%`) rather than baked into the cached module, because the transform
-cache is content-addressed and does not see `package.json`. Each `<style>`
-block is registered in `globalThis.__sl_css` the way a `.css` module is.
+cache is content-addressed and does not see `package.json`. The compiled CSS
+is registered in `globalThis.__sl_css` like any other module's, though the two
+loaders key it differently: `vue-loader.js` registers one entry per `<style>`
+block as `<path>?<index>`, the way an `.astro` style module is keyed, while
+`svelte-loader.js` registers the component's single combined output under the
+bare path.
 
 The island imports that same module URL to hydrate, so the loader's default
 export is the *client* build. Vue's one component object serves both — Vue's
@@ -500,8 +514,10 @@ a config it could not read at all is the error above.
 
 `sandbox-lite check DIR…` loads each directory as a base, creates an
 in-memory tenant on it, and calls `Engine::build(…, Kind::Module)` on every
-source file under `src/` (`.astro`, `.ts`, `.tsx`, `.js`, `.jsx`, `.mjs`,
-`.mts`, `.md`, `.mdx`). It prints diagnostics and a census — islands, glob calls,
+source file under `src/` — `is_source`: `.astro`, `.ts`, `.tsx`, `.js`,
+`.jsx`, `.mjs`, `.mts`, `.md`, `.mdx`, `.vue`, `.svelte`, which is what makes
+the `.vue` type errors above reachable from the command line. It prints
+diagnostics and a census — islands, glob calls,
 Sass, MDX, endpoints, `@astrojs/*` integrations, bare imports — and exits 1 on
 compile errors, 2 when a directory cannot be loaded. `/api/t/{id}/check` and
 `/__sl/check` run the same loop (`api::check_tenant`) on a live tenant; the
@@ -539,11 +555,33 @@ bearer token whenever `--api-token` is set; `http::tests` asserts both halves.
 
 ## Chat (`src/http/ai.rs`)
 
-`POST /api/t/{id}/chat` runs a tool loop against the Anthropic Messages API
-with five tools scoped to the tenant — `list_files`, `read_file`,
-`write_file`, `delete_file`, `check_site` — for at most 16 rounds, and returns
-the model's last text, the changed paths and the tenant version. Writes go
-through the same `Tenant::write` as the editor, so previews follow.
+`POST /api/t/{id}/chat` runs a tool loop against `{api_base}/v1/messages` —
+`https://api.anthropic.com` unless `SANDBOX_LITE_ANTHROPIC_BASE` says
+otherwise — with five tools scoped to the tenant: `list_files`, `read_file`,
+`write_file`, `delete_file` and `check_site`. With `--chrome` set there is a
+sixth, `screenshot` (`tools`), which renders one page of the tenant's own
+preview in headless Chrome on the daemon's host and hands the PNG back as an
+image block; `SECURITY.md` says what that costs. The loop runs at most 16
+rounds (`MAX_ITERATIONS`) and answers
+`{text, changes, iterations, version, chat}`. Writes go through the same
+`Tenant::write` as the editor, so previews follow.
+
+Every turn is streamed from the API whichever way the caller asked for it
+(`converse`). With `Accept: text/event-stream` the endpoint answers SSE —
+`text`, `tool`, `tool_result` events as they happen, then one `done` carrying
+that same JSON, or `error`; otherwise the JSON is buffered and returned in one
+response.
+
+The request body is `{messages, chat?}`. `chat` names a stored conversation
+(`src/http/chats.rs`, one JSON file per chat under `<data-dir>/<id>/chats/`, or
+in memory with `--no-persist`), whose turns come before `messages`.
+`Conversation::for_model` replays the last `--chat-window` turns in full; when a
+conversation crosses that, `compact` folds everything older into one summary
+written by a second call to the same API and stored with the conversation, and
+sent as its opening turn from then on. A summary the API will not write is not
+fatal: the turns stay stored and are cut from the request anyway. A save past
+`--chats-per-tenant` drops the tenant's least recently updated conversation
+(`evictable`).
 
 ## Layout
 
@@ -554,7 +592,9 @@ src/http/mod.rs        routers, host dispatch, the two token middlewares, MIME t
 src/http/api.rs        editor page, /api handlers, SSE, check_tenant
 src/http/archive.rs    tar.gz export and import of a tenant tree
 src/http/preview.rs    tenant-host handlers: shell, modules, raw, routes, renderers, shims, content
-src/http/ai.rs         chat tool loop
+src/http/ai.rs         chat tool loop, the screenshot tool, conversation compaction
+src/http/anthropic.rs  SSE frame reassembly and the streamed reply's content blocks
+src/http/chats.rs      stored conversations: the window, the cap, load/save/list
 src/metrics.rs         atomic counters, the compile histogram, the Prometheus renderer
 src/resolve.rs         Resolver, CDN URLs, renderers, sandbox-lite.json, tsconfig paths
 src/routes.rs          src/pages → route table

--- a/README.md
+++ b/README.md
@@ -54,46 +54,50 @@ TypeScript in their `<script>` blocks stripped by the daemon first);
 
 `bench/mem.sh` starts the release binary, creates N tenants from the starter
 project, edits one file in each, loads the preview module graph of each, and
-reads the daemon's RSS from `/proc`.
-
-Release build on Linux x86-64, three base projects loaded, every tenant with
-one edited page and a loaded preview:
+reads the daemon's RSS from `/proc`. CI runs it on every push, so the figures
+below are a CI run's and not a laptop's — `bench/mem.sh 100 4398` on
+`ubuntu-latest`, at commit `49be004`, in
+[run 34060501537](https://github.com/productdevbook/sandbox-lite/actions/runs/34060501537).
+Every tenant there has one edited page and a loaded preview, with all five
+`examples/` projects loaded as bases:
 
 | | daemon RSS |
 |---|---|
-| idle | 7.0 MB |
-| after 1000 tenants (edit + preview each) | 19.7 MB — 13 kB per tenant |
+| idle | 7.4 MB |
+| after 100 tenants (edit + preview each) | 14.6 MB — 72 kB per tenant |
 
 Creating a tenant, writing its edit and fetching its whole module graph took
-~147 ms per tenant through the HTTP API. After 1000 tenants the transform cache
-held 1008 entries in 571 kB (1000 unique edited pages plus the 8 shared modules
-every tenant reuses), 7993 hits to 1008 misses. The binary is 15.8 MB.
+~90 ms per tenant through the HTTP API. The transform cache then held 108
+entries in 66 kB — 100 unique edited pages plus the 8 shared modules every
+tenant reuses — at 793 hits to 108 misses. 100 is the count CI runs, so 100 is
+the count this table reports; `bench/mem.sh N` takes any other, and the
+per-tenant figure is the marginal cost at the count it was measured at rather
+than a constant to multiply.
 
 ### The same project, the other way
 
 `bench/vs-astro-dev.sh` runs the comparison on one machine: `npm install` plus
-`astro dev` for one tenant, then the daemon serving the same project.
+`astro dev` for one tenant, then the daemon serving the same project. It prints
+install time and `node_modules` size, time to a ready server, time to the first
+page, and RSS for each side. Nothing runs it in CI, so no numbers off it are
+quoted here; run it on the hardware you care about.
 
-| | `astro dev`, one per tenant | sandbox-lite, one for all |
-|---|---|---|
-| dependencies | 4.1 s install, 166 MB of `node_modules` **per tenant** | none — the browser fetches packages from a CDN, already built |
-| server ready | 3.0 s | 8 ms |
-| tenant ready | (the process *is* the tenant) | 6 ms |
-| first page, whole module graph | 97 ms | 51 ms (6 modules compiled) |
-| **cold → first page** | **7.2 s** | **65 ms** |
-| memory | 636 MB for that one tenant | 12 MB for the daemon and every tenant in it |
-
-The install was measured with a warm npm cache; in a fresh container it was
-18 s, which is the number that matters — that is what a hosted builder pays
-every time it starts a session. For scale: ComputeSDK's public
+The shape of the difference is not a measurement, though. `astro dev` needs a
+dependency install and a Node process for every tenant; sandbox-lite needs
+neither, because the browser fetches packages from a CDN already built and one
+daemon serves every tenant. The install is what dominates a cold start, and it
+is paid again every time a hosted builder opens a session. For scale:
+ComputeSDK's public
 [sandbox benchmark](https://www.computesdk.com/benchmarks/sandboxes/dax/) times
 32 providers doing clone + install + typecheck in a fresh sandbox, and the
 fastest finishes in 33.5 s.
 
-sandbox-lite is not in that benchmark and cannot be: it has no shell and runs no
-customer code. It removes the install step rather than accelerating it, which
-only works because the compiler is a library and the runtime is the browser's.
-That trade is the whole design — see *What the preview does not do*.
+sandbox-lite is not in that benchmark and cannot be: it has no shell, installs
+nothing and never runs the project's build. It removes the install step rather
+than accelerating it, which only works because the compiler is a library and the
+runtime is the browser's. That trade is the whole design — see *What the preview
+does not do*. (`--chrome` is the one thing that runs tenant JavaScript on the
+daemon's own host; `SECURITY.md` says what that means.)
 
 Per-tenant state is the overlay (only edited files) plus a content-addressed
 transform cache shared by every tenant: two tenants with the same `Header.astro`
@@ -104,10 +108,15 @@ would push a tenant past it is refused with `413`.
 
 ## Install
 
-Every [release](https://github.com/productdevbook/sandbox-lite/releases) carries
-a stripped binary for Linux (x86-64 and arm64, glibc 2.35 or newer) and macOS
-(Intel and Apple silicon) as `sandbox-lite-<tag>-<target>.tar.gz`, holding
-`sandbox-lite`, `LICENSE` and `README.md`, plus a `SHA256SUMS` file:
+**No version has been tagged yet**, so there is nothing on the releases page
+and no image in the registry: build from source for now, and read the next two
+blocks as what a `v*` tag will produce (`.github/workflows/release.yml`).
+
+Each [release](https://github.com/productdevbook/sandbox-lite/releases) will
+carry a stripped binary for Linux (x86-64 and arm64, built in `rust:1-bookworm`
+so glibc 2.36 or newer) and macOS (Intel and Apple silicon) as
+`sandbox-lite-<tag>-<target>.tar.gz`, holding `sandbox-lite`, `LICENSE` and
+`README.md`, plus a `SHA256SUMS` file:
 
 ```sh
 tag=v0.1.0
@@ -118,18 +127,19 @@ sandbox-lite --bases path/to/your/astro-projects
 ```
 
 The same tag is published as a multi-arch image (`linux/amd64`, `linux/arm64`)
-at `ghcr.io/productdevbook/sandbox-lite:<tag>`, and `:latest` follows the newest
-release; see [Docker](#docker) for what the image bundles:
+at `ghcr.io/productdevbook/sandbox-lite:<tag>`, with `:latest` following the
+newest release; see [Docker](#docker) for what the image bundles:
 
 ```sh
 docker run -p 4321:4321 -v sandbox-data:/data ghcr.io/productdevbook/sandbox-lite:latest
 ```
 
-Or build from source with a current stable Rust toolchain. The browser runtime
-is embedded in the binary, so nothing else is needed at run time:
+Build from source with a current stable Rust toolchain — the way in today. The
+browser runtime is embedded in the binary, so nothing else is needed at run
+time:
 
 ```sh
-cargo install --locked --git https://github.com/productdevbook/sandbox-lite   # --tag v0.1.0 pins a release
+cargo install --locked --git https://github.com/productdevbook/sandbox-lite   # --tag v0.1.0 will pin a release
 ```
 
 ## Try it
@@ -149,9 +159,10 @@ With `ANTHROPIC_API_KEY` set, the Chat tab talks to Claude with `read_file`,
 `write_file`, `delete_file`, `list_files` and `check_site` tools scoped to that
 tenant. Every write shows up in the preview as it happens. The reply is
 streamed: the editor sends `Accept: text/event-stream` and paints the text and
-each tool call as they arrive. Conversations are kept per tenant under
-`<data-dir>/<id>/chats/` and are listed in the Chat tab's dropdown, so a
-customer can pick an old thread back up; the tool loop sees the earlier turns.
+each tool call as they arrive. Conversations are kept per tenant as one JSON
+file each under `<data-dir>/<id>/chats/` — in memory with `--no-persist` — and
+are listed in the Chat tab's dropdown, so a customer can pick an old thread back
+up; the tool loop sees the earlier turns.
 
 A conversation does not grow without end. The last `--chat-window` turns
 (default 24) are replayed to the model in full; when a conversation passes that,
@@ -194,7 +205,8 @@ its 20 s deadline is killed and reaped before its profile directory goes.
 --chats-per-tenant N conversations a tenant may keep (default 50)
 --tenant-quota-mb N  edited files a tenant may hold, in MiB (default 64)
 --cookie-samesite lax|none
-                     SameSite of the preview cookie; none also sets Secure (default lax)
+                     SameSite of the preview cookie; none also sets Secure
+                     (default: none with --preview-secret, lax without)
 ```
 
 `SANDBOX_LITE_API_TOKEN`, `SANDBOX_LITE_PREVIEW_SECRET`,
@@ -264,7 +276,7 @@ Editor host (`localhost`):
 | GET/PUT/DELETE | `/api/t/{id}/file/{path}` | raw file bytes |
 | GET | `/api/t/{id}/events` | SSE: `update` / `delete` with the new version and a `kind` (`css`, `style`, `module`) |
 | GET | `/api/t/{id}/check` | compile every source file, return diagnostics |
-| POST | `/api/t/{id}/chat` | `{messages:[{role,content}], chat?}` → `{text, changes, chat}`, or SSE with `Accept: text/event-stream` |
+| POST | `/api/t/{id}/chat` | `{messages:[{role,content}], chat?}` → `{text, changes, iterations, version, chat}`, or SSE with `Accept: text/event-stream` |
 | GET | `/api/t/{id}/chats` | saved conversations, newest first |
 | GET/DELETE | `/api/t/{id}/chats/{chat}` | one conversation with its turns / remove it |
 
@@ -289,8 +301,10 @@ curl -fsS -X POST --data-binary @acme.tar.gz localhost:4321/api/tenants/acme-cop
 `sandbox_lite_tenants`, `sandbox_lite_overlay_bytes`, `sandbox_lite_cache_*`,
 `sandbox_lite_sse_subscribers`, `sandbox_lite_rss_bytes`,
 `sandbox_lite_uptime_seconds`, one series per base, `sandbox_lite_sass_*`
-(running, runaway, timeouts, refusals), `sandbox_lite_screenshots_*` (running,
-calls told the tool was busy, browsers killed on their deadline),
+(running, runaway, timeouts, refusals), `sandbox_lite_compiles_*` (permits
+held, builds queued, the `--max-compiles` limit, builds refused with 503),
+`sandbox_lite_screenshots_*` (running, calls told the tool was busy, browsers
+killed on their deadline),
 `sandbox_lite_module_requests_total{kind,status}` and
 `sandbox_lite_compile_seconds{kind}` — a histogram of what a transform-cache
 miss costs, so `histogram_quantile(0.99, …)` answers "how slow is a cold
@@ -376,15 +390,22 @@ the two configurations that work — is [`docs/multi-node.md`](docs/multi-node.m
    byte-identical to the last build changed only its `<style>` blocks and is
    `style`, and everything else is `module`. On `css` and `style` the CSS
    module is re-imported and the matching `<style data-sl=…>` swapped in place,
-   leaving the page's DOM and JS state alone; on `module` — or on anything the
-   daemon cannot prove, or while the error overlay is up — the page reloads.
+   leaving the page's DOM and JS state alone; a stylesheet the page only reaches
+   through another sheet's `@import` has no block of its own, so the importing
+   block's `/__sl/raw/` URL gets a fresh `?v=` instead. On `module` — or on
+   anything the daemon cannot prove, or while the error overlay is up — the page
+   reloads.
    Tailwind is the exception: a `type="text/tailwindcss"` block is compiled by
    Tailwind's browser build when it loads and there is no rebuild hook to call,
    so a write that touches one reloads the page.
 
-Error states are pages too: a compile error, a missing import, a 404 route or
-a failing `getStaticPaths` render an overlay that lists the daemon's
-diagnostics and reloads when the file is fixed.
+Error states are pages too, and they all reload when the file is fixed —
+`live.js` is in the overlay, and its `<body data-sl-overlay>` is what stops a
+CSS swap being applied to it. A render that throws — a compile error, a missing
+import, a `getStaticPaths` that fails — fetches `/__sl/check` and lists the
+daemon's diagnostics. The overlays that have none to list say what happened
+instead: no route matched (with the route table), no static path matched the
+URL, or the page answered `4xx`/`5xx` with an empty body.
 
 ## Layout
 
@@ -413,7 +434,7 @@ e2e/                   Playwright suite for the browser side: every example page
 
 - **Solid islands.** React, Preact, Vue and Svelte renderers ship; another
   framework needs a `server` module exposing `check` and
-  `renderToStaticMarkup` (see `assets/shims/renderer-react.js`, 40 lines) and a
+  `renderToStaticMarkup` (see `assets/shims/renderer-react.js`, 42 lines) and a
   `client` entrypoint, listed under `renderers` in `sandbox-lite.json`.
 - **Type-driven Vue macros.** There is no Rust compiler for `.vue` or
   `.svelte`, so the daemon serves the component as a loader module that runs

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,15 +34,43 @@ every hostname that does not parse as a tenant host. Put the daemon behind a
 proxy that only forwards the hostnames you intend, and treat every request
 that reaches the editor/API router as coming from your own backend.
 
-Tenant files never run inside the daemon. The daemon compiles `.astro`
-(astro_codegen), TypeScript/JSX (oxc), Sass (grass), Markdown (pulldown-cmark)
-and parses JSON/YAML; the resulting JavaScript runs in the visitor's browser on
-the tenant origin, using Astro's own runtime bundled as `/__sl/astro.js`.
+Serving a preview evaluates no tenant code in the daemon. The daemon compiles
+`.astro` (astro_codegen), TypeScript/JSX (oxc), Sass (grass), Markdown
+(pulldown-cmark) and parses JSON/YAML; the resulting JavaScript runs in the
+visitor's browser on the tenant origin, using Astro's own runtime bundled as
+`/__sl/astro.js`. One flag changes that.
 
 Whoever can call `/api/*` owns every tenant: create, delete, read and write any
 file, drive the chat endpoint. They also decide what the daemon reads off the
 host as a base project, bounded only by `--bases` (below). There are no users,
 roles or per-tenant credentials on the API side.
+
+### What `--chrome` adds
+
+`--chrome PATH` gives the chat model a sixth tool, `screenshot` (`tools`,
+`src/http/ai.rs`). Calling it spawns the operator's Chrome binary **on the
+daemon's host** and points it at the tenant's own preview URL (`shoot`, and
+`preview_url_path` in `src/http/api.rs`). That browser then executes the
+tenant's compiled modules, its inline `<script>` blocks and everything they
+import from `--cdn`, as the daemon's user. Three consequences:
+
+- Chrome is started with `--no-sandbox`, so its renderer sandbox is off: a
+  renderer bug reaches the daemon's uid directly rather than a sandbox.
+- Tenant JavaScript gets the daemon's host and network position for the length
+  of the run — loopback services, a cloud instance-metadata endpoint, anything
+  the daemon's egress reaches. The 20 s deadline (`SHOT_TIMEOUT`) bounds how
+  long that lasts, not what it can reach.
+- The tenant's `sl_token` is passed to Chrome as a command-line argument, so it
+  is in the host's process table for the life of the browser.
+
+The URL itself stays on the tenant: `shot_path` refuses `://`, a leading `//`,
+whitespace and control characters, and the origin is built from the tenant id
+rather than from the model's input. What runs *on* that page is the exposure.
+
+The path to it is: whoever can call `POST /api/t/{id}/chat` → the model → a
+page of that tenant. So enable `--chrome` only where the tenant trees are
+trusted, and run the browser somewhere it cannot reach anything else: a
+container, or a network namespace of its own.
 
 ## What the daemon enforces
 
@@ -77,14 +105,17 @@ roles or per-tenant credentials on the API side.
   `astro_codegen`, `satteri-mdxjs` or `grass`, all of which are
   recursive-descent and so can overflow a thread stack — which aborts the whole
   daemon, since the release profile sets `panic = "abort"`. The three apply to
-  the extensions those parsers read: `.astro`, `.ts`, `.tsx`, `.jsx`, `.mts`,
-  `.js`, `.mjs`, `.mdx`, `.scss`, `.sass`.
+  the extensions those parsers read (`parses_source`, `src/transform/mod.rs`):
+  `.astro`, `.ts`, `.tsx`, `.jsx`, `.mts`, `.js`, `.mjs`, `.mdx`, `.scss`,
+  `.sass`, `.vue` and `.svelte` — the last two because `sfc::strip_types` runs
+  oxc over their `<script lang="ts">` blocks before the browser sees them.
   - **Size** is capped by `--max-source-kb` (default 64 KiB).
   - **Nesting** is capped at 2000 (`MAX_NESTING_DEPTH`) — the deepest run of
     unclosed `(`, `[`, `{` or of markdown blockquote markers, counted on the
     bytes before any parser sees them.
   - **Stack**: every compile runs on a thread whose stack is sized from the
-    size cap (`Engine::parser_stack_bytes`, 256 MiB at the default), which
+    size cap — `max_source_bytes * 4000`, never below 16 MiB
+    (`Engine::parser_stack_bytes`), so 250 MiB at the default — which
     covers the recursion the nesting scan does not model — chained unary `-`
     for oxc, `<<` for `astro_codegen`. Raising `--max-source-kb` raises the
     stack with it. The reservation is virtual address space; only the pages a
@@ -210,6 +241,9 @@ that router answers `401` unless the request carries
 - It is the only thing gating `POST /api/tenants/{id}/import`, which writes a
   whole file tree into a tenant in one request, and
   `GET /api/t/{id}/export`, which returns one.
+- It is the only thing gating `GET /api/t/{id}/chats` and
+  `GET /api/t/{id}/chats/{chat}`, which return a tenant's stored conversations
+  in full — including whatever the model quoted out of the tenant's files.
 - It is the only thing gating `POST /api/bases`, which reads a directory of
   the host into memory, and `POST /api/bases/{name}/reload`, which re-reads
   one and makes every tenant on it reload.
@@ -265,15 +299,31 @@ endpoint, including `/__sl/raw/`, `/__sl/events` and `/__sl/check`.
 ## Tenant files are public to anyone who can open the preview
 
 `/__sl/raw/<path>` returns any file of the tenant (base project plus overlay)
-as-is, and `/__sl/m/<path>?raw` returns it as a module. That includes `.env`,
-`package.json`, `sandbox-lite.json` and every source file. Only the shell's
-`import.meta.env` is filtered to `PUBLIC_*` keys; the `.env` file itself is
-not. The compiled output of every page and component is served too, because
-that is what the browser renders.
+as-is, and `/__sl/m/<path>?raw` returns it as a module. That includes
+`package.json`, `sandbox-lite.json`, `tsconfig.json` and every source file, and
+the compiled output of every page and component, because that is what the
+browser renders.
 
-Do not put secrets in base projects or tenant trees. With `--preview-secret`
-the audience is "whoever has the tenant's link"; without it, the audience is
-the network.
+Dotfiles are the exception. `is_private_path` (`src/store.rs`) refuses any path
+with a segment starting with `.`, `.well-known` excepted, and it gates all
+three preview read paths: `/__sl/m/{path}`, `/__sl/raw/{path}` and the
+`public/` fallback (`src/http/preview.rs`). A preview visitor cannot fetch
+`.env`.
+
+Put no secrets in base projects or tenant trees anyway. A dotfile is not a
+secret store, and three things reach past that rule:
+
+- The `PUBLIC_*` keys of `.env` are read into the shell's `import.meta.env`
+  (`env_map`, `src/http/preview.rs`) and exported by the `astro:env` shim, so
+  they are in the page every visitor loads.
+- The editor/API router serves the file itself: `GET /api/t/{id}/file/.env`
+  goes through `clean_path` alone, and the chat's `read_file` tool does the
+  same. Both are behind `--api-token`, whose audience is already every file of
+  every tenant.
+- An export carries every dotfile of the tenant (see "Hidden files" above).
+
+With `--preview-secret` the preview's audience is "whoever has the tenant's
+link"; without it, the audience is the network.
 
 ## Put previews on their own registrable domain
 
@@ -300,15 +350,19 @@ editor stores the API token in `localStorage` and embeds tenant previews in an
 ## What leaves the machine
 
 - **Anthropic API.** When `ANTHROPIC_API_KEY` is set, `POST /api/t/{id}/chat`
-  sends to `https://api.anthropic.com/v1/messages`: the conversation the
-  caller supplies, a system prompt containing the tenant id and base name, and
-  every tool result — the file listing, the contents of any file the model
-  reads (up to 200 KiB per file, any path in the tenant), and `check`
-  diagnostics. `write_file` and `delete_file` take effect on the tenant
+  sends to `{api_base}/v1/messages` (`src/http/ai.rs`), where `api_base` is
+  `https://api.anthropic.com` unless `SANDBOX_LITE_ANTHROPIC_BASE` names
+  another endpoint (`src/main.rs`). What is sent: the conversation the caller
+  supplies, the stored turns of the conversation it continues, a system prompt
+  containing the tenant id and base name, and every tool result — the file
+  listing, the contents of any file the model reads (up to 200 KiB per file,
+  any path in the tenant, dotfiles included), `check` diagnostics, and, under
+  `--chrome`, a PNG of the rendered page up to 4 MiB (`MAX_SHOT`) base64-encoded
+  into the tool result. `write_file` and `delete_file` take effect on the tenant
   immediately, without confirmation. A conversation that has passed
-  `--chat-window` costs one further call, which sends the turns being folded
-  away and takes back the summary that replaces them. Without the key the
-  endpoint answers `503` and nothing is sent.
+  `--chat-window` costs one further call to the same endpoint, which sends the
+  turns being folded away and takes back the summary that replaces them.
+  Without the key the endpoint answers `503` and nothing is sent.
 - **CDN, in the visitor's browser.** Bare imports (`react`, `dayjs`) resolve to
   `--cdn` (default `https://esm.sh`) with the version range from
   `package.json`; React and Preact client entrypoints come from the same CDN.
@@ -320,10 +374,13 @@ editor stores the API token in `localStorage` and embeds tenant previews in an
 ## Limits that do not exist
 
 - No rate limiting on any route.
-- Compilation is CPU work per request; `/__sl/check` and `/api/t/{id}/check`
-  build every source file of a tenant on every call — a cache hit for an
-  unchanged file, a compile for a changed one. Only Sass has a deadline and a
-  thread cap (above); nothing bounds the total CPU a caller can ask for.
+- **No deadline on a single non-Sass compile.** `--max-compiles` bounds how
+  many run at once (above), and Sass has a deadline of its own, but an
+  `.astro`, `.ts` or `.mdx` compile runs to completion however long it takes,
+  holding its permit throughout. Nothing bounds the total CPU a caller can ask
+  for over time either: compilation is CPU work per request, and `/__sl/check`
+  and `/api/t/{id}/check` build every source file of a tenant on every call — a
+  cache hit for an unchanged file, a compile for a changed one.
 - No timeout once a request head has arrived: a body may trickle in, and a
   response may be read slowly, for as long as the client likes.
 - The transform cache is bounded by `--cache-mb` and each tenant's overlay by
@@ -332,7 +389,9 @@ editor stores the API token in `localStorage` and embeds tenant previews in an
   persistence every write goes to disk under `--data-dir`, and files over
   256 KiB are kept only there and re-read on demand; with `--no-persist`,
   every written file is held in memory whatever its size.
-- Tenant code is limited only by the visitor's browser.
+- Tenant code is limited only by the visitor's browser — except under
+  `--chrome`, where the screenshot tool runs it in a browser on the daemon's
+  own host, unsandboxed (see "What `--chrome` adds").
 
 ## Deployment checklist
 
@@ -348,4 +407,9 @@ editor stores the API token in `localStorage` and embeds tenant previews in an
 5. Your own limits on tenant count and request rate; `--tenant-quota-mb`
    bounds each tenant's write volume, not how many tenants there are.
 6. `ANTHROPIC_API_KEY` only if the chat endpoint is wanted, knowing what it
-   sends and that the API token is the only thing gating it.
+   sends and that the API token is the only thing gating it;
+   `SANDBOX_LITE_ANTHROPIC_BASE` set only to an endpoint you trust with all of
+   that.
+7. `--chrome` only where the tenant trees are trusted, and then with the
+   browser confined — a container, or a network namespace — because it runs
+   tenant JavaScript on the daemon's host, unsandboxed.

--- a/docs/multi-node.md
+++ b/docs/multi-node.md
@@ -23,6 +23,13 @@ A daemon is not a stateless front end over the data directory. Each one holds:
 - **An SSE channel per tenant** (`tokio::sync::broadcast`, 64 slots) that only
   that daemon's own writes publish to.
 
+Conversations are the exception, and the only shared state here. With a
+`--data-dir`, `Chats` holds nothing: every load, save, list and delete goes
+straight to `<data-dir>/<id>/chats/*.json` (`src/http/chats.rs`), so a chat
+started on one node is readable on the other as soon as that node has the
+tenant. Two nodes saving the same chat id is last-writer-wins like any other
+file. With `--no-persist` they are per-node memory and are not shared at all.
+
 So with two daemons, A and B, sharing `--data-dir`:
 
 | | What happens |
@@ -34,6 +41,8 @@ So with two daemons, A and B, sharing `--data-dir`:
 | A writes again after B has restored | B does not see it. The restore happens once, on the miss. |
 | `DELETE /api/tenants/acme` on A | The directory goes; B keeps serving the tenant it already holds in memory. |
 | `POST /api/bases/theme/reload` on A | Only A re-reads the base. B keeps the copy it loaded. |
+| `POST /api/t/acme/chat` on A, then `GET /api/t/acme/chats` on B | B lists it: conversations are read from the shared data directory on every call, not cached. |
+| `POST /api/tenants/acme/import` on A | A's overlay and the data directory change; B's overlay does not, exactly as for a single write. |
 | `/api/stats`, `/metrics` on B | B's own tenants, cache and subscribers. Neither number is a cluster total. |
 
 The version being per node also means a browser that moves from A to B
@@ -89,6 +98,10 @@ What still bites:
 - **`POST /api/bases` and `POST /api/bases/{name}/reload` are per node.** Call
   them on every node, or give every node `--watch-bases N` over a shared base
   directory.
+- **`--chats-per-tenant` is enforced per call, against the shared directory.**
+  Two nodes saving conversations for one tenant at the same time can each
+  evict what the other just wrote; the cap holds, which conversation survives
+  is a race.
 
 ## Configuration 2: one node per base
 
@@ -119,4 +132,5 @@ Not implemented, listed so nobody has to rediscover it:
    follows.
 
 Until then: route stickily, keep one tenant on one node, and treat
-`--data-dir` as durability rather than as shared state.
+`--data-dir` as durability rather than as shared state — conversations being
+the one thing it does share.


### PR DESCRIPTION
Closes #66

Closes #67

Every behavioural sentence in `README.md`, `SECURITY.md`, `ARCHITECTURE.md` and
`docs/multi-node.md` was checked against the function that implements it. The
ten claims the two issues name are below, and then the ones the sweep turned up
on its own. Nothing outside those four files changed.

## From #66 — the threat model

| Claim | What disproves it |
|---|---|
| SECURITY.md:37 "Tenant files never run inside the daemon." | `tools` (`src/http/ai.rs`) adds `screenshot` whenever `st.chrome.is_some()`, and `shoot` spawns `Command::new(chrome)` at `preview_url_path(st, &t.id, path)` (`src/http/api.rs`) — a real browser on the daemon's host, rendering the tenant's own page. Replaced with a "What `--chrome` adds" section naming `--no-sandbox`, the daemon's network position, the `SHOT_TIMEOUT` bound, and `sl_token` landing in Chrome's argv, plus the recommendation to confine the browser. |
| SECURITY.md:334 "Tenant code is limited only by the visitor's browser." | Same code path. Now carries the `--chrome` exception. |
| SECURITY.md:266-271 "That includes `.env` … the `.env` file itself is not [filtered]." | `is_private_path` (`src/store.rs`) refuses dotfiles, and gates `preview::module`, `preview::raw` and the `public/` fallback in `src/http/preview.rs`. Rewritten to name what *is* served, and to keep the "no secrets in tenant trees" advice with the three routes that still reach a dotfile: `PUBLIC_*` through `env_map`, the API's `read_file` / `GET /api/t/{id}/file/{path}` (which use `clean_path` alone), and an export. |
| SECURITY.md "What leaves the machine" omits the screenshot. | `shoot` returns a base64 PNG up to `MAX_SHOT` (4 MiB) as an `image` block in the tool result. Added. |

## From #67 — the stale numbers and lists

| # | Claim | What disproves it |
|---|---|---|
| 1 | README.md:196 `--cookie-samesite` "default lax" | `SameSite::default_for` (`src/http/mod.rs`) returns `None` when a preview secret is set, applied at `src/main.rs`. The prose and `usage()` were already right. |
| 2 | SECURITY.md:87 "256 MiB at the default" | `Engine::parser_stack_bytes` is `max_source_bytes * STACK_PER_SOURCE_BYTE` with the constant at 4000 (`src/transform/mod.rs`): 65536 × 4000 = **250 MiB**. The `MIN_PARSER_STACK` floor is now stated too. |
| 3 | SECURITY.md:80-81 capped-extension list | `parses_source` (`src/transform/mod.rs`) also matches `vue` and `svelte`, because `sfc::strip_types` runs oxc over their `<script lang="ts">` blocks. Added, with the reason. |
| 4 | ARCHITECTURE.md:492-493 `check`'s source list | `is_source` (`src/transform/mod.rs`) includes `vue` and `svelte`, which ARCHITECTURE.md:238 already relied on. Added. |
| 5 | ARCHITECTURE.md:531-535 the chat section | `tools` adds a sixth tool under `--chrome`; `run` answers `{text, changes, iterations, version, chat}`; `chat` answers SSE on `Accept: text/event-stream` (`src/http/ai.rs`); `ChatReq` carries `chat`, and `compact` / `Conversation::for_model` / `evictable` (`src/http/chats.rs`) are the window, the summary and the cap. Section rewritten. |
| 6 | ARCHITECTURE.md:23-28 the editor/API route table | `http::app` (`src/http/mod.rs`) also routes `/api/tenants/{id}/import`, `/api/t/{id}/export`, `/api/t/{id}/chats` and `/api/t/{id}/chats/{chat}`. Added, and the list now says plainly that it *is* the `--api-token` surface. |
| 7 | SECURITY.md:324-325 "nothing bounds the total CPU" | The gate (`Gate::enter`, `src/transform/mod.rs`) bounds concurrency and is documented at SECURITY.md:105-110, so the section contradicted itself. Replaced with what is actually missing: no deadline on a single non-Sass compile, and no bound on total work over time. |
| — | SECURITY.md:303 `https://api.anthropic.com/v1/messages` | Both call sites use `{api_base}/v1/messages` (`src/http/ai.rs`), with `api_base` from `SANDBOX_LITE_ANTHROPIC_BASE` (`src/main.rs`). Corrected here and in ARCHITECTURE.md, and added to the deployment checklist. |

## Found by the sweep

**README, the headline measurements.** `bench/mem.sh` runs in CI on every push,
so the "What it costs" table now reports what CI measured rather than a laptop:
`bench/mem.sh 100 4398` on `ubuntu-latest` at `49be004`,
[run 34060501537](https://github.com/productdevbook/sandbox-lite/actions/runs/34060501537)
— idle 7.4 MB, 14.6 MB after 100 tenants, ~90 ms per tenant, 108 cache entries
in 66 kB at 793 hits to 108 misses. The README says where the figures come from.

Two numbers went rather than moved. `bench/vs-astro-dev.sh` runs nowhere in CI
and cannot be run locally for this, so its table of one-machine timings is
replaced by a description of what the script prints and the structural claim
that survives measurement; and "The binary is 15.8 MB" is gone, because nothing
in CI measures it.

**README, install.** No `v*` tag has ever been pushed
(`gh release list` is empty), so "Every release carries a stripped binary…" and
`tag=v0.1.0` described a releases page with nothing on it and a registry with no
image — `release.yml` publishes only on `push: tags: ["v*"]`. The section now
says that outright. Its glibc floor was wrong too: the Linux build runs in
`rust:1-bookworm`, so 2.36, not 2.35.

**README, smaller.**

- `POST /api/t/{id}/chat` returns five fields, not three (`run`, `src/http/ai.rs`).
- The `/metrics` series list omitted `sandbox_lite_compiles_*`, which `render` emits (`src/metrics.rs`).
- Step 8 said `css` always re-imports the CSS module; `cssJobs` (`assets/live.js`) only does that for a block the page owns (`el.dataset.sl === path`) — an `@import`ed sheet gets a fresh `?v=` on the importing block's `/__sl/raw/` URL instead. ARCHITECTURE.md had this right; the README summary did not.
- "a 404 route or a failing `getStaticPaths` render an overlay that lists the daemon's diagnostics": only the top-level catch fetches `/__sl/check` (`assets/shell.js`). The no-route and no-static-path overlays carry no diagnostics, and there is a third with none — a `4xx`/`5xx` with an empty body. Rewritten to say which is which.
- Conversations are in memory with `--no-persist` (`dir(t)`, `src/http/chats.rs`).
- `renderer-react.js` is 42 lines, not 40.

**ARCHITECTURE, smaller.**

- The shell also fills `%TOKEN%` / `%TOKENQ%`, and `%ENV%` includes `ASSETS_PREFIX` (`env_map`, `preview::page`).
- The `public/` fallback is gated by `is_private_path` too, which the step did not say.
- Step 8 gained the empty-body branch (`assets/shell.js`), the behaviour #48 was about.
- "Each `<style>` block is registered … the way a `.css` module is" is true of neither loader exactly: `vue-loader.js` keys per block as `<path>?<index>`, `svelte-loader.js` registers one combined output under the bare path.
- The layout block omitted `src/http/anthropic.rs` and `src/http/chats.rs`.

**docs/multi-node.md.** Its list of what a daemon holds in memory predates
saved conversations, and they are the exception it turns on: with a
`--data-dir`, `Chats` caches nothing — every load, save, list and delete goes
straight to `<data-dir>/<id>/chats/*.json` (`src/http/chats.rs`) — so a chat
started on one node is readable on the other, unlike an overlay. Added to the
prose, to the table, and to what still bites (two nodes can each evict the
conversation the other just saved).

## Noticed, not fixed

Code, not documentation, so filed separately rather than changed here:

- `sandbox-lite check`'s endpoint census (`src/check.rs`) counts
  `src/pages/**` files ending `.ts` or `.js`, while `routes::route`
  (`src/routes.rs`) makes an endpoint of `.ts`, `.js`, `.mjs` and `.mts` and
  skips any path with a `_`-prefixed segment. So the census under-counts a
  project whose endpoints are `.mjs`/`.mts` and counts `src/pages/_helpers.ts`
  as an endpoint. Filed as an issue.
- `usage()` in `src/main.rs` describes `--max-source-kb` as the cap on
  ".astro/.ts/.js/.mdx/.scss" files, omitting `.vue` and `.svelte` that
  `parses_source` covers. The README's flag block has it right. A one-line
  string change, left out of a documentation-only PR.
- `preview_url_path` passing `sl_token` in Chrome's argv is described in
  SECURITY.md now, and named in #66 as related-but-separate; no separate issue
  filed for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
