### PR TITLE
import: refuse a bomb before it lands, and never half-apply an archive

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -71,6 +71,14 @@ resulting overlay under one lock — the removals, the tombstones and every file
 Its event carries an empty path, which the editor reads as "the whole tree
 changed" and the preview treats like any other update.
 
+All three writers (`write`, `write_many`, `delete`) do their disk work through
+`Staged`, which records every step before it happens and moves a file it
+replaces or removes aside instead of deleting it. The overlay is swapped only
+once every step has succeeded, so a failure anywhere puts the directory back
+and memory and disk cannot end up describing different tenants. The one case
+that cannot be undone — the undo itself failing — is `WriteError::Torn`, which
+names the paths that are neither way instead of reporting a clean refusal.
+
 With a `--data-dir`, the overlay is persisted as
 `<data-dir>/<id>/tenant.json` (`{"base": name}`), `<data-dir>/<id>/files/<path>`
 and `<data-dir>/<id>/deleted.json` (the tombstones). Every write goes to disk;
@@ -109,9 +117,13 @@ its open handle rather than read into memory.
 `POST /api/tenants/{id}/import` reads one back. Entries that are not regular
 files are skipped (directories, pax headers) or refused (links, devices); an
 entry name must be tenant-relative — a leading `/`, a `..` segment, a backslash
-or a NUL byte is refused, while `./` and `//` are normalised away; the sizes are
-summed from the tar headers and the import is refused with `413` before any
-body is decompressed once they pass the quota. `.sandbox-lite/deleted.json` is
+or a NUL byte is refused, while `./` and `//` are normalised away; every entry's
+declared size counts against the quota, skipped ones included, and the import is
+refused with `413` before that body is decompressed once the running total
+passes it. A counting reader around the decompressor caps the whole stream as
+well — the quota plus 16 MiB of framing, and never more than a thousand times
+the compressed body — which is what bounds what `tar` reads and never shows as
+an entry (a GNU long name, a pax payload). `.sandbox-lite/deleted.json` is
 applied as tombstones instead of being written, so an overlay export imported
 into a tenant on the same base reproduces the source overlay exactly.
 `?replace=1` also drops the edits the archive does not carry — an edit over a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -182,12 +182,23 @@ container, or a network namespace of its own.
   refused with `400` naming the entry — an absolute path is refused, not
   stripped the way `clean_path` strips one from a request path — while `./` and
   `//` segments are normalised away. So an import writes only under
-  `<data-dir>/<id>/files`. Entry sizes are summed from the tar headers as
-  the archive is read and the whole import is refused with `413` once the total
-  passes the quota, so an archive that decompresses past it is rejected without
-  being decompressed. What survives is then applied under the tenant's write
-  lock as one batch, quota-checked against the resulting overlay: a refusal
-  writes nothing, and the response says so.
+  `<data-dir>/<id>/files`. Every entry costs its declared size against the
+  quota whether or not it is taken — `tar` reads those bytes to reach the next
+  header either way — and the import is refused with `413` as soon as the
+  running total passes the quota, before that entry's body is read. The
+  decompressor is capped on top of that, at the quota plus 16 MiB of tar
+  framing and never more than a thousand times the compressed body, which is
+  what bounds the bytes `tar` reads without ever surfacing them as an entry: a
+  GNU long name, a pax payload, padding. So an archive that decompresses past
+  the quota is rejected without being decompressed. What survives is then
+  applied under the tenant's write lock as one batch, quota-checked against the
+  resulting overlay. The batch is all or nothing: the disk work is staged with
+  an undo — a file it replaces or removes is moved aside, not deleted — and the
+  overlay is swapped only once every file has landed, so a refusal or an I/O
+  failure leaves the tenant exactly as it was, on disk as well as in memory,
+  and the response says so. If the undo itself fails the response says that
+  instead, naming the paths that are neither way, rather than claiming a clean
+  refusal.
 - **Hidden files** are exported and imported like any other file: an export
   carries `.env`, `sandbox-lite.json` and every dotfile of the tenant, and an
   import may write them. What the preview refuses to serve is unchanged

--- a/src/http/archive.rs
+++ b/src/http/archive.rs
@@ -3,6 +3,8 @@
 
 use std::collections::BTreeMap;
 use std::io::{self, Read, Write};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use axum::Json;
 use axum::body::Bytes;
@@ -111,28 +113,81 @@ fn reject(name: &str, why: &str) -> (StatusCode, String) {
     (StatusCode::BAD_REQUEST, format!("{name}: {why}"))
 }
 
