### PR TITLE
security: a deadline on every compile, so one tenant cannot starve the rest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,12 @@ jobs:
           curl -sf -H 'Host: ci.localhost' 'http://127.0.0.1:4399/__sl/m/src/deep.astro?astro&type=style&index=0' | grep -q __sl_css
           curl -sf -H 'Host: ci.localhost' 'http://127.0.0.1:4399/__sl/m/src/deep.astro?astro&type=script&index=0' | grep -q console.log
           test 200 = "$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:4399/health)"
+          # issue #63: 64 KiB of repeated headings was ~40 minutes of one core; it must now be a page
+          python3 -c "import sys; sys.stdout.write('# a\n' * 16000)" > headings.mdx
+          curl -sf -X PUT --data-binary @headings.mdx http://127.0.0.1:4399/api/t/ci/file/src/pages/headings.mdx
+          # to a file, not a pipe: the module is megabytes and `grep -q` would close the pipe early
+          curl -sf --max-time 60 -H 'Host: ci.localhost' 'http://127.0.0.1:4399/__sl/m/src/pages/headings.mdx?v=1' -o /tmp/headings.js
+          grep -q '"a-15999"' /tmp/headings.js
           curl -sf http://127.0.0.1:4399/metrics > /tmp/metrics.txt
           grep -qxF '# TYPE sandbox_lite_tenants gauge' /tmp/metrics.txt
           grep -qxF 'sandbox_lite_tenants 1' /tmp/metrics.txt
@@ -55,6 +61,12 @@ jobs:
           curl -sf http://127.0.0.1:4399/api/stats | grep -q '"max_per_tenant"'
           grep -qxF '# TYPE sandbox_lite_compile_seconds histogram' /tmp/metrics.txt
           grep -qxF '# TYPE sandbox_lite_compiles_queued gauge' /tmp/metrics.txt
+          # issue #63: a compile past its deadline is abandoned, so the count of abandoned threads is reportable
+          grep -qxF '# TYPE sandbox_lite_compiles_runaway gauge' /tmp/metrics.txt
+          grep -qxF 'sandbox_lite_compiles_runaway 0' /tmp/metrics.txt
+          grep -qxF '# TYPE sandbox_lite_compiles_timeouts_total counter' /tmp/metrics.txt
+          curl -sf http://127.0.0.1:4399/api/stats \
+            | python3 -c "import json,sys; c = json.load(sys.stdin)['compiles']; assert c['runaway'] == 0 and c['timeouts'] == 0, c"
           # issue #47: the permit count is what bounds concurrent compiles, so it must never render as 0
           grep -qE '^sandbox_lite_compiles_limit [1-9][0-9]*$' /tmp/metrics.txt
           grep -qxF 'sandbox_lite_bases{base="starter"} 1' /tmp/metrics.txt

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -219,7 +219,7 @@ What `compile` does per kind and extension:
 | `.js` `.mjs` | served as-is when it parses as ESM, otherwise transformed |
 | `.css` | a module that registers the text in `globalThis.__sl_css`, with relative `url()` and `@import` targets rewritten to `/__sl/raw/…` (`src/transform/css.rs`) |
 | `.scss` `.sass` | grass over a snapshot of the tenant's file tree, on its own thread with a deadline (`src/transform/scss.rs`), then as `.css` |
-| `.md` | frontmatter + pulldown-cmark HTML, wrapped as a page component that renders through `layout:` when set (`src/transform/markdown.rs`) |
+| `.md` | frontmatter + pulldown-cmark HTML, wrapped as a page component that renders through `layout:` when set (`src/transform/markdown.rs`); headings are collected and their slugs uniquified by the same `content::Slugs` `.mdx` uses, so `getHeadings()` agrees across the two |
 | `.mdx` | satteri-mdxjs (`src/transform/mdx.rs`): frontmatter split off, headings given ids and collected, JSX compiled against `astro/jsx-runtime`, then wrapped as `@astrojs/mdx` does — `frontmatter`, `file`, `url`, `getHeadings`, a `layout:` wrapper, and a default `Content` export tagged for the `astro:jsx` renderer |
 | `.json` | `export default JSON.parse(…)` |
 | `.vue` `.svelte` | a loader module (`transform::sfc_loader`) that hands the source — its `<script lang="ts">` blocks already stripped to JavaScript by `transform::sfc` — to `/__sl/shim/vue-loader.js` or `svelte-loader.js`, which compiles it in the browser |
@@ -322,15 +322,43 @@ let 512 of those exist together. So a miss takes one of `--max-compiles`
 permits first (default: one per core, never fewer than one). A build that
 finds none free waits five seconds for one and is then refused with 503 rather
 than queueing without end. `/api/stats` reports the permits held, the builds
-waiting, the limit and the refusals under `compiles`; `/metrics` has the same
-four.
+waiting, the limit, the refusals, and the two deadline counters below under
+`compiles`; `/metrics` has the same six.
 
 Two builds take no permit. A cache hit is not a compile, so a warm daemon
 serving cached modules never queues. And a `?type=style` or `?type=script`
 build asks for the module from inside its own compile: that inner build runs
-under the permit — and on the stack — its parent is already holding, which a
-thread-local marks for each. A second permit there would deadlock as soon as
-the gate was full.
+under the permit — and on the stack, and under the deadline — its parent is
+already holding, which a thread-local marks for each. A second permit there
+would deadlock as soon as the gate was full.
+
+### How long one compile may run
+
+A permit is only a bound if something takes it back. `astro_codegen`, oxc and
+satteri-mdxjs are synchronous and offer no cancellation, so every compile runs
+on a thread of its own with a wall-clock deadline (`--compile-timeout-ms`,
+default 10000, or `SANDBOX_LITE_COMPILE_TIMEOUT_MS`) and the request gives up
+on it rather than joining it — the same shape Sass has used since #35. Past
+the deadline the request is answered with a diagnostic, the permit goes back
+to the pool, and the thread is left to run out: it keeps its core and its
+`parser_stack_bytes()` reservation until it returns on its own, and is counted
+under `compiles.runaway` in `/api/stats` and `/metrics` while it does. Eight
+runaways is the cap; past that a compile is refused with 503 rather than
+starting a ninth abandoned thread. The thread outlives the request, so it owns
+everything it may still touch — an `Engine` handle, the tenant, the source
+bytes — which is why `Engine` is a handle to a shared `EngineInner`.
+
+The size and nesting caps are checked before the permit and before the thread:
+a source that cannot be compiled has no business queueing for the right to try.
+
+Issue #63 is why the deadline exists. Heading ids in `.mdx` were assigned by
+rescanning the ids already given out, which is O(n³) in the headings of one
+file: 64 KiB of `# a` — under the size cap, and with no bracket or blockquote
+for `nesting_depth` to count — was about forty minutes of one core, and enough
+such files refused every other tenant's compiles for as long as they ran. That
+particular cost is gone (`content::Slugs` carries a per-slug counter, so ids
+are O(1) amortised and a page is linear in its headings), but the deadline is
+what bounds the next shape nobody has thought of.
 
 ### Why resolution and `import.meta.glob` happen at serve time
 
@@ -409,8 +437,9 @@ request. Eight threads may compile at once, which is the bound on distinct
 runaway sources too. `/api/stats` counts them under `sass`.
 
 None of this stops an abandoned compile — it keeps its core and keeps
-allocating until it returns on its own. Only a child process with rlimits
-would, and that is the design discussion in issue #26.
+allocating until it returns on its own, and the same is true of a compile
+abandoned by `--compile-timeout-ms`. Only a child process with rlimits would,
+and that is the design discussion in issue #26.
 
 ## Versions, browser cache and SSE
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,9 @@ its 20 s deadline is killed and reaped before its profile directory goes.
 --cache-mb N         transform cache budget (default 64)
 --max-source-kb N    largest .astro/.ts/.js/.mdx/.scss/.vue/.svelte file the compilers accept (default 64)
 --sass-timeout-ms N  deadline for one Sass compile (default 5000)
