### PR TITLE
report what is actually true: restore failures, stale swaps, the endpoint census

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
           curl -sf http://127.0.0.1:4399/metrics > /tmp/metrics.txt
           grep -qxF '# TYPE sandbox_lite_tenants gauge' /tmp/metrics.txt
           grep -qxF 'sandbox_lite_tenants 1' /tmp/metrics.txt
+          # issue #61: a tenant that will not load must be countable, so the gauge has to exist at zero
+          grep -qxF '# TYPE sandbox_lite_tenants_failed gauge' /tmp/metrics.txt
+          grep -qxF 'sandbox_lite_tenants_failed 0' /tmp/metrics.txt
           grep -qxF '# TYPE sandbox_lite_cache_hits_total counter' /tmp/metrics.txt
           grep -qxF '# TYPE sandbox_lite_sass_runaway gauge' /tmp/metrics.txt
           grep -qxF 'sandbox_lite_screenshots_running 0' /tmp/metrics.txt

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -58,8 +58,10 @@ same base share the base's memory; a tenant costs its overlay.
 Each tenant has a **version**, a `u64` of milliseconds since the epoch at
 creation. `write` and `delete` call `bump`, which sets it to
 `max(now, previous + 1)` — strictly increasing — and sends
-`{"type":"update"|"delete","path":…,"kind":…,"version":N}` on the tenant's
-`tokio::sync::broadcast` channel (64 slots). Both SSE endpoints
+`{"type":"update"|"delete","path":…,"kind":…,"version":N,"prev":P}` on the tenant's
+`tokio::sync::broadcast` channel (64 slots). `prev` is the version the event
+follows, and it is what lets a client tell a message it missed from one it did
+not — see "CSS without a reload". Both SSE endpoints
 (`/api/t/{id}/events`, `/__sl/events`) subscribe to that channel and open with
 an `event: hello` carrying the current version.
 
@@ -87,11 +89,24 @@ With a `--data-dir`, the overlay is persisted as
 `<data-dir>/<id>/tenant.json` (`{"base": name}`), `<data-dir>/<id>/files/<path>`
 and `<data-dir>/<id>/deleted.json` (the tombstones). Every write goes to disk;
 files over 256 KiB are then kept only there. `Store::restore` rebuilds tenants