+/// Framing an archive may spend above the tenant's quota: a 512-byte header and up to 511 bytes of
+/// padding per file, so about sixteen thousand files. An import that needs more than this is refused
+/// rather than read, and the message says so.
+const FRAMING_SLACK: u64 = 16 << 20;
+/// However well it compresses, an archive may not hand `tar` more than this many times its own size:
+/// gzip itself tops out near 1030:1, so this is a ceiling on the amplification, not on the content.
+const MAX_EXPANSION: u64 = 1000;
+/// The floor under that ratio — an archive this small is not worth bounding more tightly.
+const MIN_EXPANSION: u64 = 1 << 20;
+
+/// What `tar` may read out of the decompressor, whatever the entries declare.
+fn stream_cap(compressed: u64, quota: u64) -> u64 {
+    compressed.saturating_mul(MAX_EXPANSION).max(MIN_EXPANSION).min(quota.saturating_add(FRAMING_SLACK))
+}
+
+/// Cuts the decompressor off at `limit` bytes and remembers that it did, so a bomb is told apart
+/// from a truncated archive.
+struct Capped<R> {
+    inner: R,
+    read: u64,
+    limit: u64,
+    tripped: Arc<AtomicBool>,
+}
+
+impl<R: Read> Read for Capped<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let n = self.inner.read(buf)?;
+        self.read += n as u64;
+        if self.read > self.limit {
+            self.tripped.store(true, Ordering::Relaxed);
+            return Err(io::Error::other("the archive expands past what the tenant may hold"));
+        }
+        Ok(n)
+    }
+}
+
 /// Reads the archive into memory, refusing anything that is not a plain file inside the tenant
-/// tree. `quota` bounds the total: entry sizes are summed from the headers before any body is
-/// read, so an archive that decompresses past the quota is refused without being decompressed.
+/// tree. `quota` bounds the total two ways: every entry costs its declared size whether or not it is
+/// taken — `tar` reads those bytes to reach the next header either way — and the decompressor itself
+/// is cut off at `stream_cap`, which also bounds what `tar` reads without ever showing it as an
+/// entry (a GNU long name, a pax payload, padding). So an archive that decompresses past the quota
+/// is refused without being decompressed.
 fn unpack(body: &[u8], quota: u64) -> Result<Unpacked, (StatusCode, String)> {
-    let mut archive = Archive::new(GzDecoder::new(body));
-    let unreadable = |e: io::Error| (StatusCode::BAD_REQUEST, format!("cannot read the archive: {e}"));
+    let cap = stream_cap(body.len() as u64, quota);
+    let tripped = Arc::new(AtomicBool::new(false));
+    let mut archive = Archive::new(Capped { inner: GzDecoder::new(body), read: 0, limit: cap, tripped: tripped.clone() });
+    let unreadable = |e: io::Error| {
+        if tripped.load(Ordering::Relaxed) {
+            let over = format!(
+                "the archive expands past {cap} bytes, the most an import may read for a quota of {quota} bytes (--tenant-quota-mb)"
+            );
+            (StatusCode::PAYLOAD_TOO_LARGE, over)
+        } else {
+            (StatusCode::BAD_REQUEST, format!("cannot read the archive: {e}"))
+        }
+    };
     let mut files: BTreeMap<String, Vec<u8>> = BTreeMap::new();
     let mut deleted: Vec<String> = Vec::new();
     let mut total: u64 = 0;
     for entry in archive.entries().map_err(unreadable)? {
         let mut entry = entry.map_err(unreadable)?;
         let name = String::from_utf8_lossy(&entry.path_bytes()).into_owned();
+        // before the type match: a directory or pax entry declares a size too, and those bytes are
+        // read out of the decompressor to reach the next header even though nothing is kept
+        total = total.saturating_add(entry.size());
+        if total > quota {
+            let over =
+                format!("the archive declares at least {total} bytes of entries, the tenant quota is {quota} bytes (--tenant-quota-mb)");
+            return Err((StatusCode::PAYLOAD_TOO_LARGE, over));
+        }
         match entry.header().entry_type() {
             EntryType::Regular | EntryType::Continuous => {}
             EntryType::Directory | EntryType::XHeader | EntryType::XGlobalHeader => continue,
             EntryType::Symlink | EntryType::Link => return Err(reject(&name, "symbolic and hard links are not imported")),
             other => return Err(reject(&name, &format!("unsupported tar entry (type byte {})", other.as_byte()))),
-        }
-        total = total.saturating_add(entry.size());
-        if total > quota {
-            let over = format!("the archive holds at least {total} bytes of files, the tenant quota is {quota} bytes (--tenant-quota-mb)");
-            return Err((StatusCode::PAYLOAD_TOO_LARGE, over));
         }
         let mut bytes = Vec::with_capacity(entry.size() as usize);
         entry.read_to_end(&mut bytes).map_err(unreadable)?;
@@ -152,6 +207,7 @@ fn unpack(body: &[u8], quota: u64) -> Result<Unpacked, (StatusCode, String)> {
 }
 
 /// A refused import applies nothing, and says so where a caller looking for the counts will see it.
+/// Only an error `write_many` has undone may answer this way — a `Torn` one has not, and says so.
 fn refused(message: String) -> Json<Value> {
     Json(json!({ "error": message, "files": 0, "deleted": 0 }))
 }
@@ -173,7 +229,10 @@ pub async fn import(AxState(st): AxState<State>, Path(id): Path<String>, RawQuer
             Json(json!({ "files": written, "deleted": deleted, "version": version })).into_response()
         }
         Err(e @ WriteError::Quota { .. }) => (StatusCode::PAYLOAD_TOO_LARGE, refused(e.to_string())).into_response(),
-        Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
+        // the batch put itself back, so the tenant is what it was and the counts say it
+        Err(e @ WriteError::Io(_)) => (StatusCode::INTERNAL_SERVER_ERROR, refused(e.to_string())).into_response(),
+        // it could not, so there are no counts to give: the message names what is neither way
+        Err(e @ WriteError::Torn { .. }) => err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
     }
 }
 
