### PR TITLE
store: contain base symlinks, and make a delete actually delete

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -35,8 +35,12 @@ A **base** is a project directory read at startup (`Base::load`): every regular
 file, skipping `node_modules`, `.git`, `dist`, `.astro`, `.vercel`, `.netlify`,
 `.output`. Files up to 256 KiB are held in memory (`FileData::Mem`); larger ones
 stay on disk and are re-read on each access (`FileData::Disk`). Bases come from
-every sub-directory of `--bases` (default `./examples` when it exists), from
-each `--base NAME=PATH`, and from `POST /api/bases` at run time. `Base::load`
+every sub-directory of `--bases` (default `./examples` when it exists) that is
+a directory in its own right — `Store::bases_in_dir` reads the entry's own
+type, so a symbolic link is skipped rather than followed — from each
+`--base NAME=PATH`, and from `POST /api/bases` at run time. All three put the
+root through `Store::base_root` first, so with `--bases` set a root outside it
+is refused whichever way it arrives. `Base::load`
 also records a `stamp`: a hash of the name, size and mtime of every file it
 took, in path order, which is what the watcher compares.
 
@@ -77,6 +81,15 @@ at startup with a fresh version and skips any whose base is not loaded.
 daemon created under a shared `--data-dir` is restored the first time this one
 is asked for it; a tenant already in memory is never re-read, which is the
 limit `docs/multi-node.md` sets out. `--no-persist` keeps everything in memory.