-at startup with a fresh version and skips any whose base is not loaded.
-`Store::tenant` falls back to the same read on a miss, so a tenant another
+at startup with a fresh version and skips any it cannot build one from — a base
+this node has not loaded, an unreadable `tenant.json`. Skipping is right; being
+silent about it was not (issue #61), so each skipped id and its reason is kept
+in `Store::failed`, reported by `Store::failed_tenants` and rendered as
+`tenants_failed` and `failed_tenants` in `/api/stats`, the
+`sandbox_lite_tenants_failed` gauge in `/metrics`, a line on stderr at startup
+and a banner in the editor's header.
+
+`Store::resolve` falls back to the same read on a miss, so a tenant another
 daemon created under a shared `--data-dir` is restored the first time this one
 is asked for it; a tenant already in memory is never re-read, which is the
-limit `docs/multi-node.md` sets out. `--no-persist` keeps everything in memory.
+limit `docs/multi-node.md` sets out. It answers `NoTenant::Unknown` when
+neither the map nor the data directory holds the id and `NoTenant::Failed(why)`
+when `<data-dir>/<id>` is there and would not load — recording it the way
+`restore` does — so the HTTP layer can answer 404 for a tenant that never
+existed and 500 with the reason for one that could not be loaded. `Store::tenant`
+is `resolve(…).ok()`, for the callers that only need to know whether it is here.
+`--no-persist` keeps everything in memory.
 
 Because that fallback makes the data directory as much a source of tenants as
 the map, the two operations that decide whether a tenant exists consult both:
@@ -518,6 +533,13 @@ The version does three jobs:
   restart, since restored tenants get a fresh version. A swap sets
   `window.__sl.version` to the version it applied, so a later reconnect does
   not read the page as stale.
+- **Gap detection.** Each event's `prev` is the version it follows, and
+  `live.js` swaps only when `prev` is the version the page last rendered. A
+  message dropped on a connection that stayed open — a backgrounded tab, a
+  lagging stream — leaves the page behind that chain, and the next event
+  reloads it instead of swapping (issue #62). Without this, a lost `module`
+  event left the page running stale JS and every later style-only write was
+  swapped in over it, indefinitely.
 - **Editor refresh.** The editor subscribes to `/api/t/{id}/events` to reload
   its file list and the open file.
 
@@ -540,7 +562,8 @@ two of them.
   keyed `<file>?<index>` and re-imported from
   `?astro&type=style&index=<i>&lang.css`.
 - Anything else reloads: a `module` kind, a `delete`, a `write_many`'s empty
-  path, a `kind` the client does not know, a page showing the error overlay
+  path, an event whose `prev` is not the version the page rendered, a `kind` the
+  client does not know, a page showing the error overlay
   (`<body data-sl-overlay>`), a block the page does not have, or a failed swap.
 
 `Engine::update_kind` decides. It compares the JS the incoming bytes compile to
@@ -608,7 +631,15 @@ source file under `src/` — `is_source`: `.astro`, `.ts`, `.tsx`, `.js`,
 the `.vue` type errors above reachable from the command line. It prints
 diagnostics and a census — islands, glob calls,
 Sass, MDX, endpoints, `@astrojs/*` integrations, bare imports — and exits 1 on
-compile errors, 2 when a directory cannot be loaded. `/api/t/{id}/check` and
+compile errors, 2 when a directory cannot be loaded.
+
+The endpoint count is `routes::build` on that same tenant filtered to
+`kind == "endpoint"`, not a second rule over the file names: counting
+`src/pages/**.ts|.js` by hand missed `.mjs` and `.mts` and counted
+`_`-prefixed files the router skips, so a project written in `.mjs` censused as
+"endpoints 0" (issue #76). The MDX count stays wider than the route table on
+purpose — every `.mdx` file in the tree, because a collection entry is MDX the
+preview must support as much as a page is. `/api/t/{id}/check` and
 `/__sl/check` run the same loop (`api::check_tenant`) on a live tenant; the
 error page uses the latter as its fallback.
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ and `.scss` files, compiled in-process) and Tailwind v4 (via its browser
 build); content collections (`getCollection`, `getEntry`, `render`); Markdown
 pages with `layout:`; MDX pages and MDX collection entries (compiled
 in-process with Astro's `satteri-mdxjs`, rendered with Astro's JSX runtime);
-endpoints (`src/pages/rss.xml.ts`, `src/pages/api/*.json.ts`: the `GET` handler
+endpoints (`src/pages/rss.xml.ts`, `src/pages/api/*.json.ts`, and the same in
+`.js`, `.mjs` or `.mts`: the `GET` handler
 runs in the browser and its `Response` is shown);
 dynamic routes with `getStaticPaths` and `paginate`;
 `import.meta.glob` (eager and lazy, `import:`/`query:` options); `import.meta.env`
@@ -262,7 +263,12 @@ sandbox-lite check [--json] examples/starter path/to/other-theme ...
 
 Compiles every source file the way the preview would and prints diagnostics
 plus a feature census: how many islands, `import.meta.glob` calls, Sass files,
-MDX pages, endpoints, integrations and npm imports a project uses. Run it over a
+MDX files, endpoints, integrations and npm imports a project uses. The endpoint
+count is the route table's own — `routes::build` filtered to `kind ==
+"endpoint"` — so it takes every extension the router takes (`.ts`, `.js`,
+`.mjs`, `.mts`) and skips `_`-prefixed files the way the preview does. The MDX
+count is deliberately wider than the route table: a collection entry is MDX the
+preview has to support too. Run it over a
 theme catalogue before deciding what the preview must support; the exit code is
 non-zero when any file fails to compile, so it doubles as a CI check.
 
@@ -315,7 +321,9 @@ curl -fsS -X POST --data-binary @acme.tar.gz localhost:4321/api/tenants/acme-cop
 ```
 
 `/metrics` is scrapeable as it is — no exporter, no client library. It carries
-`sandbox_lite_tenants`, `sandbox_lite_overlay_bytes`, `sandbox_lite_cache_*`,
+`sandbox_lite_tenants`, `sandbox_lite_tenants_failed` (tenant directories
+under `--data-dir` this daemon could not load; their ids are in `/api/stats`),
+`sandbox_lite_overlay_bytes`, `sandbox_lite_cache_*`,
 `sandbox_lite_sse_subscribers`, `sandbox_lite_rss_bytes`,
 `sandbox_lite_uptime_seconds`, one series per base, `sandbox_lite_sass_*`
 (running, runaway, timeouts, refusals), `sandbox_lite_compiles_*` (permits
@@ -401,14 +409,16 @@ the two configurations that work — is [`docs/multi-node.md`](docs/multi-node.m
 6. `experimental_AstroContainer.renderToResponse()` produces the HTML;
    `document.write` replaces the shell with it, so scripts, links and relative
    URLs behave like a normal page.
-7. A `.ts`/`.js` file under `src/pages` is an endpoint: the same call with
+7. A `.ts`, `.js`, `.mjs` or `.mts` file under `src/pages` is an endpoint: the same call with
    `routeType: "endpoint"` runs its `GET` (or `ALL`) handler with an
    `APIContext`. An HTML response is written as a page; anything else — XML,
    JSON, plain text — is shown with its status and content-type above the body.
 8. `live.js` holds an `EventSource`. Each event carries a `kind`: a `.css`,
    `.scss` or `.sass` write is `css`, an `.astro` write whose compiled JS is
    byte-identical to the last build changed only its `<style>` blocks and is
-   `style`, and everything else is `module`. On `css` and `style` the CSS
+   `style`, and everything else is `module`. It also carries `prev`, the
+   version it follows, and a client whose page rendered some other version has
+   missed a message and reloads rather than swapping. On `css` and `style` the CSS
    module is re-imported and the matching `<style data-sl=…>` swapped in place,
    leaving the page's DOM and JS state alone; a stylesheet the page only reaches
    through another sheet's `@import` has no block of its own, so the importing

--- a/assets/editor.html
+++ b/assets/editor.html
@@ -15,6 +15,7 @@ button{cursor:pointer;background:#1d2230}button:hover{border-color:var(--accent)
 button:disabled{opacity:.5;cursor:default}
 .stat{margin-left:auto;color:var(--muted);font-variant-numeric:tabular-nums;white-space:nowrap}
 .stat b{color:var(--ok)}
+#failed{color:var(--err);border:1px solid var(--err);border-radius:6px;padding:3px 8px;cursor:help;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:40%}
 #left{grid-area:left;display:grid;grid-template-rows:auto minmax(120px,32%) 1fr;border-right:1px solid var(--line);min-height:0}
 #tabs{display:flex;gap:2px;padding:6px 8px 0;border-bottom:1px solid var(--line);background:var(--panel)}
 #tabs button{border-radius:6px 6px 0 0;border-bottom:none;background:transparent}
@@ -54,6 +55,7 @@ dialog form{display:grid;gap:8px}dialog::backdrop{background:rgba(0,0,0,.5)}
   <select id="tenant"></select>
   <button id="newTenant">+ tenant</button>
   <button id="delTenant" title="delete this tenant">✕</button>
+  <div id="failed" hidden></div>
   <div class="stat" id="stat">…</div>
 </header>
 <section id="left">
@@ -107,6 +109,13 @@ async function refreshStats() {
   const sum = (o) => Object.values(o).reduce((a, b) => a + b, 0);
   const mods = (s.modules || []).reduce((a, m) => ({ requests: a.requests + sum(m.requests), compiles: a.compiles + m.compiles, seconds: a.seconds + m.compile_seconds }), { requests: 0, compiles: 0, seconds: 0 });
   $("#stat").innerHTML = `daemon RSS <b>${esc(fmtKB(s.rss_kb))}</b> · ${esc(s.tenants)} tenants · cache ${esc((s.cache.bytes / 1024).toFixed(0))} kB / ${esc(s.cache.entries)} · ${esc(mods.requests)} module requests · ${esc(mods.compiles)} compiles in ${esc(mods.seconds.toFixed(1))}s · astro ${esc(s.astro)} · chat ${esc(s.ai ? "on" : "off")}`;
+  // A tenant under --data-dir that would not load is not in the tenant list at all: without this
+  // the daemon reports itself healthy while a customer's site answers 500.
+  const failed = s.failed_tenants || [];
+  const banner = $("#failed");
+  banner.hidden = failed.length === 0;
+  banner.textContent = failed.length ? `⚠ ${failed.length} tenant${failed.length === 1 ? "" : "s"} failed to load: ${failed.map((f) => f.id).join(", ")}` : "";
+  banner.title = failed.map((f) => `${f.id}: ${f.error}`).join("\n");
   $("#chatSend").disabled = !s.ai || state.busy;
   if (!s.ai) $("#chatHint").textContent = "Chat is off: start the daemon with ANTHROPIC_API_KEY set to enable the built-in assistant. The file editor works without it.";
 }

--- a/assets/live.js
+++ b/assets/live.js
@@ -64,6 +64,15 @@
     return true;
   }
 
+  // Every event names the version it follows. A swap is only sound on a page that rendered exactly
+  // that one: a `module` event lost on a stream that stayed open leaves the page's JS behind, and
+  // the next style-only write would then be swapped in over stale markup for good. So a gap in the
+  // sequence reloads, which is what makes a lost message self-correcting.
+  function follows(d) {
+    const at = window.__sl && window.__sl.version;
+    return typeof at === "number" && d.prev === at;
+  }
+
   es.addEventListener("hello", (e) => {
     const v = Number(e.data);
     if (window.__sl && window.__sl.version && v > window.__sl.version) reload();
@@ -72,7 +81,7 @@
     let d;
     try { d = JSON.parse(e.data); } catch { return; }
     if (d.type !== "update" && d.type !== "delete") return;
-    if (d.type === "delete" || !d.path) return reload();
+    if (d.type === "delete" || !d.path || !follows(d)) return reload();
     swap(d).then((swapped) => {
       // the page now matches this version, so a reconnect's hello must not send it back
       if (swapped && window.__sl) window.__sl.version = d.version;

--- a/docs/multi-node.md
+++ b/docs/multi-node.md
@@ -37,14 +37,15 @@ So with two daemons, A and B, sharing `--data-dir`:
 | `PUT /api/t/acme/file/src/pages/index.astro` on A | A's overlay and `<data-dir>/acme/files/…` both change. B's overlay does not. |
 | A preview open against B | B still serves its own copy of the file, at its own version. It gets no event, so it does not reload. |
 | `GET /api/t/acme/files` on B | B's view: the files it knows about, at B's version. |
-| A tenant created on A, then a request for it on B | B has no such tenant in memory, so it restores one from `<data-dir>/acme` and serves it (`Store::tenant`). |
+| A tenant created on A, then a request for it on B | B has no such tenant in memory, so it restores one from `<data-dir>/acme` and serves it (`Store::resolve`). |
+| The same, but on a base B has not loaded | B cannot build a tenant from the directory. It answers 500 naming the base rather than 404 "unknown tenant", and counts the id under `tenants_failed` in `/api/stats` and `sandbox_lite_tenants_failed` in `/metrics`, so the gap is visible instead of reading as a tenant that never existed. |
 | A writes again after B has restored | B does not see it. The restore happens once, on the miss. |
 | `DELETE /api/tenants/acme` on A | The directory goes, whether or not A had the tenant loaded — a node deletes what the data directory holds, not only what its map does. B keeps serving the tenant it already holds in memory; a B that had not loaded it has nothing left to restore. |
 | Creating `acme` on B while A's `acme` is on disk | Refused. The directory is what says the tenant exists, so B says so too, even when it cannot build a tenant from it because A's base is not loaded here. |
 | `POST /api/bases/theme/reload` on A | Only A re-reads the base. B keeps the copy it loaded. |
 | `POST /api/t/acme/chat` on A, then `GET /api/t/acme/chats` on B | B lists it: conversations are read from the shared data directory on every call, not cached. |
 | `POST /api/tenants/acme/import` on A | A's overlay and the data directory change; B's overlay does not, exactly as for a single write. |
-| `/api/stats`, `/metrics` on B | B's own tenants, cache and subscribers. Neither number is a cluster total. The chats figures are counters B keeps as it saves and evicts, seeded from the directory the first time it touches a tenant, so what A writes afterwards is not in them either. |
+| `/api/stats`, `/metrics` on B | B's own tenants, cache and subscribers — `tenants_failed` included, which counts the directories B could not load and says nothing about A. The chats figures are counters B keeps as it saves and evicts, seeded from the directory the first time it touches a tenant, so what A writes afterwards is not in them either. Neither number is a cluster total. |
 
 The version being per node also means a browser that moves from A to B
 mid-session gets a lower `?v=` than it had. That is harmless — the daemon never

--- a/e2e/live-reload.spec.ts
+++ b/e2e/live-reload.spec.ts
@@ -71,3 +71,48 @@ test('an edit to the frontmatter still reloads', async ({ daemon, page }) => {
   await expect(page.locator('h1')).toHaveText('Design that reloads.', { timeout: 5_000 });
   expect(await marker(page), 'the page was reloaded').toBeUndefined();
 });
+
+// Issue #62: a `module` event lost on a stream that stays open — a backgrounded tab, a network blip —
+// left the page running the JS it had. The next style-only write was then correctly classified
+// `style`, swapped in place, and the page went on showing new CSS over stale markup indefinitely.
+// Dropping exactly one message from the open EventSource is that failure, reproduced.
+test('a page that missed a module event reloads instead of swapping the next style in', async ({ daemon, page }) => {
+  const site = await daemon.tenant('live-gap', 'starter');
+  await page.goto(site.url('/'));
+  await expect(page.locator('h1')).toHaveText('Design that ships.');
+  await mark(page);
+
+  await page.evaluate(() => {
+    const es = (window as any).__sl_es as EventSource;
+    const deliver = es.onmessage!.bind(es);
+    (window as any).__slDropped = false;
+    es.onmessage = (e: MessageEvent) => {
+      if (!(window as any).__slDropped && JSON.parse(e.data).kind === 'module') {
+        (window as any).__slDropped = true;
+        es.onmessage = deliver;
+        return;
+      }
+      deliver(e);
+    };
+  });
+
+  const index = await site.read('src/pages/index.astro');
+  const edited = index.replace('const headline = "Design that ships.";', 'const headline = "Design that self-corrects.";');
+  expect(edited).not.toBe(index);
+  await site.write('src/pages/index.astro', edited);
+
+  // the event that would have reloaded the page never reached it, so the page still holds the old JS
+  await expect.poll(() => page.evaluate(() => (window as any).__slDropped), { timeout: 5_000 }).toBe(true);
+  expect(await marker(page), 'the dropped event reloaded the page after all').toBe('kept');
+  await expect(page.locator('h1')).toHaveText('Design that ships.');
+
+  // a style-only write follows a version this page never rendered, so it reloads rather than swapping
+  const card = await site.read('src/components/Card.astro');
+  const restyled = card.replace('.card { background: var(--card);', '.card { background: rgb(0, 128, 0);');
+  expect(restyled).not.toBe(card);
+  await site.write('src/components/Card.astro', restyled);
+
+  await expect(page.locator('h1')).toHaveText('Design that self-corrects.', { timeout: 5_000 });
+  expect(await marker(page), 'the page swapped the style in over stale markup').toBeUndefined();
+  await expect(page.locator('article.card').first()).toHaveCSS('background-color', 'rgb(0, 128, 0)');
+});

--- a/src/check.rs
+++ b/src/check.rs
@@ -78,13 +78,16 @@ pub fn inspect(dir: &Path) -> Result<Report, String> {
         integrations: package_deps(&tenant)?.into_iter().map(|(n, _)| n).filter(|n| n.starts_with("@astrojs/")).collect(),
         bare_imports: BTreeSet::new(),
     };
+    // Counted over the route table rather than re-derived from the path, so the census and the
+    // preview cannot disagree about what an endpoint is: `routes::route` also takes `.mjs`/`.mts`
+    // and skips any `_`-prefixed segment (issue #76).
+    report.endpoints = crate::routes::build(&tenant).iter().filter(|r| r.kind == "endpoint").count();
     for entry in tenant.list() {
         let path = entry.path;
+        // Every `.mdx` file, not only the routed ones: a collection entry is MDX the preview has to
+        // support too, which is why this one is deliberately wider than the route table.
         if path.ends_with(".mdx") {
             report.mdx += 1;
-        }
-        if path.starts_with("src/pages/") && (path.ends_with(".ts") || path.ends_with(".js")) {
-            report.endpoints += 1;
         }
         if scss::is_sass_path(&path) {
             report.sass += 1;
@@ -169,7 +172,67 @@ pub fn run(dirs: &[std::path::PathBuf], json: bool) -> i32 {
 
 #[cfg(test)]
 mod tests {
-    use super::is_npm_import;
+    use std::path::Path;
+
+    use super::{inspect, is_npm_import};
+    use crate::store::{Base, Store};
+
+    fn seed(root: &Path, files: &[(&str, &str)]) {
+        let _ = std::fs::remove_dir_all(root);
+        for (path, body) in files {
+            let full = root.join(path);
+            std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+            std::fs::write(full, body).unwrap();
+        }
+    }
+
+    /// Issue #76: the census counted `src/pages/**.ts|.js` while `routes::route` routes `.ts`, `.js`,
+    /// `.mjs` and `.mts` and skips any `_`-prefixed segment. A project written in `.mjs` reported
+    /// "endpoints 0", and `_helpers.ts` counted as a route that does not exist.
+    #[test]
+    fn the_endpoint_census_is_the_route_table() {
+        let handler = "export function GET() { return new Response(\"ok\"); }\n";
+        let root = std::env::temp_dir().join(format!("sandbox-lite-census-{}", std::process::id()));
+        seed(
+            &root,
+            &[
+                ("src/pages/index.astro", "<h1>home</h1>\n"),
+                ("src/pages/about.md", "# about\n"),
+                ("src/pages/note.mdx", "# note\n"),
+                ("src/pages/rss.xml.ts", handler),
+                ("src/pages/sitemap.js", handler),
+                ("src/pages/feed.mjs", handler),
+                ("src/pages/atom.mts", handler),
+                ("src/pages/api/products.json.ts", handler),
+                // not routes: routes.rs skips any path with a `_`-prefixed segment
+                ("src/pages/_helpers.ts", "export const n = 1;\n"),
+                ("src/pages/_drafts/hidden.mjs", handler),
+                // not a route either: outside src/pages
+                ("src/lib/data.ts", "export const n = 1;\n"),
+                ("src/content/posts/one.mdx", "# one\n"),
+            ],
+        );
+
+        let report = inspect(&root).unwrap();
+
+        // the same tenant the census walked, so the two answers cannot come from different rules
+        let store = Store::new(None, u64::MAX);
+        store.add_base(Base::load("check", &root).unwrap());
+        let tenant = store.create_tenant("check", "check").unwrap();
+        let mut routed: Vec<String> =
+            crate::routes::build(&tenant).iter().filter(|r| r.kind == "endpoint").map(|r| r.component.clone()).collect();
+        routed.sort();
+        assert_eq!(
+            routed,
+            ["src/pages/api/products.json.ts", "src/pages/atom.mts", "src/pages/feed.mjs", "src/pages/rss.xml.ts", "src/pages/sitemap.js"],
+            "the router takes every one of these extensions and skips the `_` ones"
+        );
+        assert_eq!(report.endpoints, routed.len(), "the census counts exactly what the preview routes");
+        assert_eq!(report.endpoints, 5);
+        // deliberately wider than the route table: a collection entry is MDX the preview must support
+        assert_eq!(report.mdx, 2);
+        std::fs::remove_dir_all(&root).unwrap();
+    }
 
     #[test]
     fn npm_import_filter() {

--- a/src/http/ai.rs
+++ b/src/http/ai.rs
@@ -553,7 +553,10 @@ pub async fn chat(AxState(st): AxState<State>, Path(id): Path<String>, headers: 
     let Some(key) = st.api_key.clone() else {
         return err(StatusCode::SERVICE_UNAVAILABLE, "ANTHROPIC_API_KEY is not set on the daemon");
     };
-    let Some(t) = st.store.tenant(&id) else { return err(StatusCode::NOT_FOUND, "unknown tenant") };
+    let t = match st.store.resolve(&id) {
+        Ok(t) => t,
+        Err(e) => return super::api::no_tenant(&id, e),
+    };
     let conv = match &req.chat {
         Some(chat) => match st.chats.load(&t, chat) {
             Ok(Some(c)) => c,

--- a/src/http/api.rs
+++ b/src/http/api.rs
@@ -14,7 +14,7 @@ use tokio_stream::{Stream, StreamExt};
 
 use super::{AppState, State, mime};
 use crate::metrics::{BaseSize, KINDS, STATUSES, Snapshot, render};
-use crate::store::{Base, Tenant, WriteError, clean_path, valid_id};
+use crate::store::{Base, NoTenant, Tenant, WriteError, clean_path, valid_id};
 use crate::transform::{Engine, Kind, is_source};
 
 pub async fn editor() -> Html<&'static str> {
@@ -29,9 +29,18 @@ pub fn err(status: StatusCode, message: impl Into<String>) -> Response {
     (status, Json(json!({ "error": message.into() }))).into_response()
 }
 
+/// A tenant whose data directory is there and would not load answers 500 with the reason, not 404:
+/// *never existed* and *could not be loaded* are different facts (issue #61).
 #[allow(clippy::result_large_err)]
 pub fn tenant_or_404(st: &AppState, id: &str) -> Result<Arc<Tenant>, Response> {
-    st.store.tenant(id).ok_or_else(|| err(StatusCode::NOT_FOUND, format!("unknown tenant '{id}'")))
+    st.store.resolve(id).map_err(|e| no_tenant(id, e))
+}
+
+pub fn no_tenant(id: &str, e: NoTenant) -> Response {
+    match e {
+        NoTenant::Unknown => err(StatusCode::NOT_FOUND, format!("unknown tenant '{id}'")),
+        NoTenant::Failed(why) => err(StatusCode::INTERNAL_SERVER_ERROR, format!("tenant '{id}' exists but could not be loaded: {why}")),
+    }
 }
 
 pub fn rss_kb() -> Option<u64> {
@@ -101,10 +110,15 @@ pub async fn stats(AxState(st): AxState<State>) -> Response {
         "max_per_tenant": st.chats.cap(),
         "window_turns": st.chats.window(),
     });
+    let failed = st.store.failed_tenants();
     Json(json!({
         "rss_kb": rss_kb(),
         "uptime_s": st.started.elapsed().as_secs(),
         "tenants": tenants.len(),
+        // A tenant that would not load is a site answering nothing while the daemon reports itself
+        // healthy, so the count and the ids are part of the answer rather than a line in the log.
+        "tenants_failed": failed.len(),
+        "failed_tenants": failed.iter().map(|(id, e)| json!({ "id": id, "error": e })).collect::<Vec<_>>(),
         "overlay_bytes": overlay_bytes,
         "sse_subscribers": subscribers,
         "bases": st.store.bases().iter().map(|b| json!({ "name": b.name, "files": b.file_count(), "bytes": b.bytes() })).collect::<Vec<_>>(),
@@ -134,6 +148,7 @@ fn snapshot(st: &AppState, chats: (u64, u64)) -> Snapshot {
         uptime_seconds: st.started.elapsed().as_secs(),
         rss_bytes: rss_kb().map(|kb| kb * 1024),
         tenants: tenants.len() as u64,
+        tenants_failed: st.store.failed_tenants().len() as u64,
         overlay_bytes: tenants.iter().map(|t| t.overlay_stats().1).sum(),
         bases: st.store.bases().iter().map(|b| BaseSize { name: b.name.clone(), files: b.file_count() as u64, bytes: b.bytes() }).collect(),
         cache_entries: cache.entries as u64,

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -379,6 +379,41 @@ mod tests {
         (status, String::from_utf8_lossy(&body).into_owned())
     }
 
+    /// Issue #61: the daemon skipped a tenant it could not restore and said nothing, so a customer's
+    /// site answered "unknown tenant" while `/api/stats` and `/metrics` looked healthy.
+    #[tokio::test]
+    async fn a_tenant_that_could_not_be_restored_is_reported_rather_than_absent() {
+        let root = std::env::temp_dir().join(format!("sandbox-lite-api-failed-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&root);
+        let data = root.join("data");
+        std::fs::create_dir_all(data.join("bakery/files")).unwrap();
+        std::fs::write(data.join("bakery/tenant.json"), r#"{"base":"never-loaded-here"}"#).unwrap();
+        let store = Store::new(Some(data), u64::MAX);
+        assert_eq!(store.restore().unwrap(), 0, "it does not load, and it does not stop the daemon either");
+        let app = app(state_for(store, None, None));
+
+        let (status, body) = get(&app, "/api/stats", None).await;
+        assert_eq!(status, StatusCode::OK);
+        let stats: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(stats["tenants"], 0);
+        assert_eq!(stats["tenants_failed"], 1, "{body}");
+        assert_eq!(stats["failed_tenants"][0]["id"], "bakery");
+        assert!(stats["failed_tenants"][0]["error"].as_str().unwrap().contains("never-loaded-here"), "{body}");
+
+        let (status, body) = get(&app, "/metrics", None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(body.contains("\nsandbox_lite_tenants_failed 1\n"), "{body}");
+
+        // could not be loaded is a 500 that says why; never existed stays a 404
+        let (status, body) = get(&app, "/api/t/bakery/files", None).await;
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR, "{body}");
+        assert!(body.contains("could not be loaded"), "{body}");
+        let (status, body) = get(&app, "/api/t/nobody/files", None).await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert!(body.contains("unknown tenant"), "{body}");
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
     #[tokio::test]
     async fn bases_are_added_and_reloaded_over_the_api() {
         let root = std::env::temp_dir().join(format!("sandbox-lite-api-bases-{}", std::process::id()));

--- a/src/http/preview.rs
+++ b/src/http/preview.rs
@@ -7,7 +7,7 @@ use axum::response::{Html, IntoResponse, Response};
 use serde_json::{Map, Value, json};
 use xxhash_rust::xxh3::xxh3_64;
 
-use super::api::{check_tenant, err, sse};
+use super::api::{check_tenant, err, no_tenant, sse};
 use super::{AppState, State, TenantId, mime};
 use crate::resolve::{Resolver, renderers};
 use crate::store::{Tenant, clean_path, is_private_path};
@@ -26,7 +26,7 @@ pub fn asset_version() -> &'static str {
 
 #[allow(clippy::result_large_err)]
 fn tenant(st: &AppState, id: &TenantId) -> Result<Arc<Tenant>, Response> {
-    st.store.tenant(&id.0).ok_or_else(|| err(StatusCode::NOT_FOUND, format!("unknown tenant '{}'", id.0)))
+    st.store.resolve(&id.0).map_err(|e| no_tenant(&id.0, e))
 }
 
 fn text(body: impl Into<String>, content_type: &'static str, cache: &'static str) -> Response {

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,6 +189,14 @@ async fn main() {
             std::process::exit(1);
         }
     }
+    let failed = store.failed_tenants();
+    if !failed.is_empty() {
+        eprintln!(
+            "{} tenants could not be restored and answer 500 until they are fixed; see /api/stats and sandbox_lite_tenants_failed: {}",
+            failed.len(),
+            failed.iter().map(|(id, _)| id.as_str()).collect::<Vec<_>>().join(", ")
+        );
+    }
     let port = args.listen.rsplit(':').next().and_then(|p| p.parse().ok()).unwrap_or(80);
     let api_key = std::env::var("ANTHROPIC_API_KEY").ok().filter(|k| !k.is_empty());
     let metrics = Arc::new(metrics::Metrics::default());

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -107,6 +107,7 @@ pub struct Snapshot {
     pub uptime_seconds: u64,
     pub rss_bytes: Option<u64>,
     pub tenants: u64,
+    pub tenants_failed: u64,
     pub overlay_bytes: u64,
     pub bases: Vec<BaseSize>,
     pub cache_entries: u64,
@@ -155,6 +156,13 @@ pub fn render(s: &Snapshot) -> String {
         scalar(&mut out, "sandbox_lite_rss_bytes", "gauge", "Resident set size of the daemon process.", rss);
     }
     scalar(&mut out, "sandbox_lite_tenants", "gauge", "Tenants currently loaded.", s.tenants);
+    scalar(
+        &mut out,
+        "sandbox_lite_tenants_failed",
+        "gauge",
+        "Tenants whose data directory is present and could not be loaded; each one is a site answering 500. Their ids are in /api/stats.",
+        s.tenants_failed,
+    );
     scalar(&mut out, "sandbox_lite_overlay_bytes", "gauge", "Bytes of tenant-edited files held across every tenant.", s.overlay_bytes);
 
     family(&mut out, "sandbox_lite_bases", "gauge", "Base projects loaded, one series per base.");
@@ -322,6 +330,7 @@ mod tests {
             uptime_seconds: 42,
             rss_bytes: Some(101_384_192),
             tenants: 2,
+            tenants_failed: 1,
             overlay_bytes: 4096,
             bases: vec![
                 BaseSize { name: "starter".into(), files: 12, bytes: 34567 },
@@ -360,6 +369,9 @@ sandbox_lite_rss_bytes 101384192
 # HELP sandbox_lite_tenants Tenants currently loaded.
 # TYPE sandbox_lite_tenants gauge
 sandbox_lite_tenants 2
+# HELP sandbox_lite_tenants_failed Tenants whose data directory is present and could not be loaded; each one is a site answering 500. Their ids are in /api/stats.
+# TYPE sandbox_lite_tenants_failed gauge
+sandbox_lite_tenants_failed 1
 # HELP sandbox_lite_overlay_bytes Bytes of tenant-edited files held across every tenant.
 # TYPE sandbox_lite_overlay_bytes gauge
 sandbox_lite_overlay_bytes 4096
@@ -528,6 +540,7 @@ sandbox_lite_compile_seconds_count{kind="url"} 0
             uptime_seconds: 0,
             rss_bytes: None,
             tenants: 0,
+            tenants_failed: 0,
             overlay_bytes: 0,
             bases: vec![],
             cache_entries: 0,

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -121,6 +121,8 @@ mod tests {
         assert_eq!(of("src/pages/rss.xml.ts"), ("/rss.xml".into(), "endpoint", "^/rss\\.xml/?$".into()));
         assert_eq!(of("src/pages/api/products.json.ts"), ("/api/products.json".into(), "endpoint", "^/api/products\\.json/?$".into()));
         assert_eq!(of("src/pages/sitemap.js").0, "/sitemap");
+        assert_eq!(of("src/pages/feed.mjs"), ("/feed".into(), "endpoint", "^/feed/?$".into()));
+        assert_eq!(of("src/pages/atom.mts"), ("/atom".into(), "endpoint", "^/atom/?$".into()));
         assert_eq!(of("src/pages/api/index.ts").0, "/api");
         assert_eq!(of("src/pages/about.astro"), ("/about".into(), "astro", "^/about/?$".into()));
         assert!(route("src/pages/_helpers.ts").is_none());

--- a/src/store.rs
+++ b/src/store.rs
@@ -411,20 +411,20 @@ impl Tenant {
         Ok(self.bump("delete", path, UpdateKind::Module))
     }
 
+    /// The event carries `prev`, the version it follows, as well as the one it makes. A client that
+    /// holds some other version has missed a message, and `live.js` reloads rather than swapping
+    /// (issue #62) — a lost `module` event would otherwise leave it swapping CSS over stale JS.
     fn bump(&self, event: &str, path: &str, kind: UpdateKind) -> u64 {
-        let mut v = self.version.load(Ordering::Relaxed);
-        loop {
-            let next = now_millis().max(v + 1);
-            match self.version.compare_exchange(v, next, Ordering::Relaxed, Ordering::Relaxed) {
-                Ok(_) => {
-                    v = next;
-                    break;
-                }
-                Err(cur) => v = cur,
+        let mut prev = self.version.load(Ordering::Relaxed);
+        let v = loop {
+            let next = now_millis().max(prev + 1);
+            match self.version.compare_exchange(prev, next, Ordering::Relaxed, Ordering::Relaxed) {
+                Ok(_) => break next,
+                Err(cur) => prev = cur,
             }
-        }
+        };
         let _ = self.events.send(format!(
-            r#"{{"type":"{event}","path":{},"kind":"{}","version":{v}}}"#,
+            r#"{{"type":"{event}","path":{},"kind":"{}","version":{v},"prev":{prev}}}"#,
             serde_json::to_string(path).unwrap_or_default(),
             kind.as_str()
         ));
@@ -681,9 +681,23 @@ fn stage_delete(staged: &mut Staged, overlay: &BTreeMap<String, Option<FileData>
     staged.tombstones(&list)
 }
 
+/// Why a tenant is not here. A caller that cannot tell the two apart reports a customer's site that
+/// this node could not load as one that never existed (issue #61).
+#[derive(Debug)]
+pub enum NoTenant {
+    /// Neither the map nor `--data-dir` holds it.
+    Unknown,
+    /// `<data-dir>/<id>` is there and a tenant could not be built from it; the reason is the string.
+    Failed(String),
+}
+
 pub struct Store {
     bases: RwLock<HashMap<String, Arc<Base>>>,
     tenants: RwLock<HashMap<String, Arc<Tenant>>>,
+    /// Tenant ids whose data directory is on disk and would not load, and why: `restore` fills it at
+    /// startup and `resolve` on a later miss. Reported by `/api/stats`, `/metrics` and the editor,
+    /// because a tenant that answers 404 while the daemon reports itself healthy is invisible.
+    failed: RwLock<BTreeMap<String, String>>,
     data_dir: Option<PathBuf>,
     bases_dir: Option<PathBuf>,
     tenant_quota: u64,
@@ -691,7 +705,14 @@ pub struct Store {
 
 impl Store {
     pub fn new(data_dir: Option<PathBuf>, tenant_quota: u64) -> Store {
-        Store { bases: RwLock::new(HashMap::new()), tenants: RwLock::new(HashMap::new()), data_dir, bases_dir: None, tenant_quota }
+        Store {
+            bases: RwLock::new(HashMap::new()),
+            tenants: RwLock::new(HashMap::new()),
+            failed: RwLock::new(BTreeMap::new()),
+            data_dir,
+            bases_dir: None,
+            tenant_quota,
+        }
     }
 
     /// `--bases`: the directory a base added through the API must live under.
@@ -822,12 +843,37 @@ impl Store {
     /// other node is not in this node's map until something asks for it. What this does not do is
     /// refresh a tenant already in memory — it never sees the other node's later writes
     /// (`docs/multi-node.md`).
-    pub fn tenant(&self, id: &str) -> Option<Arc<Tenant>> {
+    ///
+    /// A directory that is there and will not load is `NoTenant::Failed`, not `Unknown`, and is
+    /// remembered so `/api/stats`, `/metrics` and the editor can report it.
+    pub fn resolve(&self, id: &str) -> Result<Arc<Tenant>, NoTenant> {
         if let Some(t) = self.tenants.read().unwrap().get(id).cloned() {
-            return Some(t);
+            return Ok(t);
         }
-        let restored = Arc::new(self.read_tenant(id).ok()?);
-        Some(self.tenants.write().unwrap().entry(id.to_string()).or_insert(restored).clone())
+        if self.tenant_dir(id).is_none() {
+            return Err(NoTenant::Unknown);
+        }
+        match self.read_tenant(id) {
+            Ok(t) => {
+                self.failed.write().unwrap().remove(id);
+                let restored = Arc::new(t);
+                Ok(self.tenants.write().unwrap().entry(id.to_string()).or_insert(restored).clone())
+            }
+            Err(e) => {
+                self.failed.write().unwrap().insert(id.to_string(), e.clone());
+                Err(NoTenant::Failed(e))
+            }
+        }
+    }
+
+    pub fn tenant(&self, id: &str) -> Option<Arc<Tenant>> {
+        self.resolve(id).ok()
+    }
+
+    /// The tenants whose data directory this node could not build a tenant from, id and reason, in
+    /// id order. Empty is the healthy answer; anything in it is a site answering nothing.
+    pub fn failed_tenants(&self) -> Vec<(String, String)> {
+        self.failed.read().unwrap().iter().map(|(id, e)| (id.clone(), e.clone())).collect()
     }
 
     /// `<data-dir>/<id>` when that directory is there: the bytes a tenant is, whether or not this
@@ -877,6 +923,7 @@ impl Store {
     /// error: it answered 204 and the tenant comes back at the next restore.
     pub fn remove_tenant(&self, id: &str) -> io::Result<bool> {
         let dropped = self.tenants.write().unwrap().remove(id);
+        self.failed.write().unwrap().remove(id);
         let dir = dropped.as_ref().and_then(|t| t.dir.clone()).or_else(|| self.tenant_dir(id));
         let mut held = dropped.is_some();
         if let Some(dir) = dir {
@@ -904,10 +951,14 @@ impl Store {
             let id = entry.file_name().to_string_lossy().into_owned();
             match self.read_tenant(&id) {
                 Ok(tenant) => {
+                    self.failed.write().unwrap().remove(&id);
                     self.tenants.write().unwrap().insert(id, Arc::new(tenant));
                     n += 1;
                 }
-                Err(e) => eprintln!("data dir entry '{id}': {e}, skipping"),
+                Err(e) => {
+                    eprintln!("data dir entry '{id}': {e}, skipping");
+                    self.failed.write().unwrap().insert(id, e);
+                }
             }
         }
         Ok(n)
@@ -1167,6 +1218,63 @@ mod tests {
         assert!(seen[0].contains(r#""type":"update","path":"src/styles/a.css","kind":"css""#), "{}", seen[0]);
         assert!(seen[1].contains(r#""kind":"style""#), "{}", seen[1]);
         assert!(seen[2].contains(r#""type":"delete","path":"src/styles/a.css","kind":"module""#), "{}", seen[2]);
+    }
+
+    /// Issue #61: a tenant whose directory is there and will not load used to leave nothing behind
+    /// but a line on stderr — the site answered 404 and the daemon called itself healthy.
+    #[test]
+    fn a_tenant_that_cannot_be_restored_is_counted_and_named() {
+        let root = temp("restore-failure");
+        seed(root.join("theme").join(PAGE), "<h1>base</h1>\n");
+        let data = root.join("data");
+        let store = Store::new(Some(data.clone()), 1 << 20);
+        store.add_base(Base::load("theme", &root.join("theme")).unwrap());
+        store.create_tenant("acme", "theme").unwrap();
+        // a tenant another node created on a base this one has not loaded
+        seed(data.join("bakery/tenant.json"), r#"{"base":"missing"}"#);
+        seed(data.join("bakery/files").join(PAGE), "<h1>bakery</h1>\n");
+
+        let fresh = Store::new(Some(data.clone()), 1 << 20);
+        fresh.add_base(Base::load("theme", &root.join("theme")).unwrap());
+        assert_eq!(fresh.restore().unwrap(), 1, "the good tenant is restored");
+
+        let failed = fresh.failed_tenants();
+        assert_eq!(failed.len(), 1, "the one that would not load is counted, not dropped: {failed:?}");
+        assert_eq!(failed[0].0, "bakery");
+        assert!(failed[0].1.contains("missing"), "the reason names the base: {}", failed[0].1);
+
+        // never existed and could not be loaded stay apart
+        assert!(matches!(fresh.resolve("bakery"), Err(NoTenant::Failed(_))));
+        assert!(matches!(fresh.resolve("nobody"), Err(NoTenant::Unknown)));
+        assert!(fresh.resolve("acme").is_ok());
+
+        // and a miss on a later request records the same way
+        let cold = Store::new(Some(data.clone()), 1 << 20);
+        assert!(cold.failed_tenants().is_empty());
+        assert!(matches!(cold.resolve("bakery"), Err(NoTenant::Failed(_))));
+        assert_eq!(cold.failed_tenants().len(), 1);
+
+        // deleting it closes the gap rather than leaving a phantom failure behind
+        assert!(fresh.remove_tenant("bakery").unwrap());
+        assert!(fresh.failed_tenants().is_empty());
+        assert!(matches!(fresh.resolve("bakery"), Err(NoTenant::Unknown)));
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    /// Issue #62: the client can only refuse a swap it should not apply if every event says which
+    /// version it follows.
+    #[test]
+    fn every_event_names_the_version_it_follows() {
+        let t = tenant(u64::MAX, None);
+        let mut events = t.events.subscribe();
+        let start = t.version();
+        let a = t.write("src/styles/a.css", b"a{}".to_vec(), UpdateKind::Css).unwrap();
+        let b = t.write("src/x.astro", b"<p/>".to_vec(), UpdateKind::Style).unwrap();
+        let c = t.delete("src/styles/a.css").unwrap();
+        let seen: Vec<String> = (0..3).map(|_| events.try_recv().unwrap()).collect();
+        assert!(seen[0].contains(&format!(r#""version":{a},"prev":{start}"#)), "{}", seen[0]);
+        assert!(seen[1].contains(&format!(r#""version":{b},"prev":{a}"#)), "{}", seen[1]);
+        assert!(seen[2].contains(&format!(r#""version":{c},"prev":{b}"#)), "{}", seen[2]);
     }
 
     #[test]


### PR DESCRIPTION
Closes #61
Closes #62
Closes #76

Three places where the daemon or the page reported something that was not so.

## #61 — a tenant that fails to restore is counted, not just logged

Continuing past one bad tenant is right; saying nothing about it is not. The
site answered `404 unknown tenant` while `/api/stats` and `/metrics` called the
daemon healthy, and the only trace was a line on stderr.

`Store` now keeps the ids it could not build a tenant from and why — filled by
`restore` at startup and by `resolve` on a later miss, cleared when the tenant
loads or is deleted — and reports them:

- `/api/stats` gains `tenants_failed` (the count) and `failed_tenants`
  (`[{id, error}]`);
- `/metrics` gains the `sandbox_lite_tenants_failed` gauge;
- the daemon prints one summary line at startup;
- the editor shows a red banner in its header, with the reason per id on hover.

`Store::resolve` replaces the `Option`: `NoTenant::Unknown` when neither the map
nor `--data-dir` holds the id, `NoTenant::Failed(why)` when `<data-dir>/<id>` is
there and would not load. So the HTTP layer answers **404 for a tenant that
never existed** and **500 with the reason for one that could not be loaded** —
the two facts stay apart all the way to the caller. `Store::tenant` is now
`resolve(…).ok()` for the callers that only need to know whether it is here.

## #62 — a dropped module event no longer leaves a page swapping over stale JS

`last_js` tracks the daemon's last build, not what an open page runs. A `module`
event lost on a connection that *stayed open* — a backgrounded tab, a lagging
stream — left the page's JavaScript behind, and the next write that only touched
a `<style>` block was correctly classified `style`, swapped in place, and never
reloaded: new CSS over stale markup, indefinitely. A reconnect was already
covered by the `hello` comparison; a live connection that dropped a message was
not.

Every event now carries `prev`, the version it follows, and `live.js` swaps only
when `prev` is the version it last rendered. Any gap in the chain reloads, which
makes a lost message self-correcting.

## #76 — the endpoint census is the route table

`check::inspect` counted `src/pages/**` files ending `.ts`/`.js` while
`routes::route` routes `.ts`/`.js`/`.mjs`/`.mts` and skips `_`-prefixed
segments. A project written in `.mjs` censused as "endpoints 0" — exactly the
answer that makes someone skip a feature — and `src/pages/_helpers.ts` counted
as a route that does not exist.

It now counts `kind == "endpoint"` over `routes::build` on the same tenant, so
the census and the preview cannot drift by construction.

The other counters were checked for the same drift, as the issue asks:

- `islands`, `import.meta.glob`, `sass`, `integrations` and `npm imports` are
  feature counts over the source tree. None of them claims to be a route count,
  and each is derived from the same build the preview runs. No drift.
- `mdx` counts every `.mdx` file in the tree rather than the routed ones. That
  is the wider number the issue suspected was intended, and it stays: a
  collection entry is MDX the preview must support as much as a page is. What
  was wrong was the README calling them "MDX pages"; it now says "MDX files" and
  says why the number is wider.

While verifying the documentation against the code, the README's route rule
("a `.ts`/`.js` file under `src/pages` is an endpoint") was corrected to name
`.mjs` and `.mts` too, and `routes.rs` gained the two extension cases its test
did not cover.

## Tests

- `store::tests::a_tenant_that_cannot_be_restored_is_counted_and_named` — one
  good tenant restores, the bad one is counted and named, `Unknown` and `Failed`
  stay distinguishable both at startup and on a later miss, and deleting it
  closes the gap.
- `http::tests::a_tenant_that_could_not_be_restored_is_reported_rather_than_absent`
  — the same fact over the wire: `/api/stats`, `/metrics`, a 500 that says why,
  and a 404 that still says "unknown tenant" for one that never existed.
- `store::tests::every_event_names_the_version_it_follows` — the `prev` chain,
  which is what the client checks.
- `e2e/live-reload.spec.ts` — drops exactly one `module` message from the open
  `EventSource`, confirms the page keeps running its old JS, then writes a
  style-only change and asserts the page **reloads** instead of swapping.
- `check::tests::the_endpoint_census_is_the_route_table` — a project using every
  extension the router accepts (`.astro`, `.md`, `.mdx`, `.ts`, `.js`, `.mjs`,
  `.mts`) plus `_`-prefixed files, with the census compared against
  `routes::build` on the same tenant.
- CI's smoke test asserts the new gauge renders from the real binary.

## CI

Green on `fix/say-what-is-true` @ 298375e — run
[34064572216](https://github.com/productdevbook/sandbox-lite/actions/runs/34064572216):
`cargo fmt --check`, `clippy -D warnings`, `cargo test`, the release build,
`sandbox-lite check`, the smoke test, `bench/mem.sh`, the dev-server comparison,
and the Playwright e2e suite — which is what proves the #62 reload behaviour in
a real browser.

## Noticed, not fixed

- `api::sse` reads `t.version()` for the `hello` event *before* calling
  `t.events.subscribe()`. A bump in that window is in neither the hello nor the
  stream, so the client would never learn of it. #62's `prev` chain now makes
  that self-correcting on the next event, but the ordering is still wrong and
  swapping the two lines would close it outright.
- With #62 in place, two swappable writes landing inside one swap's `await
  import(...)` make the second reload rather than swap: `window.__sl.version` is
  only advanced after the first swap completes. Conservative and never wrong,
  but it is a swap the old code would have kept.
- `Store::tenants` is still a list of what this node has loaded, not a census of
  `--data-dir`, so `/api/tenants` and the `tenants` gauge still under-report on
  a second node. `tenants_failed` is a count of what this node *tried and
  failed* to load, not of what it has never been asked for.
- The 500 body names the base or the OS error to whoever asked, including a
  preview visitor. That matches the daemon's existing habit of returning compile
  diagnostics to the preview, but it is a decision rather than an accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