@@ -387,6 +446,75 @@ mod tests {
         assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
         assert_eq!(f.state.store.tenant("a").unwrap().overlay_stats(), (1, 40));
         assert!(!f.root.join("data/a/files/src/huge.ts").exists());
+    }
+
+    #[tokio::test]
+    async fn a_bomb_is_refused_before_it_lands() {
+        let f = fixture("bomb", 64);
+        // a directory entry declares a size like any other, and tar reads those bytes to reach the
+        // next header even though the entry itself is skipped
+        let archive = tar_gz(&[("dir", EntryType::Directory, &vec![0u8; 8 << 20][..])]);
+        assert!(archive.len() < 64 << 10, "the bomb is small on the wire: {} bytes", archive.len());
+        let (status, body) = call(&f, "POST", "/api/tenants/a/import", archive).await;
+        assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE, "{}", String::from_utf8_lossy(&body));
+        let body: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body["files"], 0);
+        assert!(body["error"].as_str().unwrap().contains("quota"), "{body}");
+        assert_eq!(f.state.store.tenant("a").unwrap().overlay_stats(), (0, 0));
+
+        // tar reads a GNU long name itself and never shows it as an entry, so only the cap on the
+        // decompressor bounds it — and it reads the whole thing into memory
+        let archive = tar_gz(&[("longname", EntryType::GNULongName, &vec![b'a'; 24 << 20][..])]);
+        let (status, body) = call(&f, "POST", "/api/tenants/a/import", archive).await;
+        assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE, "{}", String::from_utf8_lossy(&body));
+        assert_eq!(f.state.store.tenant("a").unwrap().overlay_stats(), (0, 0));
+    }
+
+    #[test]
+    fn the_cap_on_the_decompressor_bounds_both_ways() {
+        // a small request cannot buy a large decompression...
+        assert_eq!(stream_cap(1 << 10, 64 << 20), MIN_EXPANSION);
+        assert_eq!(stream_cap(64 << 10, 64 << 20), (64 << 10) * MAX_EXPANSION);
+        // ...and no request buys more than the quota and the framing allowed above it
+        assert_eq!(stream_cap(64 << 20, 64 << 20), (64 << 20) + FRAMING_SLACK);
+        assert_eq!(stream_cap(u64::MAX, u64::MAX), u64::MAX);
+    }
+
+    #[tokio::test]
+    async fn a_failed_import_leaves_the_tenant_exactly_as_it_was() {
+        for (name, query) in [("atomic", ""), ("atomic-replace", "?replace=1")] {
+            let f = fixture(name, 1 << 20);
+            call(&f, "PUT", "/api/t/a/file/src/data.ts", b"export const n = 9;\n".to_vec()).await;
+            call(&f, "DELETE", "/api/t/a/file/readme.md", Vec::new()).await;
+            let before = (listing(&f, "a"), bytes_of(&f, "a"));
+            let tombstones = std::fs::read(f.root.join("data/a/deleted.json")).ok();
+
+            // "x" < "x/y", so the file lands first and the directory the second entry needs cannot
+            // be created over it: the batch fails on its last entry
+            let archive = tar_gz(&[("x", EntryType::Regular, b"i am a file"), ("x/y", EntryType::Regular, b"child")]);
+            let (status, body) = call(&f, "POST", &format!("/api/tenants/a/import{query}"), archive).await;
+            assert!(status.is_server_error(), "{query}: {status} {}", String::from_utf8_lossy(&body));
+            let report: Value = serde_json::from_slice(&body).unwrap();
+            assert_eq!(report["files"], 0, "{query}: {report}");
+            assert_eq!(report["deleted"], 0, "{query}: {report}");
+
+            assert_eq!((listing(&f, "a"), bytes_of(&f, "a")), before, "{query}");
+            assert!(!f.root.join("data/a/files/x").exists(), "{query}: the failed import left its file on disk");
+            assert!(f.root.join("data/a/files/src/data.ts").exists(), "{query}: the failed import took an edit away");
+            assert_eq!(std::fs::read(f.root.join("data/a/deleted.json")).ok(), tombstones, "{query}");
+            let left: Vec<String> =
+                std::fs::read_dir(f.root.join("data/a")).unwrap().map(|e| e.unwrap().file_name().to_string_lossy().into_owned()).collect();
+            assert!(!left.iter().any(|n| n.starts_with(".staged")), "{query}: staging left behind: {left:?}");
+
+            // and the daemon does not change its mind about what it holds when it is restarted
+            let store = Store::new(Some(f.root.join("data")), 1 << 20);
+            store.add_base(Base::load("b", &f.root.join("base")).unwrap());
+            store.restore().unwrap();
+            let t = store.tenant("a").unwrap();
+            let restored: Vec<(String, u64, bool)> = t.list().into_iter().map(|e| (e.path, e.size, e.modified)).collect();
+            assert_eq!(restored, before.0, "{query}: a restart reads a different tenant");
+            assert_eq!(t.read_text("x").unwrap(), None, "{query}: a restart reads the file the import was told not to write");
+        }
     }
 
     #[tokio::test]