+--compile-timeout-ms N
+                     deadline for one compile of any kind; past it the request gets a diagnostic
+                     and the compiler thread is abandoned (default 10000)
 --max-compiles N     compiles that may run at once (default: one per core)
 --model NAME         Claude model for the chat endpoint (default claude-fable-5-1)
 --api-token TOKEN    require `Authorization: Bearer TOKEN` (or `?token=`) on /api/*
@@ -211,6 +214,7 @@ its 20 s deadline is killed and reaped before its profile directory goes.
 
 `SANDBOX_LITE_API_TOKEN`, `SANDBOX_LITE_PREVIEW_SECRET`,
 `SANDBOX_LITE_TENANT_QUOTA_MB`, `SANDBOX_LITE_MAX_COMPILES`,
+`SANDBOX_LITE_COMPILE_TIMEOUT_MS`,
 `SANDBOX_LITE_CHROME`, `SANDBOX_LITE_CHROME_JOBS`, `SANDBOX_LITE_CHAT_WINDOW`
 and `SANDBOX_LITE_CHATS_PER_TENANT` are read as defaults for those flags, and
 `SANDBOX_LITE_ANTHROPIC_BASE` points the chat at another Messages API

--- a/src/http/ai.rs
+++ b/src/http/ai.rs
@@ -113,7 +113,7 @@ fn summarize(s: &str) -> String {
     }
 }
 
-fn file_tool(st: &AppState, t: &Tenant, name: &str, input: &Value, changes: &mut Vec<String>) -> String {
+fn file_tool(st: &AppState, t: &Arc<Tenant>, name: &str, input: &Value, changes: &mut Vec<String>) -> String {
     let path = || input.get("path").and_then(|p| p.as_str()).and_then(clean_path);
     match name {
         "list_files" => t.list().iter().map(|e| format!("{} ({} bytes)", e.path, e.size)).collect::<Vec<_>>().join("\n"),

--- a/src/http/api.rs
+++ b/src/http/api.rs
@@ -146,6 +146,8 @@ fn snapshot(st: &AppState) -> Snapshot {
         compiles_queued: compiles.queued as u64,
         compiles_limit: compiles.limit as u64,
         compiles_refused: compiles.refused,
+        compiles_runaway: compiles.runaway as u64,
+        compiles_timeouts: compiles.timeouts,
         shots_running: shots.running as u64,
         shots_busy: shots.busy,
         shots_timeouts: shots.timeouts,
@@ -326,7 +328,7 @@ pub async fn events(AxState(st): AxState<State>, Path(id): Path<String>) -> Resp
     }
 }
 
-pub fn check_tenant(st: &AppState, t: &Tenant) -> Value {
+pub fn check_tenant(st: &AppState, t: &Arc<Tenant>) -> Value {
     let mut diagnostics = Vec::new();
     let mut files = 0;
     for e in t.list() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ struct Args {
     cache_mb: usize,
     max_source_kb: usize,
     sass_timeout_ms: u64,
+    compile_timeout_ms: u64,
     max_compiles: usize,
     model: String,
     api_token: Option<String>,
@@ -40,7 +41,7 @@ struct Args {
 
 fn usage() -> ! {
     eprintln!(
-        "sandbox-lite {}\n\nUsage: sandbox-lite [options]\n       sandbox-lite check [--json] DIR...   compile every source file of an Astro project and print diagnostics + a feature census\n\n  --listen ADDR        bind address (default 127.0.0.1:4321)\n  --domain NAME        preview domain; tenants are served at http://<id>.NAME:PORT/ (default localhost)\n  --bases DIR          directory whose sub-directories are base projects (default ./examples if present)\n  --base NAME=PATH     add one base project (repeatable)\n  --watch-bases N      re-read every base project when its files change, polled every N seconds (default: off)\n  --data-dir DIR       where tenant edits are persisted (default ./data)\n  --no-persist         keep tenant edits in memory only\n  --cdn URL            where bare npm imports are fetched from in the browser (default https://esm.sh)\n  --cache-mb N         transform cache budget in MiB (default 64)\n  --max-source-kb N    largest .astro/.ts/.js/.mdx/.scss file the compilers accept, in KiB (default 64)\n  --sass-timeout-ms N  deadline for one Sass compile, after which the request fails (default 5000)\n  --max-compiles N     compiles that may run at once; one that waits too long for a slot is refused with 503 (default: one per core)\n  --model NAME         Claude model for the built-in chat (default claude-fable-5-1)\n  --api-token TOKEN    require `Authorization: Bearer TOKEN` (or ?token=) on /api/*\n  --preview-secret S   tenant hosts need a per-tenant token derived from S (the API hands it out)\n  --chrome PATH        chrome or chromium binary for the chat's screenshot tool (default: off)\n  --chrome-jobs N      screenshots that may run at once; a call that waits longer than 10s is told the tool is busy (default {})\n  --chat-window N      turns of a conversation replayed to the model in full; older ones are folded into a stored summary (default {})\n  --chats-per-tenant N conversations a tenant may keep; saving past it drops the least recently updated (default {})\n  --tenant-quota-mb N  edited files a tenant may hold, in MiB; a write past it is refused with 413 (default 64)\n  --cookie-samesite lax|none\n                       SameSite of the preview cookie; none also sets Secure. With --preview-secret the\n                       default is none, because a framed preview is cross-site and a browser\n                       drops a Lax cookie there; otherwise lax\n\nEnvironment: ANTHROPIC_API_KEY enables the chat endpoint; SANDBOX_LITE_API_TOKEN, SANDBOX_LITE_PREVIEW_SECRET, SANDBOX_LITE_TENANT_QUOTA_MB, SANDBOX_LITE_MAX_COMPILES, SANDBOX_LITE_CHROME, SANDBOX_LITE_CHROME_JOBS, SANDBOX_LITE_CHAT_WINDOW and SANDBOX_LITE_CHATS_PER_TENANT are read as defaults for those flags; SANDBOX_LITE_ANTHROPIC_BASE points the chat at another Messages API endpoint (default https://api.anthropic.com).",
+        "sandbox-lite {}\n\nUsage: sandbox-lite [options]\n       sandbox-lite check [--json] DIR...   compile every source file of an Astro project and print diagnostics + a feature census\n\n  --listen ADDR        bind address (default 127.0.0.1:4321)\n  --domain NAME        preview domain; tenants are served at http://<id>.NAME:PORT/ (default localhost)\n  --bases DIR          directory whose sub-directories are base projects (default ./examples if present)\n  --base NAME=PATH     add one base project (repeatable)\n  --watch-bases N      re-read every base project when its files change, polled every N seconds (default: off)\n  --data-dir DIR       where tenant edits are persisted (default ./data)\n  --no-persist         keep tenant edits in memory only\n  --cdn URL            where bare npm imports are fetched from in the browser (default https://esm.sh)\n  --cache-mb N         transform cache budget in MiB (default 64)\n  --max-source-kb N    largest .astro/.ts/.js/.mdx/.scss file the compilers accept, in KiB (default 64)\n  --sass-timeout-ms N  deadline for one Sass compile, after which the request fails (default 5000)\n  --compile-timeout-ms N\n                       deadline for one compile of any kind; past it the request is answered with a\n                       diagnostic and the compiler thread, which cannot be interrupted, is abandoned\n                       and counted under `compiles` in /api/stats (default 10000)\n  --max-compiles N     compiles that may run at once; one that waits too long for a slot is refused with 503 (default: one per core)\n  --model NAME         Claude model for the built-in chat (default claude-fable-5-1)\n  --api-token TOKEN    require `Authorization: Bearer TOKEN` (or ?token=) on /api/*\n  --preview-secret S   tenant hosts need a per-tenant token derived from S (the API hands it out)\n  --chrome PATH        chrome or chromium binary for the chat's screenshot tool (default: off)\n  --chrome-jobs N      screenshots that may run at once; a call that waits longer than 10s is told the tool is busy (default {})\n  --chat-window N      turns of a conversation replayed to the model in full; older ones are folded into a stored summary (default {})\n  --chats-per-tenant N conversations a tenant may keep; saving past it drops the least recently updated (default {})\n  --tenant-quota-mb N  edited files a tenant may hold, in MiB; a write past it is refused with 413 (default 64)\n  --cookie-samesite lax|none\n                       SameSite of the preview cookie; none also sets Secure. With --preview-secret the\n                       default is none, because a framed preview is cross-site and a browser\n                       drops a Lax cookie there; otherwise lax\n\nEnvironment: ANTHROPIC_API_KEY enables the chat endpoint; SANDBOX_LITE_API_TOKEN, SANDBOX_LITE_PREVIEW_SECRET, SANDBOX_LITE_TENANT_QUOTA_MB, SANDBOX_LITE_MAX_COMPILES, SANDBOX_LITE_COMPILE_TIMEOUT_MS, SANDBOX_LITE_CHROME, SANDBOX_LITE_CHROME_JOBS, SANDBOX_LITE_CHAT_WINDOW and SANDBOX_LITE_CHATS_PER_TENANT are read as defaults for those flags; SANDBOX_LITE_ANTHROPIC_BASE points the chat at another Messages API endpoint (default https://api.anthropic.com).",
         env!("CARGO_PKG_VERSION"),
         http::ai::DEFAULT_CHROME_JOBS,
         http::chats::DEFAULT_WINDOW_TURNS,
@@ -65,6 +66,10 @@ fn parse_args() -> Args {
         cache_mb: 64,
         max_source_kb: 64,
         sass_timeout_ms: transform::scss::DEFAULT_TIMEOUT_MS,
+        compile_timeout_ms: std::env::var("SANDBOX_LITE_COMPILE_TIMEOUT_MS")
+            .ok()
+            .filter(|v| !v.is_empty())
+            .map_or(transform::DEFAULT_COMPILE_TIMEOUT_MS, |v| v.parse().unwrap_or_else(|_| usage())),
         max_compiles: std::env::var("SANDBOX_LITE_MAX_COMPILES")
             .ok()
             .filter(|v| !v.is_empty())
@@ -101,6 +106,7 @@ fn parse_args() -> Args {
             "--cache-mb" => args.cache_mb = value().parse().unwrap_or_else(|_| usage()),
             "--max-source-kb" => args.max_source_kb = value().parse().unwrap_or_else(|_| usage()),
             "--sass-timeout-ms" => args.sass_timeout_ms = value().parse().unwrap_or_else(|_| usage()),
+            "--compile-timeout-ms" => args.compile_timeout_ms = value().parse().unwrap_or_else(|_| usage()),
             "--max-compiles" => args.max_compiles = value().parse().unwrap_or_else(|_| usage()),
             "--model" => args.model = value(),
             "--api-token" => args.api_token = Some(value()),
@@ -187,6 +193,7 @@ async fn main() {
                 cache_bytes: args.cache_mb << 20,
                 max_source_bytes: args.max_source_kb << 10,
                 sass_timeout: Duration::from_millis(args.sass_timeout_ms),
+                compile_timeout: Duration::from_millis(args.compile_timeout_ms),
                 max_compiles: args.max_compiles,
             },
             metrics.clone(),

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -122,6 +122,8 @@ pub struct Snapshot {
     pub compiles_queued: u64,
     pub compiles_limit: u64,
     pub compiles_refused: u64,
+    pub compiles_runaway: u64,
+    pub compiles_timeouts: u64,
     pub shots_running: u64,
     pub shots_busy: u64,
     pub shots_timeouts: u64,
@@ -195,8 +197,22 @@ pub fn render(s: &Snapshot) -> String {
         &mut out,
         "sandbox_lite_compiles_refused_total",
         "counter",
-        "Compiles refused with 503 after waiting for a permit.",
+        "Compiles refused with 503 after waiting for a permit, or because too many are past their deadline.",
         s.compiles_refused,
+    );
+    scalar(
+        &mut out,
+        "sandbox_lite_compiles_runaway",
+        "gauge",
+        "Compile threads still running past their deadline; the compilers cannot be interrupted, so these are abandoned rather than killed.",
+        s.compiles_runaway,
+    );
+    scalar(
+        &mut out,
+        "sandbox_lite_compiles_timeouts_total",
+        "counter",
+        "Compiles that overran their deadline (--compile-timeout-ms).",
+        s.compiles_timeouts,
     );
 
     scalar(&mut out, "sandbox_lite_screenshots_running", "gauge", "Headless Chrome screenshots in flight.", s.shots_running);
@@ -306,6 +322,8 @@ mod tests {
             compiles_queued: 5,
             compiles_limit: 8,
             compiles_refused: 6,
+            compiles_runaway: 7,
+            compiles_timeouts: 9,
             shots_running: 1,
             shots_busy: 5,
             shots_timeouts: 6,
@@ -372,9 +390,15 @@ sandbox_lite_compiles_queued 5
 # HELP sandbox_lite_compiles_limit Compiles that may run at once (--max-compiles).
 # TYPE sandbox_lite_compiles_limit gauge
 sandbox_lite_compiles_limit 8
-# HELP sandbox_lite_compiles_refused_total Compiles refused with 503 after waiting for a permit.
+# HELP sandbox_lite_compiles_refused_total Compiles refused with 503 after waiting for a permit, or because too many are past their deadline.
 # TYPE sandbox_lite_compiles_refused_total counter
 sandbox_lite_compiles_refused_total 6
+# HELP sandbox_lite_compiles_runaway Compile threads still running past their deadline; the compilers cannot be interrupted, so these are abandoned rather than killed.
+# TYPE sandbox_lite_compiles_runaway gauge
+sandbox_lite_compiles_runaway 7
+# HELP sandbox_lite_compiles_timeouts_total Compiles that overran their deadline (--compile-timeout-ms).
+# TYPE sandbox_lite_compiles_timeouts_total counter
+sandbox_lite_compiles_timeouts_total 9
 # HELP sandbox_lite_screenshots_running Headless Chrome screenshots in flight.
 # TYPE sandbox_lite_screenshots_running gauge
 sandbox_lite_screenshots_running 1
@@ -489,6 +513,8 @@ sandbox_lite_compile_seconds_count{kind="url"} 0
             compiles_queued: 0,
             compiles_limit: 1,
             compiles_refused: 0,
+            compiles_runaway: 0,
+            compiles_timeouts: 0,
             shots_running: 0,
             shots_busy: 0,
             shots_timeouts: 0,

--- a/src/transform/content.rs
+++ b/src/transform/content.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use globset::{GlobBuilder, GlobSet, GlobSetBuilder};
 use oxc_allocator::Allocator;
@@ -89,6 +89,7 @@ pub fn parse_markdown(src: &str) -> Result<Md, String> {
 fn render(body: &str) -> (String, Vec<Heading>) {
     let options = Options::ENABLE_TABLES | Options::ENABLE_STRIKETHROUGH | Options::ENABLE_FOOTNOTES | Options::ENABLE_TASKLISTS;
     let mut headings = Vec::new();
+    let mut slugs = Slugs::default();
     let mut current: Option<(u8, String)> = None;
     let events: Vec<Event> = Parser::new_ext(body, options)
         .inspect(|ev| match ev {
@@ -100,7 +101,9 @@ fn render(body: &str) -> (String, Vec<Heading>) {
             }
             Event::End(TagEnd::Heading(_)) => {
                 if let Some((depth, text)) = current.take() {
-                    headings.push(Heading { depth, slug: slugify(&text), text });
+                    // Issue #63: `.md` used to leave duplicate slugs alone, so `getHeadings()`
+                    // disagreed with the same page written as `.mdx`. One rule for both.
+                    headings.push(Heading { depth, slug: slugs.unique(slugify(&text)), text });
                 }
             }
             _ => {}
@@ -119,6 +122,38 @@ fn level_depth(level: HeadingLevel) -> u8 {
         HeadingLevel::H4 => 4,
         HeadingLevel::H5 => 5,
         HeadingLevel::H6 => 6,
+    }
+}
+
+/// The ids a page's headings get: the first heading keeps its slug, and a later heading whose slug
+/// is taken becomes `slug-1`, `slug-2`, and so on — what Astro's processor produces.
+///
+/// Issue #63: the count of `slug-n` tried so far is kept per base slug, so it never restarts at 1.
+/// Rescanning the headings already assigned made one heading cost O(i) probes of an O(i) scan and a
+/// page of n identical headings O(n^3): 64 KiB of `# a` is about forty minutes of CPU. Advancing
+/// the counter instead makes a probe O(1) and bounds the failed ones by the ids actually taken, so
+/// the page is linear in its headings.
+#[derive(Default)]
+pub struct Slugs {
+    taken: HashSet<String>,
+    next: HashMap<String, u32>,
+}
+
+impl Slugs {
+    /// An id the author wrote themselves, which no generated id may then collide with.
+    pub fn claim(&mut self, slug: &str) {
+        self.taken.insert(slug.to_string());
+    }
+
+    pub fn unique(&mut self, slug: String) -> String {
+        let mut n = self.next.get(&slug).copied().unwrap_or(0);
+        let mut candidate = slug.clone();
+        while !self.taken.insert(candidate.clone()) {
+            n += 1;
+            candidate = format!("{slug}-{n}");
+        }
+        self.next.insert(slug, n);
+        candidate
     }
 }
 
@@ -503,6 +538,25 @@ mod tests {
         assert_eq!(md.frontmatter["title"], "T");
         assert_eq!(md.headings[0].slug, "hello-world");
         assert!(md.html.contains("<h2>Hello World</h2>"));
+    }
+
+    /// Issue #63: `.md` handed `getHeadings()` the same slug twice where `.mdx` numbered them.
+    #[test]
+    fn markdown_headings_are_uniquified_like_mdx() {
+        let md = parse_markdown("## Second\n\n## Second\n\n## Second\n").unwrap();
+        let slugs: Vec<&str> = md.headings.iter().map(|h| h.slug.as_str()).collect();
+        assert_eq!(slugs, ["second", "second-1", "second-2"]);
+    }
+
+    /// The per-base-slug counter never restarts, so n identical headings cost n probes, not n^2 —
+    /// and it still may not hand out an id something else already holds.
+    #[test]
+    fn slugs_advance_without_rescanning_and_skip_what_is_taken() {
+        let mut slugs = Slugs::default();
+        slugs.claim("a-1");
+        let out: Vec<String> = (0..4).map(|_| slugs.unique("a".to_string())).collect();
+        assert_eq!(out, ["a", "a-2", "a-3", "a-4"]);
+        assert_eq!(slugs.unique("b".to_string()), "b");
     }
 
     fn glob(patterns: &[&str], base: &str) -> Loader {

--- a/src/transform/mdx.rs
+++ b/src/transform/mdx.rs
@@ -7,7 +7,7 @@ use satteri_mdxjs::{ElementAttributeNameCase, JsxRuntime, Options};
 use satteri_pulldown_cmark::{MDX_OPTIONS, strip_leading_bom};
 use serde_json::{Map, Value};
 
-use super::content::{Heading, slugify, split_frontmatter, yaml_to_json};
+use super::content::{Heading, Slugs, slugify, split_frontmatter, yaml_to_json};
 use super::js::{self, line_col};
 use super::markdown::page_url;
 use super::{BuildError, Diag, json_str};
@@ -36,7 +36,7 @@ pub fn compile(path: &str, source: &str) -> Result<Compiled, BuildError> {
     let mut hast = mdast_arena_to_hast_arena(&mdast);
     hast.mdx = true;
     let mut headings = Vec::new();
-    collect_headings(&mut hast, 0, &frontmatter, &mut headings);
+    collect_headings(&mut hast, 0, &frontmatter, &mut headings, &mut Slugs::default());
     let options = Options {
         jsx_runtime: Some(JsxRuntime::Automatic),
         jsx_import_source: Some("astro".into()),
@@ -60,7 +60,7 @@ fn error(path: &str, text: &str, line: u32, column: u32) -> BuildError {
     BuildError::compile(format!("{path}: {text}"), vec![diag])
 }
 
-fn collect_headings(hast: &mut Arena<Hast>, id: u32, frontmatter: &Value, out: &mut Vec<Heading>) {
+fn collect_headings(hast: &mut Arena<Hast>, id: u32, frontmatter: &Value, out: &mut Vec<Heading>, slugs: &mut Slugs) {
     if hast.get_node(id).node_type == HastNodeType::Element as u8 {
         let data = hast.get_type_data(id);
         let tag = decode_element_tag(data);
@@ -75,7 +75,13 @@ fn collect_headings(hast: &mut Arena<Hast>, id: u32, frontmatter: &Value, out: &
                 props.iter().find(|(name, _, _)| hast.get_str(*name) == "id").map(|(_, _, value)| hast.get_str(*value).to_string());
             let mut text = String::new();
             heading_text(hast, id, frontmatter, &mut text);
-            let slug = existing.clone().unwrap_or_else(|| unique(slugify(&text), out));
+            let slug = match &existing {
+                Some(id) => {
+                    slugs.claim(id);
+                    id.clone()
+                }
+                None => slugs.unique(slugify(&text)),
+            };
             if existing.is_none() {
                 let mut props = props;
                 props.push((hast.alloc_string("id"), PROP_STRING, hast.alloc_string(&slug)));
@@ -85,18 +91,8 @@ fn collect_headings(hast: &mut Arena<Hast>, id: u32, frontmatter: &Value, out: &
         }
     }
     for child in hast.get_children(id).to_vec() {
-        collect_headings(hast, child, frontmatter, out);
+        collect_headings(hast, child, frontmatter, out, slugs);
     }
-}
-
-fn unique(slug: String, taken: &[Heading]) -> String {
-    let mut candidate = slug.clone();
-    let mut n = 0;
-    while taken.iter().any(|h| h.slug == candidate) {
-        n += 1;
-        candidate = format!("{slug}-{n}");
-    }
-    candidate
 }
 
 fn heading_text(hast: &Arena<Hast>, id: u32, frontmatter: &Value, out: &mut String) {
@@ -233,5 +229,19 @@ mod tests {
         let Err(err) = compile("src/pages/bad.mdx", "---\ntitle: x\n---\n\n<Card\n") else { panic!("unclosed tag compiled") };
         assert_eq!(err.diagnostics[0].line, 5);
         assert_eq!(err.diagnostics[0].file, "src/pages/bad.mdx");
+    }
+
+    /// Issue #63: assigning ids by rescanning the headings already assigned was O(n^3), so 25.6 KB
+    /// of `# a` took 115 s of one core in release — and the 64 KiB source cap admits 2.56x that,
+    /// about forty minutes. Nothing else bounded it: `# a\n` has no bracket and no blockquote
+    /// marker, so it passes the nesting pre-scan, and it is far under the size cap.
+    #[test]
+    fn repeated_headings_are_not_cubic() {
+        let src = "# a\n".repeat(6400);
+        let t = std::time::Instant::now();
+        let c = compile("x.mdx", &src).unwrap();
+        assert!(t.elapsed() < std::time::Duration::from_secs(2), "took {:?}", t.elapsed());
+        assert_eq!(c.headings.len(), 6400);
+        assert_eq!(c.headings[6399].slug, "a-6399");
     }
 }

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -8,9 +8,10 @@ pub mod mdx;
 pub mod scss;
 pub mod sfc;
 
+use std::any::Any;
 use std::cell::Cell;
 use std::collections::{HashMap, VecDeque};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicU8, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::time::{Duration, Instant};
 
@@ -227,6 +228,7 @@ pub struct Config {
     pub cache_bytes: usize,
     pub max_source_bytes: usize,
     pub sass_timeout: Duration,
+    pub compile_timeout: Duration,
     pub max_compiles: usize,
 }
 
@@ -237,6 +239,7 @@ impl Default for Config {
             cache_bytes: 64 << 20,
             max_source_bytes: 64 << 10,
             sass_timeout: Duration::from_millis(scss::DEFAULT_TIMEOUT_MS),
+            compile_timeout: Duration::from_millis(DEFAULT_COMPILE_TIMEOUT_MS),
             max_compiles: default_max_compiles(),
         }
     }
@@ -263,6 +266,17 @@ struct Cache {
 /// instead of holding the connection open.
 const COMPILE_QUEUE_WAIT: Duration = Duration::from_secs(5);
 
+/// How long one compile may run before the request gives up on it. A whole `.astro` file of the
+/// example projects compiles in single-digit milliseconds, and the Sass inside one has its own
+/// five-second deadline, so ten seconds is three orders of magnitude of headroom over anything
+/// written by hand and still bounds what one request can hold.
+pub const DEFAULT_COMPILE_TIMEOUT_MS: u64 = 10_000;
+
+/// Compile threads that may be running past their deadline before compilation is refused outright.
+/// Each one keeps a core and a `parser_stack_bytes()` reservation until it returns on its own, and
+/// nothing can take those back, so past this the honest answer to a new compile is 503.
+const MAX_RUNAWAY_COMPILES: usize = 8;
+
 /// Compiles that may run at once when nothing says otherwise. A compile is CPU-bound and holds a
 /// `parser_stack_bytes()` reservation while it runs, so more of them than cores buys queueing.
 pub fn default_max_compiles() -> usize {
@@ -275,6 +289,8 @@ pub struct CompileStats {
     pub queued: usize,
     pub limit: usize,
     pub refused: u64,
+    pub runaway: usize,
+    pub timeouts: u64,
 }
 
 #[derive(Default)]
@@ -287,12 +303,29 @@ struct GateState {
 /// address space on a thread of its own and tokio's blocking pool would let 512 of those exist
 /// together, so without this the ceiling is the OS rather than a decision.
 struct Gate {
-    limit: usize,
+    limit: AtomicUsize,
     wait: Duration,
+    max_runaway: usize,
     state: Mutex<GateState>,
     free: Condvar,
     refused: AtomicU64,
+    runaway: AtomicUsize,
+    timeouts: AtomicU64,
 }
+
+/// A compile that is still running, and whether the request that started it has given up on it.
+struct Flight {
+    done: Mutex<Option<Outcome>>,
+    ready: Condvar,
+    state: AtomicU8,
+}
+
+/// What a compile thread hands back: the build, or the panic payload to resume on the waiter.
+type Outcome = Result<Result<Built, BuildError>, Box<dyn Any + Send>>;
+
+const RUNNING: u8 = 0;
+const RUNAWAY: u8 = 1;
+const SETTLED: u8 = 2;
 
 struct Permit<'a>(&'a Gate);
 
@@ -306,13 +339,29 @@ impl Drop for Permit<'_> {
 }
 
 impl Gate {
-    fn new(limit: usize, wait: Duration) -> Gate {
-        Gate { limit, wait, state: Mutex::new(GateState::default()), free: Condvar::new(), refused: AtomicU64::new(0) }
+    fn new(limit: usize, wait: Duration, max_runaway: usize) -> Gate {
+        Gate {
+            limit: AtomicUsize::new(limit),
+            wait,
+            max_runaway,
+            state: Mutex::new(GateState::default()),
+            free: Condvar::new(),
+            refused: AtomicU64::new(0),
+            runaway: AtomicUsize::new(0),
+            timeouts: AtomicU64::new(0),
+        }
     }
 
     fn stats(&self) -> CompileStats {
         let state = self.state.lock().unwrap();
-        CompileStats { running: state.running, queued: state.queued, limit: self.limit, refused: self.refused.load(Ordering::Relaxed) }
+        CompileStats {
+            running: state.running,
+            queued: state.queued,
+            limit: self.limit.load(Ordering::Relaxed),
+            refused: self.refused.load(Ordering::Relaxed),
+            runaway: self.runaway.load(Ordering::Relaxed),
+            timeouts: self.timeouts.load(Ordering::Relaxed),
+        }
     }
 
     /// `None` when this thread is already compiling under a permit: a `?type=style` build asks for
@@ -321,8 +370,16 @@ impl Gate {
         if COMPILING.get() {
             return Ok(None);
         }
+        let runaway = self.runaway.load(Ordering::Relaxed);
+        if runaway >= self.max_runaway {
+            self.refused.fetch_add(1, Ordering::Relaxed);
+            return Err(format!(
+                "{runaway} compiles are still running past their deadline and cannot be interrupted; not starting another"
+            ));
+        }
+        let limit = self.limit.load(Ordering::Relaxed);
         let mut state = self.state.lock().unwrap();
-        if state.running >= self.limit {
+        if state.running >= limit {
             let deadline = Instant::now() + self.wait;
             state.queued += 1;
             loop {
@@ -330,11 +387,11 @@ impl Gate {
                     state.queued -= 1;
                     drop(state);
                     self.refused.fetch_add(1, Ordering::Relaxed);
-                    let (n, ms) = (self.limit, self.wait.as_millis());
-                    return Err(format!("{n} compiles are already running and this one waited {ms} ms for a slot"));
+                    let ms = self.wait.as_millis();
+                    return Err(format!("{limit} compiles are already running and this one waited {ms} ms for a slot"));
                 };
                 state = self.free.wait_timeout(state, left).unwrap().0;
-                if state.running < self.limit {
+                if state.running < limit {
                     state.queued -= 1;
                     break;
                 }
@@ -342,6 +399,25 @@ impl Gate {
         }
         state.running += 1;
         Ok(Some(Permit(self)))
+    }
+
+    /// A compile passed its deadline. The permit goes back to the pool the moment the request
+    /// returns; the thread cannot be stopped, so it is counted here until it ends on its own. Both
+    /// this and `settled` take the gate's lock, so a compile that finishes in the same instant as
+    /// the deadline is either counted and uncounted or neither.
+    fn overran(&self, state: &AtomicU8) {
+        let _lock = self.state.lock().unwrap();
+        if state.compare_exchange(RUNNING, RUNAWAY, Ordering::Relaxed, Ordering::Relaxed).is_ok() {
+            self.runaway.fetch_add(1, Ordering::Relaxed);
+            self.timeouts.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    fn settled(&self, state: &AtomicU8) {
+        let _lock = self.state.lock().unwrap();
+        if state.swap(SETTLED, Ordering::Relaxed) == RUNAWAY {
+            self.runaway.fetch_sub(1, Ordering::Relaxed);
+        }
     }
 }
 
@@ -365,7 +441,12 @@ impl Drop for Compiling {
 /// emptied rather than evicted one by one: a forgotten entry costs a page reload, nothing more.
 const LAST_JS_ENTRIES: usize = 4096;
 
-pub struct Engine {
+/// A handle, not the engine itself: a compile that overruns its deadline is abandoned rather than
+/// joined, so the thread running it must keep everything it may still touch alive.
+#[derive(Clone)]
+pub struct Engine(Arc<EngineInner>);
+
+pub struct EngineInner {
     pub cfg: Config,
     cache: Mutex<Cache>,
     /// The JS each `.astro` module last compiled to, so a write can be told apart from an edit that
@@ -376,18 +457,30 @@ pub struct Engine {
     metrics: Arc<Metrics>,
 }
 
+impl std::ops::Deref for Engine {
+    type Target = EngineInner;
+
+    fn deref(&self) -> &EngineInner {
+        &self.0
+    }
+}
+
 impl Engine {
     pub fn new(cfg: Config, metrics: Arc<Metrics>) -> Engine {
+        let gate = Gate::new(cfg.max_compiles.max(1), COMPILE_QUEUE_WAIT, MAX_RUNAWAY_COMPILES);
+        Engine::with_gate(cfg, metrics, gate)
+    }
+
+    fn with_gate(cfg: Config, metrics: Arc<Metrics>, gate: Gate) -> Engine {
         let sass = scss::Sass::new(cfg.sass_timeout);
-        let gate = Gate::new(cfg.max_compiles.max(1), COMPILE_QUEUE_WAIT);
-        Engine {
+        Engine(Arc::new(EngineInner {
             cfg,
             cache: Mutex::new(Cache { map: HashMap::new(), order: VecDeque::new(), bytes: 0, hits: 0, misses: 0 }),
             last_js: Mutex::new(HashMap::new()),
             sass,
             gate,
             metrics,
-        }
+        }))
     }
 
     pub fn parser_stack_bytes(&self) -> usize {
@@ -442,12 +535,12 @@ impl Engine {
         }
     }
 
-    pub fn build(&self, tenant: &Tenant, path: &str, kind: Kind) -> Result<Arc<Built>, BuildError> {
+    pub fn build(&self, tenant: &Arc<Tenant>, path: &str, kind: Kind) -> Result<Arc<Built>, BuildError> {
         let data = tenant
             .read(path)
             .map_err(|e| BuildError::compile(format!("{path}: {e}"), vec![]))?
             .ok_or_else(|| BuildError::not_found(path))?;
-        let built = self.build_bytes(tenant, path, kind, &data)?;
+        let built = self.build_bytes(tenant, path, kind, data)?;
         self.remember(tenant, path, kind, &built);
         Ok(built)
     }
@@ -455,7 +548,7 @@ impl Engine {
     /// `build` of a source the tenant may not hold yet. The cache is content-addressed, so building
     /// the bytes of a write before it lands is the compile the next module request would have paid
     /// for anyway.
-    fn build_bytes(&self, tenant: &Tenant, path: &str, kind: Kind, data: &[u8]) -> Result<Arc<Built>, BuildError> {
+    fn build_bytes(&self, tenant: &Arc<Tenant>, path: &str, kind: Kind, data: Arc<[u8]>) -> Result<Arc<Built>, BuildError> {
         let site = crate::resolve::tenant_site(tenant).map_err(|e| BuildError::compile(e, vec![]))?;
         let mut h = Vec::with_capacity(data.len() + path.len() + 32);
         h.extend_from_slice(kind.tag().as_bytes());
@@ -464,25 +557,92 @@ impl Engine {
         h.push(0);
         h.extend_from_slice(site.as_deref().unwrap_or("").as_bytes());
         h.push(0);
-        if scss::is_sass_path(path) || (path.ends_with(".astro") && scss::uses_sass(&String::from_utf8_lossy(data))) {
+        if scss::is_sass_path(path) || (path.ends_with(".astro") && scss::uses_sass(&String::from_utf8_lossy(&data))) {
             h.extend_from_slice(&scss::fingerprint(tenant).to_le_bytes());
         }
-        h.extend_from_slice(data);
+        h.extend_from_slice(&data);
         let key = xxh3_128(&h);
         if let Some(b) = self.cached(key) {
             return Ok(b);
         }
+        self.within_caps(path, kind, &data)?;
         let _permit = self.gate.enter().map_err(|e| BuildError::busy(format!("{path}: {e}")))?;
         let started = Instant::now();
-        let spawned = self.on_parser_stack(|| {
-            let _compiling = Compiling::enter();
-            self.compile(tenant, path, kind, data, site.as_deref())
-        });
+        let compiled = self.bounded(tenant, path, kind, data, site);
         self.metrics.compiled(kind, started.elapsed());
-        let compiled = spawned.map_err(|e| BuildError::compile(format!("{path}: cannot start a compiler thread: {e}"), vec![]))?;
         let built = Arc::new(compiled?);
         self.insert(key, built.clone());
         Ok(built)
+    }
+
+    /// The size and nesting caps, before a compile takes a permit or a thread: a source that cannot
+    /// be compiled has no business queueing for the right to try.
+    fn within_caps(&self, path: &str, kind: Kind, data: &[u8]) -> Result<(), BuildError> {
+        let ext = path.rsplit_once('.').map(|(_, e)| e).unwrap_or("").to_ascii_lowercase();
+        if kind != Kind::Module || !parses_source(&ext) {
+            return Ok(());
+        }
+        let max = self.cfg.max_source_bytes;
+        if data.len() > max {
+            let text = format!("file too large to compile: {} KiB, limit {} KiB", data.len() / 1024, max / 1024);
+            return Err(refused(path, text, "raise --max-source-kb, or split the file"));
+        }
+        let depth = nesting_depth(data);
+        if depth > MAX_NESTING_DEPTH {
+            let text = format!("source nests {depth} deep, limit {MAX_NESTING_DEPTH}");
+            return Err(refused(path, text, "unbalanced brackets are the usual cause"));
+        }
+        Ok(())
+    }
+
+    /// One compile, on a thread of its own, with a wall-clock deadline. `astro_codegen`, oxc and
+    /// satteri-mdxjs are synchronous and offer no cancellation, so a compile that overruns is
+    /// abandoned rather than joined: the request is answered with a diagnostic, the gate permit goes
+    /// back to the pool the moment this returns, and the thread is counted under `runaway` until it
+    /// ends on its own. The thread outlives the request, so everything it may touch is owned — an
+    /// `Engine` handle, the tenant, the source bytes.
+    ///
+    /// A `?type=style` or `?type=script` build asks for its module from inside its own compile. That
+    /// inner build runs here on the stack and under the deadline its parent already has, which is
+    /// what keeps one request to one thread and one permit.
+    fn bounded(&self, tenant: &Arc<Tenant>, path: &str, kind: Kind, data: Arc<[u8]>, site: Option<String>) -> Result<Built, BuildError> {
+        if ON_PARSER_STACK.get() {
+            let _compiling = Compiling::enter();
+            return self.compile(tenant, path, kind, &data, site.as_deref());
+        }
+        let flight = Arc::new(Flight { done: Mutex::new(None), ready: Condvar::new(), state: AtomicU8::new(RUNNING) });
+        let (engine, t, owned, mine) = (self.clone(), tenant.clone(), path.to_string(), flight.clone());
+        let spawned = std::thread::Builder::new().name("compile".into()).stack_size(self.parser_stack_bytes()).spawn(move || {
+            ON_PARSER_STACK.set(true);
+            let _compiling = Compiling::enter();
+            let out = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| engine.compile(&t, &owned, kind, &data, site.as_deref())));
+            *mine.done.lock().unwrap() = Some(out);
+            mine.ready.notify_all();
+            engine.gate.settled(&mine.state);
+        });
+        if let Err(e) = spawned {
+            return Err(BuildError::compile(format!("{path}: cannot start a compiler thread: {e}"), vec![]));
+        }
+        #[cfg(test)]
+        SPAWNED.set(SPAWNED.get() + 1);
+        let deadline = Instant::now() + self.cfg.compile_timeout;
+        let mut done = flight.done.lock().unwrap();
+        loop {
+            if let Some(out) = done.take() {
+                drop(done);
+                return out.unwrap_or_else(|payload| std::panic::resume_unwind(payload));
+            }
+            let Some(left) = deadline.checked_duration_since(Instant::now()) else { break };
+            done = flight.ready.wait_timeout(done, left).unwrap().0;
+        }
+        drop(done);
+        self.gate.overran(&flight.state);
+        let ms = self.cfg.compile_timeout.as_millis();
+        Err(refused(
+            path,
+            format!("compile did not finish within {ms} ms"),
+            "the compilers cannot be interrupted, so the thread was left to run out; raise --compile-timeout-ms, or split the file",
+        ))
     }
 
     /// Only ever called for content the tenant holds, so a fingerprint here is one a page could
@@ -505,19 +665,19 @@ impl Engine {
     /// `<style>` blocks, so those swap instead. Everything else reloads, and so does anything this
     /// cannot prove: an `.astro` file nothing has built yet, one that no longer compiles, one whose
     /// hoisted `<script>` changed.
-    pub fn update_kind(&self, tenant: &Tenant, path: &str, bytes: &[u8]) -> UpdateKind {
+    pub fn update_kind(&self, tenant: &Arc<Tenant>, path: &str, bytes: &[u8]) -> UpdateKind {
         if !path.ends_with(".astro") {
             return UpdateKind::from_path(path);
         }
         let before = self.last_js.lock().unwrap().get(&(tenant.id.clone(), path.to_string())).copied();
         let Some(before) = before else { return UpdateKind::Module };
-        match self.build_bytes(tenant, path, Kind::Module, bytes) {
+        match self.build_bytes(tenant, path, Kind::Module, Arc::from(bytes)) {
             Ok(built) if module_fingerprint(&built) == before => UpdateKind::Style,
             _ => UpdateKind::Module,
         }
     }
 
-    fn compile(&self, tenant: &Tenant, path: &str, kind: Kind, data: &[u8], site: Option<&str>) -> Result<Built, BuildError> {
+    fn compile(&self, tenant: &Arc<Tenant>, path: &str, kind: Kind, data: &[u8], site: Option<&str>) -> Result<Built, BuildError> {
         let text = || String::from_utf8_lossy(data).into_owned();
         match kind {
             Kind::Url => Ok(Built::js(format!("export default {};\n", json_str(&format!("/__sl/raw/{path}"))))),
@@ -540,18 +700,6 @@ impl Engine {
             }
             Kind::Module => {
                 let ext = path.rsplit_once('.').map(|(_, e)| e).unwrap_or("").to_ascii_lowercase();
-                if parses_source(&ext) {
-                    let max = self.cfg.max_source_bytes;
-                    if data.len() > max {
-                        let text = format!("file too large to compile: {} KiB, limit {} KiB", data.len() / 1024, max / 1024);
-                        return Err(refused(path, text, "raise --max-source-kb, or split the file"));
-                    }
-                    let depth = nesting_depth(data);
-                    if depth > MAX_NESTING_DEPTH {
-                        let text = format!("source nests {depth} deep, limit {MAX_NESTING_DEPTH}");
-                        return Err(refused(path, text, "unbalanced brackets are the usual cause"));
-                    }
-                }
                 match ext.as_str() {
                     "astro" => {
                         let dir = dirname(path);
@@ -621,7 +769,7 @@ impl Engine {
         }
     }
 
-    pub fn serve(&self, tenant: &Tenant, path: &str, kind: Kind, resolver: &Resolver) -> Result<(String, &'static str), BuildError> {
+    pub fn serve(&self, tenant: &Arc<Tenant>, path: &str, kind: Kind, resolver: &Resolver) -> Result<(String, &'static str), BuildError> {
         let built = self.build(tenant, path, kind)?;
         let mut edits: Vec<(usize, usize, String)> =
             built.specs.iter().chain(&built.component_paths).map(|s| (s.start, s.end, resolver.resolve(path, &s.spec))).collect();
@@ -751,7 +899,7 @@ mod tests {
         Engine::new(Config { cache_bytes: 1 << 20, ..Config::default() }, Arc::new(crate::metrics::Metrics::default()))
     }
 
-    fn served(engine: &Engine, tenant: &Tenant) -> String {
+    fn served(engine: &Engine, tenant: &Arc<Tenant>) -> String {
         engine.serve(tenant, PAGE_PATH, Kind::Module, &Resolver::new(tenant, "https://esm.sh", 7).unwrap()).unwrap().0
     }
 
@@ -765,9 +913,14 @@ mod tests {
         tenant(&[(path, source)])
     }
 
-    /// The queue deadline is not a flag, so tests reach past `Engine::new` to shorten it.
+    /// Neither the queue deadline nor the runaway cap is a flag, so tests build the gate directly.
     fn engine_gated(cfg: Config, limit: usize, wait: Duration) -> Engine {
-        Engine { gate: Gate::new(limit, wait), ..Engine::new(cfg, Arc::new(crate::metrics::Metrics::default())) }
+        engine_bounded(cfg, limit, wait, MAX_RUNAWAY_COMPILES)
+    }
+
+    fn engine_bounded(cfg: Config, limit: usize, wait: Duration, max_runaway: usize) -> Engine {
+        let metrics = Arc::new(crate::metrics::Metrics::default());
+        Engine::with_gate(cfg, metrics, Gate::new(limit, wait, max_runaway))
     }
 
     fn capped(max_source_bytes: usize) -> Config {
@@ -966,7 +1119,7 @@ mod tests {
             assert_eq!(e.status, 503, "{}", e.message);
             assert_eq!(SPAWNED.get(), 0, "a refused compile reserves no stack");
             let stats = engine.compile_stats();
-            assert_eq!((stats.limit, stats.queued, stats.refused), (2, 0, 1));
+            assert_eq!((stats.limit, stats.queued, stats.refused, stats.runaway), (2, 0, 1, 0));
             let stacks: usize = busy.into_iter().map(|h| h.join().unwrap()).sum();
             assert_eq!(stacks, 2, "three concurrent compiles, two stacks");
         });
@@ -991,9 +1144,54 @@ mod tests {
         let t = tenant(&[("src/hit.ts", "export const x = 1;\n"), ("src/miss.ts", "export const y = 2;\n")]);
         let engine = engine_gated(capped(CAP), 1, Duration::from_millis(50));
         engine.build(&t, "src/hit.ts", Kind::Module).unwrap();
-        let closed = Engine { gate: Gate::new(0, Duration::from_millis(50)), ..engine };
-        assert!(closed.build(&t, "src/hit.ts", Kind::Module).is_ok());
-        assert_eq!(build_err(closed.build(&t, "src/miss.ts", Kind::Module)).status, 503);
+        engine.gate.limit.store(0, Ordering::Relaxed);
+        assert!(engine.build(&t, "src/hit.ts", Kind::Module).is_ok());
+        assert_eq!(build_err(engine.build(&t, "src/miss.ts", Kind::Module)).status, 503);
+    }
+
+    /// A stylesheet that grass will not finish inside the deadline. Sass has a deadline of its own,
+    /// so this test keeps that one long: what is under test is the compile deadline around it.
+    fn slow_source() -> String {
+        "@for $i from 1 through 300000 { $unused: $i * 2; }".to_string()
+    }
+
+    /// Issue #63: one tenant's file must not remove a permit from the pool for as long as it runs.
+    /// `astro_codegen`, oxc and satteri-mdxjs cannot be interrupted, so the thread is abandoned —
+    /// but the permit comes back with the answer, and the next tenant compiles on it.
+    #[test]
+    fn a_compile_past_its_deadline_gives_its_permit_back() {
+        let slow = tenant_with("src/slow.scss", &slow_source());
+        let ordinary = tenant_with("src/page.astro", "<p>hi</p>\n");
+        let cfg = Config { compile_timeout: Duration::from_millis(200), ..capped(CAP) };
+        let engine = engine_gated(cfg, 1, Duration::from_millis(50));
+
+        let started = Instant::now();
+        let e = build_err(engine.build(&slow, "src/slow.scss", Kind::Module));
+        assert!(e.message.contains("compile did not finish within 200 ms"), "{}", e.message);
+        assert_eq!(e.diagnostics.len(), 1);
+        assert!(started.elapsed() < Duration::from_secs(5), "the request waited {:?}", started.elapsed());
+
+        let stats = engine.compile_stats();
+        assert_eq!((stats.running, stats.runaway, stats.timeouts), (0, 1, 1), "the permit is back and the thread is counted");
+        // The gate holds one permit and the runaway thread is still burning a core on it.
+        assert!(engine.build(&ordinary, "src/page.astro", Kind::Module).is_ok());
+    }
+
+    /// Nothing can take a runaway's core back, so past the cap the honest answer is 503 rather than
+    /// another abandoned thread.
+    #[test]
+    fn compilation_is_refused_once_too_many_runaways_pile_up() {
+        let t = tenant(&[("src/a.scss", slow_source().as_str()), ("src/b.scss", &format!("{} // b", slow_source()))]);
+        let cfg = Config { compile_timeout: Duration::from_millis(200), ..capped(CAP) };
+        let engine = engine_bounded(cfg, 4, Duration::from_millis(50), 1);
+
+        assert!(build_err(engine.build(&t, "src/a.scss", Kind::Module)).message.contains("did not finish"));
+        assert_eq!(engine.compile_stats().runaway, 1);
+
+        let e = build_err(engine.build(&t, "src/b.scss", Kind::Module));
+        assert_eq!(e.status, 503);
+        assert!(e.message.contains("past their deadline"), "{}", e.message);
+        assert_eq!(engine.compile_stats().refused, 1);
     }
 
     const CARD: &str = "---\nconst n = 1;\n---\n<p>{n}</p>\n<style>p{color:red}</style>\n<script>console.log(1)</script>\n";


### PR DESCRIPTION
Closes #63

Two changes. They are separable, and **the deadline is the real bound** — the
slug fix removes the one shape we know about, the deadline is what holds for the
next one.

## 1. The cost itself: heading ids are no longer cubic

`unique()` assigned each id by rescanning the ids already handed out, so the
*i*-th heading cost O(i) probes of an O(i) scan and a page cost O(n³).
`content::Slugs` now keeps a per-base-slug counter beside a `HashSet` of ids
taken: the counter never restarts, so a probe is O(1) amortised and the failed
probes over a whole page are bounded by the ids actually in use.

Measured on this machine, **debug** build, `compile("x.mdx", &"# a\n".repeat(n))`
— the issue's table is release, so these are not the same numbers, but they are
the same curve:

| n | source | before | after |
|---|---|---|---|
| 200 | 800 B | 17.4 ms | 5.0 ms |
| 400 | 1.6 KB | 104 ms | 8.1 ms |
| 800 | 3.2 KB | 752 ms | 16.0 ms |
| 1600 | 6.4 KB | 5.25 s | 31.8 ms |
| 3200 | 12.8 KB | 39.7 s | 64.1 ms |
| 6400 | 25.6 KB | (~5 min, extrapolated) | 129 ms |
| 12800 | 51.2 KB | — | 269 ms |
| 16384 | 65.5 KB | — | 331 ms |

Before: each doubling costs 7–8x. After: each doubling costs 2x. 16384 headings
is what the default `--max-source-kb 64` admits — the worst case the daemon will
accept is 331 ms in debug where the issue measured ~40 minutes in release.

End to end through the daemon (debug binary, `PUT` then
`GET /__sl/m/src/pages/headings.mdx`, 16000 headings, 64 KB of source): **1.10 s**
for a 2.38 MB module, with `"a-15999"` in `getHeadings()`. That request is now a
CI step, so a regression to the old curve fails the smoke test rather than
quietly costing a core.

## 2. The bound: a deadline on every compile

A permit is only a bound if something takes it back. `astro_codegen`, oxc and
satteri-mdxjs are synchronous and offer no cancellation, so every compile now
runs on a thread of its own with a wall-clock deadline — the shape `scss.rs` has
used since #35:

- `--compile-timeout-ms`, default 10000, `SANDBOX_LITE_COMPILE_TIMEOUT_MS` as the
  env default; in the usage string and the README flags table.
- Past the deadline the request is answered with a **diagnostic** (500 + a `Diag`,
  like the size and nesting caps) and **the gate permit goes back to the pool**.
- The thread cannot be stopped, so it is abandoned and counted:
  `compiles.runaway` and `compiles.timeouts` in `/api/stats`,
  `sandbox_lite_compiles_runaway` (gauge) and
  `sandbox_lite_compiles_timeouts_total` (counter) in `/metrics` — the same pair
  Sass runaways already had.
- **Eight runaways is the cap.** Past that `Gate::enter` refuses with 503 rather
  than starting a ninth abandoned thread, counted under `compiles.refused`.

Because the thread outlives the request it owns everything it may still touch, so
`Engine` is now a handle to a shared `EngineInner` and `build`/`serve`/`update_kind`
take `&Arc<Tenant>`. A `?type=style` or `?type=script` build still asks for its
module from inside its own compile, so it still runs on one thread, under one
permit and under one deadline — the two `reserves_one_stack_not_two` tests are
unchanged and still pass.

The size and nesting caps moved ahead of the permit and the thread: a source that
cannot be compiled has no business queueing for the right to try.

## 3. No new pre-scan limit

The brief was to extend the pre-scan only where measurement shows what it must
count. Once ids are O(1) the repeated-heading shape is linear (table above), so a
heading count is not a bound anything needs — it would only refuse legitimate long
documents. `nesting_depth` is unchanged.

## Tests

- `transform::mdx::tests::repeated_headings_are_not_cubic` — the issue's own
  repro: `"# a\n".repeat(6400)` compiles in under 2 s and the last id is `a-6399`.
  It runs in ~130 ms; before this change it was ~5 min in debug.
- `transform::tests::a_compile_past_its_deadline_gives_its_permit_back` — a
  compile that overruns a 200 ms deadline answers with a diagnostic, leaves
  `running: 0, runaway: 1, timeouts: 1`, and **a second tenant's ordinary
  `.astro` page then compiles on the single permit while the runaway is still in
  flight**.
- `transform::tests::compilation_is_refused_once_too_many_runaways_pile_up` —
  with the cap at 1, the next compile is refused 503 with "past their deadline".
- `transform::content::tests::markdown_headings_are_uniquified_like_mdx` and
  `slugs_advance_without_rescanning_and_skip_what_is_taken`.
- Smoke test: the 64 KB headings page compiles and serves; the two new metric
  families render; `/api/stats` reports `compiles.runaway` and `compiles.timeouts`.

The deadline test uses a 200 ms deadline in the test config, not the 10 s
production default; the whole suite runs in ~5 s.

## Also

`.md` did not uniquify slugs at all, so `getHeadings()` disagreed with the same
page written as `.mdx` (the issue's closing note). Both now go through
`content::Slugs`. `.md` heading ids are only reported through `getHeadings()` —
the HTML pulldown-cmark emits carries no `id` attributes either way, so nothing
in a rendered page moves.

## CI

Green on `43499ac` in
[run 34062531209](https://github.com/productdevbook/sandbox-lite/actions/runs/34062531209):
`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`,
the release build, `sandbox-lite check` over all five examples, the smoke test,
`bench/mem.sh 100`, `bench/vs-astro-dev.sh` and Playwright.

`bench/mem.sh 100` is unmoved by the deadline machinery — 7.6 MB idle, 14.6 MB
after 100 tenants, 70.2 kB per tenant, against 72 kB per tenant in the README's
current figures.

## Noticed, did not fix

- `content::config` and `content::collection_json` reach oxc through
  `Engine::on_parser_stack` from `/__sl/content/{name}`, outside `build_bytes`.
  They have the size and nesting caps from #48 but **no permit and no deadline**,
  so a pathological `src/content.config.ts` still holds a request thread with
  nothing to take it back.
- A compile abandoned at the deadline throws its work away and nothing keys
  runaways by source. Sass refuses a *second* compile of a source a runaway
  already holds; the compile gate only counts the total, so eight requests for
  the same runaway file are eight threads rather than one plus seven refusals.
- `metrics.compiled` records the deadline as the duration of a compile that
  overran it, so the histogram's tail mixes "took 10 s" with "gave up at 10 s".
- `collect_headings`'s `existing` branch — a heading that already carries an `id`
  prop — looks unreachable: an authored `<h1 id="x">` in MDX becomes an MDX JSX
  element, not a hast element, so nothing sets an id before this pass. I kept the
  branch and made it claim the id, but no test can exercise it. Someone should
  count its callers rather than read it.
- `--compile-timeout-ms 0` is accepted and would refuse every compile. No numeric
  flag here validates its range, so this one does not either.
- Issue #26 stands: nothing reclaims a runaway's core or its allocations. Only a
  child process with rlimits would.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