+
+Because that fallback makes the data directory as much a source of tenants as
+the map, the two operations that decide whether a tenant exists consult both:
+`Store::remove_tenant` drops the map entry and removes `<data-dir>/<id>`,
+answering "no such tenant" only when neither holds it, and `create_tenant`
+refuses an id whose directory is already there even when it cannot build a
+tenant from it — its base may not be loaded on this node. `Store::tenants` is
+the exception, and stays a list of what this daemon has loaded: it answers
+`/api/tenants`, `/api/stats` and `/metrics`, none of which act on a tenant.
 
 ### Reloading a base
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ its 20 s deadline is killed and reaped before its profile directory goes.
 ```
 --listen ADDR        bind address (default 127.0.0.1:4321)
 --domain NAME        tenants are served at http://<id>.NAME:PORT/ (default localhost)
---bases DIR          directory whose sub-directories are base projects
+--bases DIR          directory whose sub-directories are base projects (symbolic links are skipped)
 --base NAME=PATH     add one base project (repeatable)
 --watch-bases N      re-read a base project when its files change, polled every N seconds (default: off)
 --data-dir DIR       where tenant edits are persisted (default ./data)
@@ -257,7 +257,7 @@ Editor host (`localhost`):
 | GET/POST | `/api/bases` | list / add `{name, path}`; the path must be inside `--bases` when that flag is set |
 | POST | `/api/bases/{name}/reload` | re-read the base from disk and re-point every tenant on it |
 | GET/POST | `/api/tenants` | list / create `{id, base}` |
-| DELETE | `/api/tenants/{id}` | remove tenant and its edits |
+| DELETE | `/api/tenants/{id}` | remove the tenant: its map entry and its whole `<data-dir>/{id}` directory, whether or not the daemon had it loaded |
 | POST | `/api/tenants/{id}/import` | tar.gz body → overlay; `?replace=1` drops the edits it does not carry |
 | GET | `/api/t/{id}/files` | merged base + overlay listing |
 | GET | `/api/t/{id}/export` | tar.gz of the merged tree; `?overlay=1` for the edits alone |
@@ -342,7 +342,10 @@ the mtime is not noticed; the reload endpoint is the escape hatch for that.
 `POST /api/bases {"name","path"}` adds a base to a running daemon. With
 `--bases` set the path must resolve inside that directory; without it, any
 readable directory on the host will do — the API token is the only gate, so
-this is an operator surface. See `SECURITY.md`.
+this is an operator surface. The startup scan applies the same rule: an entry
+of `--bases` becomes a base only when the entry itself is a directory, so a
+symbolic link is skipped rather than followed, and `--base NAME=PATH` is held
+to the containment too. See `SECURITY.md`.
 
 Bases and reloads are per process. Running more than one daemon behind a load
 balancer with a shared `--data-dir` — what each node does and does not see, and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -55,12 +55,28 @@ roles or per-tenant credentials on the API side.
   cannot leave it.
 - **Tenant ids** are validated by `valid_id` (same rule as the host label) and
   are used as directory names under `--data-dir`.
+- **Deleting a tenant** (`DELETE /api/tenants/{id}`) resolves it the way every
+  other tenant route does — this daemon's memory first, then `<data-dir>/<id>`
+  — and removes both. A tenant the daemon can serve but has not loaded is
+  deleted rather than answered `404` and then restored by the next request
+  (issue #74). What goes is the whole directory: the overlay files, the
+  tombstone list and the tenant's conversations. `204` means the bytes are gone
+  from that data directory; a second daemon that already holds the tenant in
+  memory keeps serving its own copy (`docs/multi-node.md`).
 - **Base projects** are read at startup, and again on
   `POST /api/bases/{name}/reload` or a `--watch-bases` tick. `node_modules`,
   `.git`, `dist`, `.astro`, `.vercel`, `.netlify` and `.output` are skipped,
   and so is anything that is not a regular file or directory (symbolic links
   are not followed) — by the reload and the poll exactly as by the first read,
-  since all three walk the same function.
+  since all three walk the same function. The top of the tree is held to the
+  same rule: the `--bases` scan takes an entry only when the entry itself is a
+  directory (`Store::bases_in_dir` reads `DirEntry::file_type`, which does not
+  resolve a link), so a symbolic link sitting in `--bases` is skipped whatever
+  it points at and named on stderr. Each root it does take, and each
+  `--base NAME=PATH`, then goes through `Store::base_root` — the containment
+  `POST /api/bases` applies — so a base outside `--bases` is refused however it
+  arrives: a `--base` outside it stops startup, an entry of the scan that
+  resolves out of it is skipped and named on stderr (issue #73).
 - **Adding a base at runtime** (`POST /api/bases` with `{"name", "path"}`) is
   an operator-only surface behind `--api-token`, and nothing else gates it.
   The name must pass `valid_id`. The path is canonicalized, must be a
@@ -172,7 +188,8 @@ roles or per-tenant credentials on the API side.
   (default 24) is how many turns of one conversation reach the model — older
   turns are folded into a stored summary, and are cut from the request even
   when that summary could not be written. `/api/stats` reports what the chats
-  directory holds across every tenant.
+  directory holds across every tenant it has loaded (`Store::tenants` is this
+  daemon's memory, not a census of `--data-dir`).
 - **The screenshot tool** runs `--chrome-jobs` browsers at once (default 1).
   A call that waits 10 s without a slot is answered "busy" rather than queued,
   and one whose browser overruns its 20 s deadline is killed and reaped before

--- a/docs/multi-node.md
+++ b/docs/multi-node.md
@@ -32,7 +32,8 @@ So with two daemons, A and B, sharing `--data-dir`:
 | `GET /api/t/acme/files` on B | B's view: the files it knows about, at B's version. |
 | A tenant created on A, then a request for it on B | B has no such tenant in memory, so it restores one from `<data-dir>/acme` and serves it (`Store::tenant`). |
 | A writes again after B has restored | B does not see it. The restore happens once, on the miss. |
-| `DELETE /api/tenants/acme` on A | The directory goes; B keeps serving the tenant it already holds in memory. |
+| `DELETE /api/tenants/acme` on A | The directory goes, whether or not A had the tenant loaded — a node deletes what the data directory holds, not only what its map does. B keeps serving the tenant it already holds in memory; a B that had not loaded it has nothing left to restore. |
+| Creating `acme` on B while A's `acme` is on disk | Refused. The directory is what says the tenant exists, so B says so too, even when it cannot build a tenant from it because A's base is not loaded here. |
 | `POST /api/bases/theme/reload` on A | Only A re-reads the base. B keeps the copy it loaded. |
 | `/api/stats`, `/metrics` on B | B's own tenants, cache and subscribers. Neither number is a cluster total. |
 
@@ -98,6 +99,11 @@ theme. A tenant's base is in `<data-dir>/<id>/tenant.json`, and a node skips
 any tenant whose base it has not loaded — at startup with a message, and on a
 lookup miss silently — so the tenants of another node's bases are simply not
 served, which is what you want here.
+
+Tenant ids are still shared, because `<data-dir>/<id>` is one directory
+whichever node created it: creating an id that another node's base already uses
+is refused rather than written over, and deleting one removes the directory
+from under whichever node holds it.
 
 This is how to scale a catalogue of themes past what one process should hold in
 memory: two daemons, disjoint base sets, one data directory, and the routing

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -358,6 +358,14 @@ mod tests {
         (status, String::from_utf8_lossy(&body).into_owned())
     }
 
+    async fn delete(app: &axum::Router, uri: &str) -> (StatusCode, String) {
+        let req = Request::builder().method("DELETE").uri(uri);
+        let res = app.clone().oneshot(req.body(Body::empty()).unwrap()).await.unwrap();
+        let status = res.status();
+        let body = axum::body::to_bytes(res.into_body(), usize::MAX).await.unwrap();
+        (status, String::from_utf8_lossy(&body).into_owned())
+    }
+
     #[tokio::test]
     async fn bases_are_added_and_reloaded_over_the_api() {
         let root = std::env::temp_dir().join(format!("sandbox-lite-api-bases-{}", std::process::id()));
@@ -386,6 +394,62 @@ mod tests {
         assert_eq!(t.read_text("src/pages/index.astro").unwrap().as_deref(), Some("<h1>two</h1>\n"));
         assert!(t.version() > version);
         assert_eq!(post(&app, "/api/bases/nope/reload", "").await.0, StatusCode::NOT_FOUND);
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    /// Issue #73: the two ways a `--bases` sub-directory becomes a base, on one path that is a
+    /// symbolic link out of the directory. Neither takes it.
+    #[tokio::test]
+    async fn a_symlink_in_the_bases_directory_is_refused_at_startup_and_over_the_api() {
+        let root = std::env::temp_dir().join(format!("sandbox-lite-api-symlink-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("bases/theme")).unwrap();
+        std::fs::create_dir_all(root.join("outside")).unwrap();
+        std::fs::write(root.join("outside/secret.txt"), "SECRET\n").unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(root.join("outside"), root.join("bases/sneaky")).unwrap();
+        let store = Store::new(None, 1 << 20).with_bases_dir(Some(root.join("bases")));
+
+        // startup: what main.rs loads from --bases
+        let scanned: Vec<String> = store.bases_in_dir().unwrap().into_iter().map(|(name, _)| name).collect();
+        assert_eq!(scanned, vec!["theme".to_string()], "the link is not a base at startup");
+
+        // and the same path over POST /api/bases
+        let app = app(state_for(store, None, None));
+        let body = format!(r#"{{"name":"sneaky","path":{}}}"#, serde_json::to_string(&root.join("bases/sneaky")).unwrap());
+        let (status, body) = post(&app, "/api/bases", &body).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+        assert_eq!(get(&app, "/api/bases", None).await.1, "[]", "no base was loaded either way");
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    /// Issue #74: this node never loaded the tenant — the other one created it — so the delete used
+    /// to answer 404 and leave every byte where it was.
+    #[tokio::test]
+    async fn deleting_a_tenant_this_node_never_loaded_removes_its_files() {
+        let root = std::env::temp_dir().join(format!("sandbox-lite-api-delete-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let page = root.join("theme/src/pages/index.astro");
+        std::fs::create_dir_all(page.parent().unwrap()).unwrap();
+        std::fs::write(&page, "<h1>one</h1>\n").unwrap();
+        let data = root.join("data");
+        let base = || crate::store::Base::load("theme", &root.join("theme")).unwrap();
+        let other = Store::new(Some(data.clone()), 1 << 20);
+        other.add_base(base());
+        other.create_tenant("acme", "theme").unwrap().write("secret.txt", b"SECRET".to_vec(), crate::store::UpdateKind::Module).unwrap();
+
+        let store = Store::new(Some(data.clone()), 1 << 20);
+        store.add_base(base());
+        let app = app(state_for(store, None, None));
+        assert_eq!(get(&app, "/api/tenants", None).await.1, "[]", "this node holds no tenant in memory");
+
+        assert_eq!(delete(&app, "/api/tenants/acme").await.0, StatusCode::NO_CONTENT);
+        assert!(!data.join("acme").exists(), "the tenant's directory is gone");
+        assert_eq!(get(&app, "/api/t/acme/files", None).await.0, StatusCode::NOT_FOUND, "and nothing restores it");
+        let fresh = Store::new(Some(data.clone()), 1 << 20);
+        fresh.add_base(base());
+        assert_eq!(fresh.restore().unwrap(), 0, "a fresh daemon over the same data dir does not bring it back");
+        assert_eq!(delete(&app, "/api/tenants/acme").await.0, StatusCode::NOT_FOUND, "a tenant nothing holds is still a 404");
         std::fs::remove_dir_all(&root).unwrap();
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,16 +140,21 @@ async fn main() {
     let args = parse_args();
     let store =
         store::Store::new(args.data_dir.clone(), args.tenant_quota_mb.saturating_mul(1 << 20)).with_bases_dir(args.bases_dir.clone());
-    let mut bases = args.bases.clone();
-    if let Some(dir) = &args.bases_dir {
-        match std::fs::read_dir(dir) {
-            Ok(entries) => {
-                for e in entries.flatten() {
-                    if e.path().is_dir() {
-                        bases.push((e.file_name().to_string_lossy().into_owned(), e.path()));
-                    }
-                }
+    // `--base NAME=PATH` and the `--bases` scan are contained by the one rule `POST /api/bases`
+    // applies, so a path outside `--bases` cannot become a base whichever way it arrives.
+    let mut bases = Vec::new();
+    for (name, path) in &args.bases {
+        match store.base_root(path) {
+            Ok(root) => bases.push((name.clone(), root)),
+            Err(e) => {
+                eprintln!("cannot add base {name}: {e}");
+                std::process::exit(1);
             }
+        }
+    }
+    if let Some(dir) = &args.bases_dir {
+        match store.bases_in_dir() {
+            Ok(found) => bases.extend(found),
             Err(e) => {
                 eprintln!("cannot read bases dir {}: {e}", dir.display());
                 std::process::exit(1);

--- a/src/store.rs
+++ b/src/store.rs
@@ -499,10 +499,10 @@ impl Store {
         base
     }
 
-    /// Where `POST /api/bases` may read a project from. With `--bases` set the path must resolve
-    /// inside it — canonicalized first, so a symbolic link out of the directory is refused too.
-    /// Without the flag any readable directory on the host is allowed, which is why the route is
-    /// operator-only (see SECURITY.md).
+    /// Where a base project may be read from — `POST /api/bases` and the startup scan alike. With
+    /// `--bases` set the path must resolve inside it — canonicalized first, so a symbolic link out
+    /// of the directory is refused too. Without the flag any readable directory on the host is
+    /// allowed, which is why the route is operator-only (see SECURITY.md).
     pub fn base_root(&self, path: &Path) -> Result<PathBuf, String> {
         let root = path.canonicalize().map_err(|e| format!("{}: {e}", path.display()))?;
         if !root.is_dir() {
@@ -515,6 +515,34 @@ impl Store {
             }
         }
         Ok(root)
+    }
+
+    /// The base projects `--bases` holds: one per sub-directory, named after it, in name order.
+    /// Every root goes through `base_root`, so the startup scan and `POST /api/bases` refuse the
+    /// same paths. `Ok(Vec::new())` without the flag.
+    pub fn bases_in_dir(&self) -> io::Result<Vec<(String, PathBuf)>> {
+        let Some(dir) = &self.bases_dir else { return Ok(Vec::new()) };
+        let mut found = Vec::new();
+        for entry in std::fs::read_dir(dir)? {
+            let entry = entry?;
+            let name = entry.file_name().to_string_lossy().into_owned();
+            // the entry's own type, not the resolved one: `Path::is_dir` follows the link and takes
+            // whatever it points at as a base
+            let file_type = entry.file_type()?;
+            if file_type.is_symlink() {
+                eprintln!("bases dir: skipping '{name}': a symbolic link is not followed (SECURITY.md)");
+                continue;
+            }
+            if !file_type.is_dir() {
+                continue;
+            }
+            match self.base_root(&entry.path()) {
+                Ok(root) => found.push((name, root)),
+                Err(e) => eprintln!("bases dir: skipping '{name}': {e}"),
+            }
+        }
+        found.sort();
+        Ok(found)
     }
 
     /// Re-reads a base from its own root and points every tenant on it at the result. Each of those
@@ -566,9 +594,10 @@ impl Store {
             return Err("tenant id must be lowercase letters, digits and dashes".into());
         }
         let base = self.base(base_name).ok_or_else(|| format!("unknown base '{base_name}'"))?;
-        // `tenant` rather than the map: a tenant another node created under the same --data-dir
-        // exists, and creating over its directory would hide the files already in it
-        if self.tenant(id).is_some() {
+        // the data directory as well as the map: a tenant another node created exists, and creating
+        // over its directory would hide the files already in it. `tenant` alone would miss one whose
+        // base this node has not loaded, which is exactly when the map is empty of it.
+        if self.tenant(id).is_some() || self.tenant_dir(id).is_some() {
             return Err(format!("tenant '{id}' already exists"));
         }
         let dir = self.data_dir.as_ref().map(|d| d.join(id));
@@ -594,6 +623,17 @@ impl Store {
         Some(self.tenants.write().unwrap().entry(id.to_string()).or_insert(restored).clone())
     }
 
+    /// `<data-dir>/<id>` when that directory is there: the bytes a tenant is, whether or not this
+    /// node has it in memory and whether or not it could build one from them. `None` with
+    /// `--no-persist`, and for an id that is not a valid directory name.
+    fn tenant_dir(&self, id: &str) -> Option<PathBuf> {
+        if !valid_id(id) {
+            return None;
+        }
+        let dir = self.data_dir.as_ref()?.join(id);
+        dir.is_dir().then_some(dir)
+    }
+
     /// Builds a tenant from `<data-dir>/<id>` without registering it. Every reason it cannot —
     /// no `--data-dir`, no such directory, a base this node has not loaded — is an `Err`.
     fn read_tenant(&self, id: &str) -> Result<Tenant, String> {
@@ -613,23 +653,33 @@ impl Store {
         Ok(tenant)
     }
 
+    /// The tenants this node holds in memory. Not every tenant under `--data-dir`: one no request
+    /// has asked for since startup is not here (`Store::tenant`), so on a second node this is a
+    /// report of what is loaded rather than a census. Anything that acts on a tenant resolves it
+    /// through `tenant` or `tenant_dir` instead.
     pub fn tenants(&self) -> Vec<Arc<Tenant>> {
         let mut v: Vec<_> = self.tenants.read().unwrap().values().cloned().collect();
         v.sort_by(|a, b| a.id.cmp(&b.id));
         v
     }
 
-    /// `Ok(false)` is a tenant that was not there. A data directory that survives the delete is an
+    /// Drops the tenant from memory and removes `<data-dir>/<id>`, resolving it the way
+    /// `Store::tenant` does: a tenant that is on disk and not loaded is deleted, not answered
+    /// `404`, or the next request would restore it and serve it again. `Ok(false)` is a tenant
+    /// neither memory nor the data directory holds. A data directory that survives the delete is an
     /// error: it answered 204 and the tenant comes back at the next restore.
     pub fn remove_tenant(&self, id: &str) -> io::Result<bool> {
-        let Some(t) = self.tenants.write().unwrap().remove(id) else { return Ok(false) };
-        if let Some(dir) = &t.dir
-            && let Err(e) = std::fs::remove_dir_all(dir)
-            && e.kind() != io::ErrorKind::NotFound
-        {
-            return Err(e);
+        let dropped = self.tenants.write().unwrap().remove(id);
+        let dir = dropped.as_ref().and_then(|t| t.dir.clone()).or_else(|| self.tenant_dir(id));
+        let mut held = dropped.is_some();
+        if let Some(dir) = dir {
+            match std::fs::remove_dir_all(&dir) {
+                Ok(()) => held = true,
+                Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e),
+            }
         }
-        Ok(true)
+        Ok(held)
     }
 
     pub fn restore(&self) -> io::Result<usize> {
@@ -776,6 +826,81 @@ mod tests {
             assert!(store.base_root(&root.join("bases/link")).is_err(), "a symlink out of --bases is resolved and refused");
         }
         assert!(Store::new(None, 0).base_root(&root.join("elsewhere")).is_ok(), "without --bases any directory is allowed");
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    /// Issue #73: `Path::is_dir` resolved a link in `--bases`, so a directory the API refused a
+    /// second later was already a base — and every file under it was served through `/__sl/raw/`.
+    #[test]
+    fn the_startup_scan_takes_only_what_the_api_would_take() {
+        let root = temp("bases-scan");
+        std::fs::create_dir_all(root.join("bases/theme")).unwrap();
+        std::fs::create_dir_all(root.join("outside")).unwrap();
+        seed(root.join("outside/secret.txt"), "SECRET\n");
+        seed(root.join("bases/README.md"), "not a base\n");
+        let store = Store::new(None, 0).with_bases_dir(Some(root.join("bases")));
+        let theme = || vec![("theme".to_string(), root.join("bases/theme").canonicalize().unwrap())];
+
+        assert_eq!(store.bases_in_dir().unwrap(), theme(), "a file in the bases dir is not a base");
+        #[cfg(unix)]
+        {
+            std::os::unix::fs::symlink(root.join("outside"), root.join("bases/sneaky")).unwrap();
+            std::os::unix::fs::symlink(root.join("bases/theme"), root.join("bases/alias")).unwrap();
+            assert_eq!(store.bases_in_dir().unwrap(), theme(), "a symbolic link in --bases is skipped, wherever it points");
+            assert!(store.base_root(&root.join("bases/sneaky")).is_err(), "which is what the API answers for the same path");
+        }
+        assert!(Store::new(None, 0).bases_in_dir().unwrap().is_empty(), "no --bases, nothing to scan");
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    /// Issue #74: the delete acted on the map, and `Store::tenant` restores from the data
+    /// directory on a miss — so a tenant nothing had asked for yet answered 404, kept its files,
+    /// and was served again by the next request.
+    #[test]
+    fn deleting_a_tenant_that_is_not_loaded_removes_its_files() {
+        let root = temp("delete-unloaded");
+        seed(root.join("theme").join(PAGE), "<h1>base</h1>\n");
+        let data = root.join("data");
+        let base = || Base::load("theme", &root.join("theme")).unwrap();
+        let store = Store::new(Some(data.clone()), 1 << 20);
+        store.add_base(base());
+        let t = store.create_tenant("acme", "theme").unwrap();
+        t.write(PAGE, b"<h1>mine</h1>".to_vec(), UpdateKind::Module).unwrap();
+        // what another node's daemon holds: the tenant is on disk and in nobody's map
+        store.tenants.write().unwrap().remove("acme");
+        assert!(store.tenant("acme").is_some(), "the restore-on-miss path serves it");
+        store.tenants.write().unwrap().remove("acme");
+
+        assert!(store.remove_tenant("acme").unwrap(), "a tenant the daemon can serve is deleted, not answered 404");
+        assert!(!data.join("acme").exists(), "the tenant's bytes are gone");
+        assert!(store.tenant("acme").is_none(), "and nothing brings it back");
+        let fresh = Store::new(Some(data.clone()), 1 << 20);
+        fresh.add_base(base());
+        assert_eq!(fresh.restore().unwrap(), 0, "a fresh store over the same data dir restores nothing");
+        assert!(fresh.tenant("acme").is_none());
+
+        assert!(!store.remove_tenant("acme").unwrap(), "neither memory nor disk holds it now");
+        assert!(!store.remove_tenant("../escape").unwrap(), "an id that is not a directory name never reaches the data dir");
+        assert!(store.create_tenant("acme", "theme").is_ok(), "and the id is free again");
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    /// The other half of the same question: a directory under `--data-dir` is a tenant even when
+    /// this node cannot build one from it, and creating over it would adopt the files in it.
+    #[test]
+    fn a_tenant_directory_is_taken_as_existing_even_when_its_base_is_not_loaded() {
+        let root = temp("create-over");
+        seed(root.join("theme").join(PAGE), "<h1>base</h1>\n");
+        let data = root.join("data");
+        let a = Store::new(Some(data.clone()), 1 << 20);
+        a.add_base(Base::load("theme", &root.join("theme")).unwrap());
+        a.create_tenant("acme", "theme").unwrap().write("secret.txt", b"SECRET".to_vec(), UpdateKind::Module).unwrap();
+
+        let b = Store::new(Some(data.clone()), 1 << 20);
+        b.add_base(Base::load("other", &root.join("theme")).unwrap());
+        assert!(b.tenant("acme").is_none(), "b cannot restore it: the base it names is not loaded here");
+        assert!(b.create_tenant("acme", "other").is_err(), "so the directory is what says the tenant exists");
+        assert_eq!(std::fs::read_to_string(data.join("acme/files/secret.txt")).unwrap(), "SECRET", "and its files are untouched");
         std::fs::remove_dir_all(&root).unwrap();
     }
 


### PR DESCRIPTION
Closes #73

Closes #74

Both are the same mistake in two places: the store trusted its own memory where
the filesystem was the truth.

## #73 — a symlink in `--bases` became a base

`src/main.rs` scanned `--bases` with `Path::is_dir()`, which resolves a
symbolic link, so a link sitting in the bases directory loaded as a base and
every file under its target was served through `/__sl/raw/` to whoever could
open a preview on a tenant created from it. `POST /api/bases` refused the same
path a second later, because `Store::base_root` canonicalizes before it
compares — two paths, two answers.

There is one function now. `Store::bases_in_dir` reads `DirEntry::file_type`,
so the entry's own type decides and a symbolic link is skipped whatever it
points at (named on stderr, so an operator is not left wondering), and every
root it takes goes through `base_root` — as does each `--base NAME=PATH`. With
`--bases` set, a base outside it is refused however it arrives: a `--base`
outside stops startup, an entry of the scan that resolves out is skipped.

A link to a directory *inside* `--bases` is skipped too. That is a small loss
of an aliasing trick nobody has asked for, and it is what makes the rule one
sentence: no symbolic link in `--bases` becomes a base.

## #74 — a delete that did not delete

`remove_tenant` acted on the in-memory map, but since #59 `Store::tenant`
restores from `<data-dir>/<id>` on a miss. So a tenant this node had not
loaded — another node created it, or its base is not loaded here — answered
`404` to a delete, kept its whole tree, and was served again by the next
`GET /api/t/{id}/files` or preview request. For a product whose tenants hold
customer content, "deleted" has to mean the bytes are gone.

`remove_tenant` now resolves the tenant the way `Store::tenant` does — memory,
then the data directory — drops the map entry, removes the directory, and
answers `404` only when neither holds it. The id goes through `valid_id` before
it is joined to `--data-dir`, so a path that is not a directory name never
reaches `remove_dir_all`.

## The question #74 ends with: what else acts on the map?

`Store`, method by method:

| | Source it trusts | |
|---|---|---|
| `add_base`, `base`, `bases` | map | Right. A base is a snapshot the operator asked for; nothing on disk records that one is loaded, and `/api/bases` says what this daemon holds. |
| `base_root`, `bases_in_dir` | disk | Fixed above — one containment rule, both entry points. |
| `reload_base` | disk for the base, map for the tenants to re-point | Right. An unloaded tenant needs no re-pointing: `read_tenant` calls `self.base(name)` and so builds it on the fresh copy whenever it is restored. |
| `reload_changed_bases` | map (bases) + disk (stamps) | Right for what it is — a poll of the roots already loaded. |
| **`create_tenant`** | **was: `Store::tenant`** | **Wrong, fixed.** The duplicate check went through `tenant`, which returns `None` for a tenant whose base is not loaded on this node — exactly the tenant that is on disk and not in the map. So a create could write its `tenant.json` over another node's directory and adopt every file already in it. It now consults `tenant_dir` as well: the directory is what says the tenant exists. |
| `tenant` | memory, then disk | The model everything else resolves through. |
| `read_tenant`, `restore` | disk | Right. |
| `tenants()` | map | Deliberate, and now documented in the code: it is a list of what this daemon has loaded, not a census of `--data-dir`. Its four callers — `/api/tenants`, `/api/stats`, `/metrics`, and the chat-usage sum — all report, none act on a tenant, and walking the data directory on every metrics scrape would be a directory read per request. On a single node `restore()` loads everything at startup, so the two agree; on a second node the listing is that node's own, which `docs/multi-node.md` already says of every number it reports. SECURITY.md's claim that `/api/stats` counts the chats directory "across every tenant" was true only under that assumption and now says so. |
| **`remove_tenant`** | **was: map** | **Wrong, fixed** — #74. |

`Tenant`, method by method: nothing of this shape. The overlay is memory
written through to disk under the tenant's write lock — `write`, `write_many`
and `delete` each change both, `delete` removing the file and rewriting
`deleted.json` rather than only tombstoning in memory — and `data`, `list`,
`overlay_stats` and the rest read that same overlay. The one thing a `Tenant`
does not do is re-read its own directory after it is built, which is the
documented multi-node limit (`docs/multi-node.md`), not a delete that fails to
delete.

## Tests

- `store::the_startup_scan_takes_only_what_the_api_would_take` — a `--bases`
  directory holding a link to an outside directory, a link to a sibling base,
  a plain file and one real base: only the real base is scanned, and
  `base_root` refuses the same link the scan skipped.
- `http::a_symlink_in_the_bases_directory_is_refused_at_startup_and_over_the_api`
  — the same link through both doors: the scan `main.rs` runs, then
  `POST /api/bases` with that path (`400`), and `/api/bases` still empty.
- `store::deleting_a_tenant_that_is_not_loaded_removes_its_files` — create,
  drop from the map, confirm the restore-on-miss path serves it, delete: the
  directory is gone, `tenant` does not restore it, a fresh `Store` over the
  same data dir restores nothing, a second delete is `false`, and an id that is
  not a directory name never reaches the data dir.
- `http::deleting_a_tenant_this_node_never_loaded_removes_its_files` — end to
  end over two stores on one data dir, which is how a tenant comes to be on
  disk and not in the map: `DELETE` answers `204`, the directory is gone,
  `/api/t/acme/files` is `404`, and a fresh store restores nothing.
- `store::a_tenant_directory_is_taken_as_existing_even_when_its_base_is_not_loaded`
  — the `create_tenant` half: node B refuses the id and node A's files are
  untouched.

`bases_are_added_and_reloaded_over_the_api` still passes, and CI's smoke test
starts the daemon with `--bases examples`, so the new scan is what loads the
five example bases.

CI: run [34061598978](https://github.com/productdevbook/sandbox-lite/actions/runs/34061598978) — green on `fix/store-truth` — fmt, clippy `-D warnings`, tests,
release build, `sandbox-lite check`, the smoke test, `bench/mem.sh` and
Playwright.

## Noticed, did not fix

- `Store::restore` finds tenants with `entry.path().join("tenant.json").is_file()`,
  which follows a symbolic link: a link in `--data-dir` pointing at a directory
  with a `tenant.json` is restored as a tenant, and `remove_dir_all` on that
  link then fails with `ENOTDIR` — a `500`, not a lost delete. `--data-dir` is
  the daemon's own directory rather than a tree an operator shares with a
  deploy job, which is what made #73 worth a fix; the same containment there
  would be cheap if wanted.
- A base name can be claimed twice — `--base theme=X` alongside a `theme`
  sub-directory of `--bases` — and the second load silently wins. The scan now
  runs after the flags and is sorted, so which one wins is at least
  deterministic, but nothing warns.
- `--watch-bases` polls only the roots already loaded. A sub-directory that
  appears in `--bases` after startup never becomes a base;
  `POST /api/bases` is the only way to add one to a running daemon.
- `--tenant-quota-mb` is enforced against the overlay this node holds, so two
  daemons over one `--data-dir` each let the same tenant reach the quota.
  Pre-existing, and not in `docs/multi-node.md`'s list of what a second node
  does not see.
- `create_tenant` now refuses an id whose `<data-dir>/<id>` exists even when it
  holds no `tenant.json` — the directory a crash between `create_dir_all` and
  the `tenant.json` write would leave. That is the deliberate reading ("the
  directory is the tenant"), and `DELETE` clears such a directory now, so the
  id is recoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