--- a/src/store.rs
+++ b/src/store.rs
@@ -187,8 +187,17 @@ impl UpdateKind {
 
 #[derive(Debug)]
 pub enum WriteError {
-    Quota { quota: u64, after: u64 },
+    Quota {
+        quota: u64,
+        after: u64,
+    },
     Io(io::Error),
+    /// A write that failed and could not be put back. The named paths are neither what they were nor
+    /// what the write asked for, so the caller is told that rather than that nothing landed.
+    Torn {
+        cause: io::Error,
+        paths: Vec<String>,
+    },
 }
 
 impl fmt::Display for WriteError {
@@ -198,6 +207,12 @@ impl fmt::Display for WriteError {
                 write!(f, "tenant quota exceeded: edited files would total {after} bytes, the quota is {quota} bytes (--tenant-quota-mb)")
             }
             WriteError::Io(e) => fmt::Display::fmt(e, f),
+            WriteError::Torn { cause, paths } => write!(
+                f,
+                "{cause}; undoing the write failed too, so {} on disk are now neither what they were nor what the write asked for: {}",
+                paths.len(),
+                paths.join(", ")
+            ),
         }
     }
 }
@@ -320,12 +335,15 @@ impl Tenant {
         if after > self.quota {
             return Err(WriteError::Quota { quota: self.quota, after });
         }
-        let data = self.store_on_disk(path, bytes)?;
-        let was_tombstone = matches!(overlay.insert(path.to_string(), Some(data)), Some(None));
+        let was_tombstone = matches!(overlay.get(path), Some(None));
+        let mut staged = Staged::new(self.dir.as_deref());
+        let data = match stage_write(&mut staged, &overlay, path, bytes, was_tombstone) {
+            Ok(data) => data,
+            Err(cause) => return Err(staged.undo(cause)),
+        };
+        overlay.insert(path.to_string(), Some(data));
         drop(overlay);
-        if was_tombstone {
-            self.persist_tombstones()?;
-        }
+        staged.commit();
         Ok(self.bump("update", path, kind))
     }
 
@@ -334,6 +352,11 @@ impl Tenant {
     /// does not carry — dropping an edit over a base file brings the base copy back, which is what
     /// makes an overlay export reproduce the source overlay exactly. The quota is checked against
     /// the resulting overlay before anything is written, so a refusal leaves the tenant untouched.
+    ///
+    /// It is all or nothing: the disk work is staged with an undo — a replaced or removed file is
+    /// moved aside rather than deleted — and the overlay is swapped only once every step has
+    /// succeeded. A failure puts the directory back, so what the caller is told and what a restart
+    /// reads are the same tenant.
     pub fn write_many(&self, files: Vec<(String, Vec<u8>)>, deleted: &[String], replace: bool) -> Result<Applied, WriteError> {
         let mut overlay = self.overlay.write().unwrap();
         let incoming: BTreeSet<&str> = files.iter().map(|(p, _)| p.as_str()).collect();
@@ -357,59 +380,35 @@ impl Tenant {
         let touched: BTreeSet<&str> = overlay.keys().chain(deleted.iter()).map(String::as_str).collect();
         let dropped: Vec<&str> =
             touched.into_iter().filter(|p| !incoming.contains(p) && overlaid(&overlay, p) != overlaid(&next, p)).collect();
-        for path in &dropped {
-            self.forget_on_disk(path)?;
-        }
         let (written, removed) = (files.len(), dropped.len());
-        for (path, bytes) in files {
-            next.insert(path.clone(), Some(self.store_on_disk(&path, bytes)?));
+        let mut staged = Staged::new(self.dir.as_deref());
+        if let Err(cause) = stage_batch(&mut staged, &mut next, &dropped, files) {
+            return Err(staged.undo(cause));
         }
         *overlay = next;
         drop(overlay);
-        self.persist_tombstones()?;
+        staged.commit();
         Ok(Applied { version: self.bump("update", "", UpdateKind::Module), written, deleted: removed })
     }
 
-    /// Writes the file under `--data-dir` when there is one, and says how the overlay should hold it:
-    /// anything past the inline limit lives on disk only.
-    fn store_on_disk(&self, path: &str, bytes: Vec<u8>) -> io::Result<FileData> {
-        let Some(dir) = &self.dir else { return Ok(FileData::Mem(bytes.into())) };
-        let target = dir.join("files").join(path);
-        if let Some(parent) = target.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        std::fs::write(&target, &bytes)?;
-        if bytes.len() as u64 > INLINE_LIMIT { Ok(FileData::Disk(target, bytes.len() as u64)) } else { Ok(FileData::Mem(bytes.into())) }
-    }
-
-    fn forget_on_disk(&self, path: &str) -> io::Result<()> {
-        let Some(dir) = &self.dir else { return Ok(()) };
-        let target = dir.join("files").join(path);
-        if target.exists() {
-            std::fs::remove_file(target)?;
-        }
-        Ok(())
-    }
-
     pub fn delete(&self, path: &str) -> io::Result<u64> {
-        {
-            let mut overlay = self.overlay.write().unwrap();
-            if self.base.read().unwrap().get(path).is_some() {
-                overlay.insert(path.to_string(), None);
-            } else {
-                overlay.remove(path);
-            }
+        // held across the disk work, as a write is: the file leaves the directory and the tombstone
+        // list is rewritten before the overlay hears about it, and a failure puts both back
+        let mut overlay = self.overlay.write().unwrap();
+        let tombstone = self.base.read().unwrap().get(path).is_some();
+        let mut staged = Staged::new(self.dir.as_deref());
+        if let Err(cause) = stage_delete(&mut staged, &overlay, path, tombstone) {
+            staged.rollback();
+            return Err(cause);
         }
-        self.forget_on_disk(path)?;
-        self.persist_tombstones()?;
+        if tombstone {
+            overlay.insert(path.to_string(), None);
+        } else {
+            overlay.remove(path);
+        }
+        drop(overlay);
+        staged.commit();
         Ok(self.bump("delete", path, UpdateKind::Module))
-    }
-
-    fn persist_tombstones(&self) -> io::Result<()> {
-        let Some(dir) = &self.dir else { return Ok(()) };
-        let overlay = self.overlay.read().unwrap();
-        let list: Vec<&str> = overlay.iter().filter(|(_, d)| d.is_none()).map(|(p, _)| p.as_str()).collect();
-        std::fs::write(dir.join("deleted.json"), serde_json::to_vec(&list)?)
     }
 
     fn bump(&self, event: &str, path: &str, kind: UpdateKind) -> u64 {
@@ -472,6 +471,192 @@ impl Tenant {
 
 fn overlay_bytes(overlay: &BTreeMap<String, Option<FileData>>) -> u64 {
     overlay.values().flatten().map(|d| d.size()).sum()
+}
+
+/// The disk half of one write, and what it takes to put `<data-dir>/<id>` back. Nothing there is
+/// changed that is not recorded first, and a file that is replaced or removed is moved aside rather
+/// than deleted — a `FileData::Disk` entry is the only copy of its contents there is. So a failure
+/// anywhere can leave the directory exactly as it was, which is what lets the overlay be swapped
+/// only after every file has landed.
+struct Staged {
+    dir: Option<PathBuf>,
+    aside: Option<PathBuf>,
+    /// (the copy waiting in `aside`, where it came from)
+    moved: Vec<(PathBuf, PathBuf)>,
+    created: Vec<PathBuf>,
+    dirs: Vec<PathBuf>,
+    /// `Some` once `deleted.json` has been rewritten: what it held before, or `None` if there was no
+    /// such file.
+    tombstones: Option<Option<Vec<u8>>>,
+}
+
+impl Staged {
+    fn new(dir: Option<&Path>) -> Staged {
+        Staged { dir: dir.map(Path::to_path_buf), aside: None, moved: Vec::new(), created: Vec::new(), dirs: Vec::new(), tombstones: None }
+    }
+
+    /// `<data-dir>/<id>/.staged-<pid>-<n>`, a sibling of `files/` rather than a directory inside it,
+    /// so a copy left behind by a process that dies mid-write is not read back as a tenant file.
+    fn aside_dir(&mut self, dir: &Path) -> io::Result<PathBuf> {
+        if let Some(p) = &self.aside {
+            return Ok(p.clone());
+        }
+        static N: AtomicU64 = AtomicU64::new(0);
+        let p = dir.join(format!(".staged-{}-{}", std::process::id(), N.fetch_add(1, Ordering::Relaxed)));
+        std::fs::create_dir_all(&p)?;
+        self.aside = Some(p.clone());
+        Ok(p)
+    }
+
+    fn move_aside(&mut self, dir: &Path, target: &Path) -> io::Result<()> {
+        if !target.exists() {
+            return Ok(());
+        }
+        let kept = self.aside_dir(dir)?.join(self.moved.len().to_string());
+        std::fs::rename(target, &kept)?;
+        self.moved.push((kept, target.to_path_buf()));
+        Ok(())
+    }
+
+    /// Creates the directories `target` needs, recording the ones that did not exist so the undo can
+    /// take them away again.
+    fn create_dirs(&mut self, target: &Path) -> io::Result<()> {
+        let mut missing = Vec::new();
+        let mut parent = target.parent();
+        while let Some(d) = parent.filter(|d| !d.exists()) {
+            missing.push(d.to_path_buf());
+            parent = d.parent();
+        }
+        for d in missing.into_iter().rev() {
+            std::fs::create_dir(&d)?;
+            self.dirs.push(d);
+        }
+        Ok(())
+    }
+
+    /// Writes the file under `--data-dir` when there is one, and says how the overlay should hold it:
+    /// anything past the inline limit lives on disk only.
+    fn write(&mut self, path: &str, bytes: Vec<u8>) -> io::Result<FileData> {
+        let Some(dir) = self.dir.clone() else { return Ok(FileData::Mem(bytes.into())) };
+        let target = dir.join("files").join(path);
+        self.create_dirs(&target)?;
+        self.move_aside(&dir, &target)?;
+        // recorded before the write, because a write that fails partway still leaves a file
+        self.created.push(target.clone());
+        std::fs::write(&target, &bytes)?;
+        if bytes.len() as u64 > INLINE_LIMIT { Ok(FileData::Disk(target, bytes.len() as u64)) } else { Ok(FileData::Mem(bytes.into())) }
+    }
+
+    fn remove(&mut self, path: &str) -> io::Result<()> {
+        let Some(dir) = self.dir.clone() else { return Ok(()) };
+        let target = dir.join("files").join(path);
+        self.move_aside(&dir, &target)
+    }
+
+    fn tombstones(&mut self, list: &[&str]) -> io::Result<()> {
+        let Some(dir) = &self.dir else { return Ok(()) };
+        let file = dir.join("deleted.json");
+        self.tombstones = Some(std::fs::read(&file).ok());
+        std::fs::write(file, serde_json::to_vec(list)?)
+    }
+
+    fn commit(self) {
+        if let Some(aside) = &self.aside {
+            let _ = std::fs::remove_dir_all(aside);
+        }
+    }
+
+    /// Puts the directory back, newest step first. What it could not put back comes back as paths,
+    /// and those are the only ones the caller may not describe as untouched.
+    fn rollback(self) -> Vec<String> {
+        let mut torn = Vec::new();
+        for target in self.created.iter().rev() {
+            if let Err(e) = std::fs::remove_file(target)
+                && e.kind() != io::ErrorKind::NotFound
+            {
+                torn.push(target.display().to_string());
+            }
+        }
+        for (kept, target) in self.moved.iter().rev() {
+            if std::fs::rename(kept, target).is_err() {
+                torn.push(target.display().to_string());
+            }
+        }
+        if let (Some(dir), Some(before)) = (&self.dir, &self.tombstones) {
+            let file = dir.join("deleted.json");
+            let back = match before {
+                Some(raw) => std::fs::write(&file, raw),
+                None => std::fs::remove_file(&file),
+            };
+            if back.is_err() {
+                torn.push(file.display().to_string());
+            }
+        }
+        // only ever empty ones this write made: a directory something else put a file in stays
+        for d in self.dirs.iter().rev() {
+            let _ = std::fs::remove_dir(d);
+        }
+        if let Some(aside) = &self.aside {
+            let _ = std::fs::remove_dir_all(aside);
+        }
+        if !torn.is_empty() {
+            eprintln!("write: undoing a failed write left {} path(s) neither way: {}", torn.len(), torn.join(", "));
+        }
+        torn
+    }
+
+    fn undo(self, cause: io::Error) -> WriteError {
+        match self.rollback() {
+            paths if paths.is_empty() => WriteError::Io(cause),
+            paths => WriteError::Torn { cause, paths },
+        }
+    }
+}
+
+/// One file's disk work. The tombstone list is rewritten here rather than after the overlay changes,
+/// so a failure to record it is a failure of the whole write.
+fn stage_write(
+    staged: &mut Staged,
+    overlay: &BTreeMap<String, Option<FileData>>,
+    path: &str,
+    bytes: Vec<u8>,
+    was_tombstone: bool,
+) -> io::Result<FileData> {
+    let data = staged.write(path, bytes)?;
+    if was_tombstone {
+        let list: Vec<&str> = overlay.iter().filter(|(p, d)| d.is_none() && p.as_str() != path).map(|(p, _)| p.as_str()).collect();
+        staged.tombstones(&list)?;
+    }
+    Ok(data)
+}
+
+/// Every disk change one batch makes. Until it answers `Ok` nothing has touched the overlay, and the
+/// `next` it fills in is only worth swapping in if it did.
+fn stage_batch(
+    staged: &mut Staged,
+    next: &mut BTreeMap<String, Option<FileData>>,
+    dropped: &[&str],
+    files: Vec<(String, Vec<u8>)>,
+) -> io::Result<()> {
+    for path in dropped {
+        staged.remove(path)?;
+    }
+    for (path, bytes) in files {
+        let data = staged.write(&path, bytes)?;
+        next.insert(path, Some(data));
+    }
+    let list: Vec<&str> = next.iter().filter(|(_, d)| d.is_none()).map(|(p, _)| p.as_str()).collect();
+    staged.tombstones(&list)
+}
+
+fn stage_delete(staged: &mut Staged, overlay: &BTreeMap<String, Option<FileData>>, path: &str, tombstone: bool) -> io::Result<()> {
+    staged.remove(path)?;
+    let mut list: Vec<&str> = overlay.iter().filter(|(p, d)| d.is_none() && p.as_str() != path).map(|(p, _)| p.as_str()).collect();
+    if tombstone {
+        list.push(path);
+        list.sort_unstable();
+    }
+    staged.tombstones(&list)
 }
 
 pub struct Store {

--- a/src/store.rs
+++ b/src/store.rs
@@ -556,13 +556,19 @@ impl Staged {
     fn tombstones(&mut self, list: &[&str]) -> io::Result<()> {
         let Some(dir) = &self.dir else { return Ok(()) };
         let file = dir.join("deleted.json");
-        self.tombstones = Some(std::fs::read(&file).ok());
+        let before = match std::fs::read(&file) {
+            Ok(raw) => Some(raw),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => None,
+            // a list that is there and unreadable must not be undone as if there were none
+            Err(e) => return Err(e),
+        };
+        self.tombstones = Some(before);
         std::fs::write(file, serde_json::to_vec(list)?)
     }
 
     fn commit(self) {
         if let Some(aside) = &self.aside {
-            let _ = std::fs::remove_dir_all(aside);
+            sweep(aside);
         }
     }
 
@@ -571,33 +577,35 @@ impl Staged {
     fn rollback(self) -> Vec<String> {
         let mut torn = Vec::new();
         for target in self.created.iter().rev() {
-            if let Err(e) = std::fs::remove_file(target)
-                && e.kind() != io::ErrorKind::NotFound
-            {
-                torn.push(target.display().to_string());
+            if let Err(e) = remove_if_present(target) {
+                torn.push(format!("{} ({e})", target.display()));
             }
         }
         for (kept, target) in self.moved.iter().rev() {
-            if std::fs::rename(kept, target).is_err() {
-                torn.push(target.display().to_string());
+            if let Err(e) = std::fs::rename(kept, target) {
+                torn.push(format!("{} ({e})", target.display()));
             }
         }
         if let (Some(dir), Some(before)) = (&self.dir, &self.tombstones) {
             let file = dir.join("deleted.json");
             let back = match before {
                 Some(raw) => std::fs::write(&file, raw),
-                None => std::fs::remove_file(&file),
+                None => remove_if_present(&file),
             };
-            if back.is_err() {
-                torn.push(file.display().to_string());
+            if let Err(e) = back {
+                torn.push(format!("{} ({e})", file.display()));
             }
         }
-        // only ever empty ones this write made: a directory something else put a file in stays
         for d in self.dirs.iter().rev() {
-            let _ = std::fs::remove_dir(d);
+            // a directory something else has since put a file in is not empty, and stays
+            if let Err(e) = std::fs::remove_dir(d)
+                && !matches!(e.kind(), io::ErrorKind::DirectoryNotEmpty | io::ErrorKind::NotFound)
+            {
+                eprintln!("write: cannot remove the directory {} the write made: {e}", d.display());
+            }
         }
         if let Some(aside) = &self.aside {
-            let _ = std::fs::remove_dir_all(aside);
+            sweep(aside);
         }
         if !torn.is_empty() {
             eprintln!("write: undoing a failed write left {} path(s) neither way: {}", torn.len(), torn.join(", "));
@@ -610,6 +618,20 @@ impl Staged {
             paths if paths.is_empty() => WriteError::Io(cause),
             paths => WriteError::Torn { cause, paths },
         }
+    }
+}
+
+/// `remove_file` on a path whose parent turned out not to be a directory answers `ENOTDIR`, not
+/// `NotFound`, so whether the file is there is asked rather than read out of the error.
+fn remove_if_present(target: &Path) -> io::Result<()> {
+    if target.exists() { std::fs::remove_file(target) } else { Ok(()) }
+}
+
+/// The copies waiting in the staging directory are dead once a write has landed or been undone, but
+/// failing to sweep them cannot fail the write: it is reported instead.
+fn sweep(aside: &Path) {
+    if let Err(e) = std::fs::remove_dir_all(aside) {
+        eprintln!("write: cannot remove the staging directory {}: {e}", aside.display());
     }
 }
 


### PR DESCRIPTION
Closes #64

Closes #65

Both are defects in the tar.gz importer from #36, and both are places where SECURITY.md described a guarantee the code did not give.

## #65 — the quota was applied to the wrong thing

`unpack` ran the entry-type filter *before* the size accounting, so a `Directory` or pax entry cost nothing: tar still reads its declared bytes off the decompressor to reach the next header. 8 KB on the wire, 8 MB decompressed, a 64-byte quota, answered `200`.

Two bounds now, as the issue asks:

- **Every entry costs its declared size**, counted before the type match decides what to do with it, and the running total is checked against the quota before the entry's body is read. A skipped entry costs the same budget as a taken one.
- **A counting reader around `GzDecoder`** caps the whole stream at the quota plus 16 MiB of tar framing (a header and up to 511 bytes of padding per file — about sixteen thousand files), and never more than a thousand times the compressed body, with a 1 MiB floor. gzip itself tops out near 1030:1, so the ratio term is a ceiling on the amplification rather than on the content: a small request can no longer buy a large decompression.

The second bound is not belt-and-braces. `tar::Entries::next_entry` consumes GNU long-name, long-link and pax-local-extension records itself — `EntryFields::read_all()` into a `Vec`, with no entry ever surfacing for them — so the declared-size accounting cannot see those bytes at all, and an unbounded long name is a *memory* bomb rather than only a CPU one. The cap is what bounds it, and a trip is told apart from a truncated archive (`400`) by a flag the reader sets, so it answers `413`.

Worst case per import is now the quota plus 16 MiB, where it was roughly the 64 MiB body limit times gzip's ratio.

## #64 — a failed import half-landed

`write_many` did every disk step with `?` and swapped the overlay only afterwards, so an I/O failure part-way left files on disk that the response said were not written and that a restart then read; with `?replace=1` it had already deleted the dropped edits, whose only copy that was.

**I chose atomicity over reporting, because it is available here.** The disk half of a write goes through a new `Staged`, which records every step before it happens and — the part that makes an undo possible — moves a file it replaces or removes *aside* into `<data-dir>/<id>/.staged-<pid>-<n>` rather than deleting it: a `FileData::Disk` overlay entry is the only copy of its contents there is, so a delete could not be undone. The overlay is swapped only once every step has succeeded; on failure the created files are removed, the moved files are renamed back, `deleted.json` is restored and the directories the batch created are removed. Memory was never touched, so both halves end up as they were.

`write` and `delete` now use it too. They had the same shape on a smaller scale: `write` left a partial file behind on a failed `fs::write`, and `delete` changed memory *first*, so a failed `remove_file` gave a file the daemon said was gone and a restart brought back.

What this is not: crash-atomicity. A `SIGKILL` between the first rename and the overlay swap still leaves a partial batch on disk, and getting that would take a whole staged `files/` tree swapped in, which is a much larger change for a case where there is no response to disagree with. So the honest remainder is `WriteError::Torn` — a failure whose *undo* also failed. The import answers that one with the paths that are neither way, and deliberately not with `files: 0, deleted: 0`, since that would be the same lie in a smaller font. A cleanly undone failure keeps the zero counts, which are now true.

## Tests

- `a_bomb_is_refused_before_it_lands` — the issue's archive (a `Directory` entry declaring 8 MiB, 8 KB compressed, 64-byte quota) answers `413` with nothing written, and so does a 24 MiB GNU long name, which only the stream cap can see.
- `the_cap_on_the_decompressor_bounds_both_ways` — the ratio floor, the ratio, the absolute cap and the saturating edge.
- `a_failed_import_leaves_the_tenant_exactly_as_it_was` — an archive holding both `x` and `x/y` as regular files fails on its last entry (`"x" < "x/y"`, so the directory cannot be created over the file). Run plain and with `?replace=1`: the response is a `5xx` with `files: 0`, the listing and the contents are byte-identical to before, `files/x` does not exist, `deleted.json` is unchanged, no staging directory is left behind, and a fresh `Store::restore` over the same data dir sees the same tenant. The `?replace=1` run is the mirror case from the issue — the dropped edit must come back.
- The existing round trip, `?replace=1`, quota, path, entry-type and one-event tests are unchanged and still pass.

CI on this branch: https://github.com/productdevbook/sandbox-lite/actions/runs/34061898589 (fmt, clippy `-D warnings`, tests, release build, `sandbox-lite check`, smoke, `bench/mem.sh`, Playwright).

The first push was red, and both failures were worth having. The atomicity test caught a real bug in the undo: `remove_file` on `files/x/y` when `files/x` is a file answers `ENOTDIR`, not `NotFound`, so the undo reported a file it had never created as one it could not take back, and a failure that *had* put the tenant back came out as `Torn`. It asks whether the file is there now instead of reading it out of the error. `silent_failures` flagged four discarded results in the new code: the read of the previous `deleted.json` now tells "there is none" apart from "there is one and it cannot be read" (undoing the second as the first would delete a tombstone list), sweeping the staging directory reports rather than discards, and the only expected failure — removing a directory something else has since put a file in — is the one case named. Nothing was added to `TOLERATED`.

Overlap: #77 is also open against `src/store.rs` and `ARCHITECTURE.md`. It changes `Store::remove_tenant` and the bases scan, which this touches nowhere, but both add a paragraph to the same part of the store section of `ARCHITECTURE.md`, so whichever lands second will have that one line of conflict to resolve.

## Noticed, not fixed

- **`x` and `x/y` can both exist as paths.** `clean_path` allows both, so two ordinary `PUT`s put a tenant in the same state, and the second one fails with a `500` for ever. The import now fails cleanly instead of half-landing, but it still fails; refusing such an archive up front with a `400`, or refusing the second `PUT`, is a separate decision (as #64 says).
- **A `.staged-*` directory survives a process that dies mid-write.** It is a sibling of `files/`, so `restore_overlay` does not read it back as tenant files, but nothing sweeps it either. `Store::restore` could remove them.
- **`FRAMING_SLACK` is a flat 16 MiB**, so an archive of more than roughly sixteen thousand files is refused with `413` even if its content fits the quota. That is a deliberate trade against a per-entry budget, which an attacker can grow faster than it is spent (an empty header costs 512 bytes and would grant more).
- **A concurrent reader can still see a moved-aside file disappear.** A `FileData::Disk` clone taken before the write is read without the overlay lock, so it can hit a path being renamed and answer `500`. That window predates this change (`delete` did the same) and is not made wider by it.
- **`Tenant::write`'s quota check counts the whole overlay on every write** (`overlay_bytes` is O(files) under the write lock). Not touched here.
- **`Tenant::delete` still returns `io::Result`**, so a `Torn` undo of a single delete reaches the caller as its cause and is only named in full on stderr. Widening that signature touches `api.rs` and `ai.rs` and was not worth it for a case the import route reports properly.
- **Multi-node is unchanged.** Two daemons on one `--data-dir` still cannot see each other's writes, and the staging directory is per-process but the `files/` tree is not; `docs/multi-node.md` already says the sharing is unsafe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
