### PR TITLE
ops: stop three paths from costing far more than the caller expects

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -220,8 +220,15 @@ exact.
    `</head>`, and `document.write` replaces the shell. If Tailwind was seen,
    its browser build is loaded from jsDelivr. The `data-sl` key is what lets a
    later CSS write find the block again — see "CSS without a reload".
-9. **Errors.** Any exception fetches `/__sl/check` and renders an error page
-   with the daemon's diagnostics; a missing route lists the routes. Error
+9. **Errors.** Any exception renders an error page with the daemon's
+   diagnostics; a missing route lists the routes. Where those diagnostics come
+   from is issue #54: a module that does not compile is answered `500` with
+   `{"error", "diagnostics"}`, and the browser hides that body behind "failed
+   to fetch dynamically imported module", so `shell.js` re-fetches the module
+   URLs it can name — the page module it tried to import, and any `/__sl/m/`
+   URL in the error's message or stack — and reads the diagnostics out of the
+   first one that carries them. Only when none does is `/__sl/check` fetched,
+   because that compiles every source file of the tenant. Error
    pages also load `live.js`, so they reload when the file is fixed; their
    `<body data-sl-overlay>` is how `live.js` knows not to swap CSS into them.
 
@@ -337,7 +344,28 @@ The cache (`Engine::cache`) is a `HashMap<u128, Arc<Built>>` behind a mutex
 with a `VecDeque` of insertion order. The budget (`--cache-mb`, default 64
 MiB) counts `body` bytes; when exceeded, the oldest-inserted entries are
 dropped (FIFO, not LRU). `/api/stats` and `/metrics` report entries, bytes,
-hits and misses.
+hits, misses and coalesced waits.
+
+### One compile per key, however many ask for it
+
+A miss also takes the key in `Engine::inflight`, a `HashMap<u128,
+Arc<Inflight>>`. A second caller for a key already being compiled waits on it
+instead of compiling it too: issue #55, where a burst on one cold module took a
+permit and a compile each, all producing the same bytes, precisely when the
+daemon was busiest. The waiter gets the leader's answer — its `BuildError`
+included, which is why `BuildError` is `Clone` — and the leader's `Lead` guard
+takes the key out of the map and wakes the waiters on its way out, panic or
+not, so nobody waits on a compile that will never answer. The wait is bounded
+by what the leader is bounded by: its permit deadline and its compile deadline.
+
+Such a wait is counted as `coalesced`, not as a hit: it is a miss that did not
+compile, so `misses - coalesced` is what the daemon actually compiled.
+
+One caller never waits: a thread already compiling under a permit — a sweep, or
+the module build a `?type=style` compile makes from inside itself. The leader
+takes the key before it takes a permit, so it can be queueing for the very
+permit that thread is holding; it compiles the key for itself instead, which is
+the duplicate the cache has always tolerated.
 
 ### How many compiles run at once
 
@@ -350,12 +378,19 @@ than queueing without end. `/api/stats` reports the permits held, the builds
 waiting, the limit, the refusals, and the two deadline counters below under
 `compiles`; `/metrics` has the same six.
 
-Two builds take no permit. A cache hit is not a compile, so a warm daemon
-serving cached modules never queues. And a `?type=style` or `?type=script`
+Three builds take no permit. A cache hit is not a compile, so a warm daemon
+serving cached modules never queues, and neither does a miss that waits on a
+compile of the same key already running. And a `?type=style` or `?type=script`
 build asks for the module from inside its own compile: that inner build runs
 under the permit — and on the stack, and under the deadline — its parent is
 already holding, which a thread-local marks for each. A second permit there
 would deadlock as soon as the gate was full.
+
+`Engine::sweep` marks a thread the same way for a different reason: a
+whole-project compile takes one permit and holds it for the whole run, so
+`check` costs one place in the queue rather than one per file (#54). The
+per-file compile deadline is untouched — each build inside still gets its own
+thread and its own wall clock.
 
 ### How long one compile may run
 
@@ -575,7 +610,13 @@ diagnostics and a census — islands, glob calls,
 Sass, MDX, endpoints, `@astrojs/*` integrations, bare imports — and exits 1 on
 compile errors, 2 when a directory cannot be loaded. `/api/t/{id}/check` and
 `/__sl/check` run the same loop (`api::check_tenant`) on a live tenant; the
-error page uses the latter.
+error page uses the latter as its fallback.
+
+That loop runs inside `Engine::sweep`, so the whole project compiles under one
+permit taken once. A sweep that cannot have one waits the queue deadline once
+and answers with that refusal as its single diagnostic — not once per file,
+which is what made the page that explains a failure the slowest thing on the
+site (#54).
 
 ## Metrics (`src/metrics.rs`)
 
@@ -596,6 +637,7 @@ observation.
 
 `GET /metrics` (`api::metrics`) renders those counters plus the gauges
 `/api/stats` already had — tenants, overlay bytes, cache entries and bytes,
+cache hits, misses and coalesced waits, stored conversations and their bytes,
 SSE subscribers, RSS, uptime, one series per base, `Sass::stats`'s running,
 runaway, timed-out and refused compilations, and the compile gate's permits
 held, builds queued, limit and refusals — as Prometheus text format 0.0.4,
@@ -636,6 +678,16 @@ sent as its opening turn from then on. A summary the API will not write is not
 fatal: the turns stay stored and are cut from the request anyway. A save past
 `--chats-per-tenant` drops the tenant's least recently updated conversation
 (`evictable`).
+
+`Chats::sizes` holds what each tenant's conversations weigh, `<tenant> → <chat
+id> → bytes`, seeded from the store the first time a tenant is touched and
+moved by every save and delete after that. `usage` reads it, so `/api/stats`
+and `/metrics` count conversations without listing a directory: the editor
+polls `/api/stats` every five seconds, and a walk per tenant per poll is
+O(tenants) of disk on the one endpoint whose numbers say this daemon's cost
+does not grow with tenant count (#60). The cap is the exception and still reads
+the directory on a save, because it decides which files to delete and must see
+what another node's writer left there.
 
 ## Layout
 

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Editor host (`localhost`):
 | Method | Path | |
 |---|---|---|
 | GET | `/metrics` | Prometheus text format: gauges, cache and request counters, compile-latency histograms |
-| GET | `/api/stats` | RSS, tenant count, cache stats, what the chats directory holds, screenshots in flight, module requests and compile totals |
+| GET | `/api/stats` | RSS, tenant count, cache stats, what the stored conversations hold, screenshots in flight, module requests and compile totals |
 | GET/POST | `/api/bases` | list / add `{name, path}`; the path must be inside `--bases` when that flag is set |
 | POST | `/api/bases/{name}/reload` | re-read the base from disk and re-point every tenant on it |
 | GET/POST | `/api/tenants` | list / create `{id, base}` |
@@ -292,7 +292,7 @@ Editor host (`localhost`):
 | GET | `/api/t/{id}/export` | tar.gz of the merged tree; `?overlay=1` for the edits alone |
 | GET/PUT/DELETE | `/api/t/{id}/file/{path}` | raw file bytes |
 | GET | `/api/t/{id}/events` | SSE: `update` / `delete` with the new version and a `kind` (`css`, `style`, `module`) |
-| GET | `/api/t/{id}/check` | compile every source file, return diagnostics |
+| GET | `/api/t/{id}/check` | compile every source file under one compile permit, return diagnostics |
 | POST | `/api/t/{id}/chat` | `{messages:[{role,content}], chat?}` → `{text, changes, iterations, version, chat}`, or SSE with `Accept: text/event-stream` |
 | GET | `/api/t/{id}/chats` | saved conversations, newest first |
 | GET/DELETE | `/api/t/{id}/chats/{chat}` | one conversation with its turns / remove it |

--- a/assets/shell.js
+++ b/assets/shell.js
@@ -14,6 +14,48 @@ async function fetchJSON(url) {
   return r.json();
 }
 
+// A dynamic import that fails says only "failed to fetch dynamically imported module"; the daemon's
+// 500 body is where the diagnostic is, so the URL is kept for the error handler to ask for it.
+async function importModule(url) {
+  try {
+    return await import(slUrl(url));
+  } catch (e) {
+    if (e && typeof e === "object" && !e.slModule) e.slModule = url;
+    throw e;
+  }
+}
+
+const MODULE_URL = /\/__sl\/m\/[^\s"'`)]+/g;
+const MODULE_URLS_READ = 4;
+
+function moduleUrls(e) {
+  const urls = new Set();
+  if (e && e.slModule) urls.add(e.slModule);
+  for (const text of [e && e.message, e && e.stack]) {
+    for (const m of String(text ?? "").matchAll(MODULE_URL)) urls.add(m[0]);
+  }
+  // the token is added back by slUrl; a URL read out of an error message carries the old one
+  return [...urls].map((u) => u.replace(/[?&]sl_token=[^&]*/g, "")).slice(0, MODULE_URLS_READ);
+}
+
+// Issue #54: the module request that failed already answers `{error, diagnostics}`, so reading its
+// body costs one compile of one file. /__sl/check compiles every source file of the tenant, and on
+// a busy daemon each of those waits for a compile permit — the page explaining a failure must not
+// be the slowest thing on the site. It stays the fallback, for a failure no module body explains.
+async function failedModuleDiagnostics(e) {
+  for (const url of moduleUrls(e)) {
+    try {
+      const r = await fetch(slUrl(url));
+      if (r.ok) continue;
+      const body = await r.json();
+      const diagnostics = (body.diagnostics ?? []).filter((d) => d.severity === "error");
+      if (diagnostics.length) return diagnostics;
+      if (body.error) return [{ severity: "error", file: url.split("?")[0].replace("/__sl/m/", ""), text: body.error, hint: "" }];
+    } catch {}
+  }
+  return [];
+}
+
 function matchRoute(routes, pathname) {
   for (const r of routes) {
     const m = new RegExp(r.pattern).exec(pathname);
@@ -161,7 +203,7 @@ async function main() {
   if (!hit) return showError({ title: "404 — no matching page", message: `Nothing in src/pages matches ${location.pathname}`, routes });
   const endpoint = hit.route.kind === "endpoint";
   const astro = await import(slUrl("/__sl/astro.js"));
-  const mod = await import(slUrl(`/__sl/m/${hit.route.component}?v=${V}`));
+  const mod = await importModule(`/__sl/m/${hit.route.component}?v=${V}`);
   if (endpoint) {
     if (typeof mod.GET !== "function" && typeof mod.ALL !== "function") {
       return showError({ title: "Endpoint without a handler", message: `${hit.route.component} exports no GET or ALL function. The preview only issues GET requests.` });
@@ -206,8 +248,10 @@ async function main() {
 }
 
 main().catch(async (e) => {
-  let diagnostics = [];
-  try { diagnostics = (await fetchJSON("/__sl/check")).diagnostics.filter((d) => d.severity === "error"); } catch {}
+  let diagnostics = await failedModuleDiagnostics(e);
+  if (!diagnostics.length) {
+    try { diagnostics = (await fetchJSON("/__sl/check")).diagnostics.filter((d) => d.severity === "error"); } catch {}
+  }
   console.error(e);
   showError({ title: "Render failed", message: e && e.message ? e.message : String(e), stack: e && e.stack, diagnostics });
 });

--- a/docs/multi-node.md
+++ b/docs/multi-node.md
@@ -44,7 +44,7 @@ So with two daemons, A and B, sharing `--data-dir`:
 | `POST /api/bases/theme/reload` on A | Only A re-reads the base. B keeps the copy it loaded. |
 | `POST /api/t/acme/chat` on A, then `GET /api/t/acme/chats` on B | B lists it: conversations are read from the shared data directory on every call, not cached. |
 | `POST /api/tenants/acme/import` on A | A's overlay and the data directory change; B's overlay does not, exactly as for a single write. |
-| `/api/stats`, `/metrics` on B | B's own tenants, cache and subscribers. Neither number is a cluster total. |
+| `/api/stats`, `/metrics` on B | B's own tenants, cache and subscribers. Neither number is a cluster total. The chats figures are counters B keeps as it saves and evicts, seeded from the directory the first time it touches a tenant, so what A writes afterwards is not in them either. |
 
 The version being per node also means a browser that moves from A to B
 mid-session gets a lower `?v=` than it had. That is harmless — the daemon never

--- a/e2e/error-overlay.spec.ts
+++ b/e2e/error-overlay.spec.ts
@@ -2,6 +2,8 @@ import { expect, test } from './fixtures';
 
 test('a compile error shows the overlay with file:line:column and the fix recovers', async ({ daemon, page, browserLog }) => {
   const site = await daemon.tenant('broken', 'starter');
+  const requested: string[] = [];
+  page.on('request', (request) => requested.push(request.url()));
   await page.goto(site.url('/'));
   await expect(page).toHaveTitle('Home · Lumen Studio');
 
@@ -14,6 +16,10 @@ test('a compile error shows the overlay with file:line:column and the fix recove
   await expect(page.locator('h1')).toHaveText('Render failed');
   await expect(page.locator('li b')).toHaveText(/^src\/pages\/index\.astro:6:\d+$/);
   await expect(page.locator('li')).toContainText('Unexpected token');
+
+  // Issue #54: the diagnostic comes from the failed module's own 500 body. /__sl/check compiles
+  // every source file of the tenant, each taking a compile permit, and is now only the fallback.
+  expect(requested.filter((url) => url.includes('/__sl/check')), 'the overlay did not sweep the project').toEqual([]);
 
   const { consoleErrors, failedRequests } = browserLog.take();
   expect(failedRequests.length, 'the module request fails').toBeGreaterThan(0);

--- a/src/http/ai.rs
+++ b/src/http/ai.rs
@@ -145,7 +145,7 @@ fn file_tool(st: &AppState, t: &Arc<Tenant>, name: &str, input: &Value, changes:
                 Err(e) => format!("error: {e}"),
             }
         }
-        "check_site" => check_tenant(st, t).to_string(),
+        "check_site" => check_tenant(&st.engine, t).to_string(),
         _ => format!("error: unknown tool {name}"),
     }
 }

--- a/src/http/api.rs
+++ b/src/http/api.rs
@@ -15,7 +15,7 @@ use tokio_stream::{Stream, StreamExt};
 use super::{AppState, State, mime};
 use crate::metrics::{BaseSize, KINDS, STATUSES, Snapshot, render};
 use crate::store::{Base, Tenant, WriteError, clean_path, valid_id};
-use crate::transform::{Kind, is_source};
+use crate::transform::{Engine, Kind, is_source};
 
 pub async fn editor() -> Html<&'static str> {
     Html(include_str!("../../assets/editor.html"))
@@ -72,20 +72,17 @@ fn module_stats(st: &AppState) -> Vec<Value> {
 }
 
 /// Conversations and the bytes they hold across every tenant. They are outside the tenant quota,
-/// so `overlay_bytes` does not see them and this is the only place the chats directory is counted.
-fn chat_stats(st: &AppState) -> std::io::Result<Value> {
-    let (mut conversations, mut bytes) = (0usize, 0u64);
+/// so `overlay_bytes` does not see them and this is the only place they are counted. `Chats` keeps
+/// the numbers as it writes and evicts, so this is memory rather than a directory walk per tenant:
+/// the editor polls `/api/stats` every five seconds, and #60 is what that cost at 1000 tenants.
+fn chat_totals(st: &AppState) -> std::io::Result<(u64, u64)> {
+    let (mut conversations, mut bytes) = (0u64, 0u64);
     for t in st.store.tenants() {
         let (n, b) = st.chats.usage(&t)?;
-        conversations += n;
+        conversations += n as u64;
         bytes += b;
     }
-    Ok(json!({
-        "conversations": conversations,
-        "bytes": bytes,
-        "max_per_tenant": st.chats.cap(),
-        "window_turns": st.chats.window(),
-    }))
+    Ok((conversations, bytes))
 }
 
 pub async fn stats(AxState(st): AxState<State>) -> Response {
@@ -94,10 +91,16 @@ pub async fn stats(AxState(st): AxState<State>) -> Response {
     let subscribers: usize = tenants.iter().map(|t| t.events.receiver_count()).sum();
     // A gauge that reads zero because a directory could not be listed is a wrong number, not a
     // missing one, and nothing downstream can tell the two apart.
-    let chats = match chat_stats(&st) {
-        Ok(chats) => chats,
+    let (conversations, chat_bytes) = match chat_totals(&st) {
+        Ok(totals) => totals,
         Err(e) => return err(StatusCode::INTERNAL_SERVER_ERROR, format!("chats: {e}")),
     };
+    let chats = json!({
+        "conversations": conversations,
+        "bytes": chat_bytes,
+        "max_per_tenant": st.chats.cap(),
+        "window_turns": st.chats.window(),
+    });
     Json(json!({
         "rss_kb": rss_kb(),
         "uptime_s": st.started.elapsed().as_secs(),
@@ -121,7 +124,7 @@ pub async fn stats(AxState(st): AxState<State>) -> Response {
     .into_response()
 }
 
-fn snapshot(st: &AppState) -> Snapshot {
+fn snapshot(st: &AppState, chats: (u64, u64)) -> Snapshot {
     let tenants = st.store.tenants();
     let cache = st.engine.stats();
     let sass = st.engine.sass_stats();
@@ -137,6 +140,9 @@ fn snapshot(st: &AppState) -> Snapshot {
         cache_bytes: cache.bytes as u64,
         cache_hits: cache.hits,
         cache_misses: cache.misses,
+        cache_coalesced: cache.coalesced,
+        chat_conversations: chats.0,
+        chat_bytes: chats.1,
         sse_subscribers: tenants.iter().map(|t| t.events.receiver_count() as u64).sum(),
         sass_running: sass.running as u64,
         sass_runaway: sass.runaway as u64,
@@ -157,7 +163,13 @@ fn snapshot(st: &AppState) -> Snapshot {
 }
 
 pub async fn metrics(AxState(st): AxState<State>) -> Response {
-    let body = render(&snapshot(&st));
+    // As in `stats`: a chats gauge that reads zero because the store could not be read is a wrong
+    // number wearing the shape of a right one, so the scrape fails instead.
+    let chats = match chat_totals(&st) {
+        Ok(totals) => totals,
+        Err(e) => return err(StatusCode::INTERNAL_SERVER_ERROR, format!("chats: {e}")),
+    };
+    let body = render(&snapshot(&st, chats));
     ([(header::CONTENT_TYPE, "text/plain; version=0.0.4; charset=utf-8"), (header::CACHE_CONTROL, "no-store")], body).into_response()
 }
 
@@ -328,32 +340,30 @@ pub async fn events(AxState(st): AxState<State>, Path(id): Path<String>) -> Resp
     }
 }
 
-pub fn check_tenant(st: &AppState, t: &Arc<Tenant>) -> Value {
-    let mut diagnostics = Vec::new();
-    let mut files = 0;
-    for e in t.list() {
-        if !is_source(&e.path) {
-            continue;
-        }
-        files += 1;
-        match st.engine.build(t, &e.path, Kind::Module) {
-            Ok(b) => diagnostics.extend(b.warnings.iter().cloned()),
-            Err(be) => {
-                if be.diagnostics.is_empty() {
-                    diagnostics.push(crate::transform::Diag {
-                        severity: "error".into(),
-                        text: be.message,
-                        hint: String::new(),
-                        file: e.path.clone(),
-                        line: 0,
-                        column: 0,
-                    });
-                } else {
-                    diagnostics.extend(be.diagnostics);
-                }
+fn diag(file: &str, text: String) -> crate::transform::Diag {
+    crate::transform::Diag { severity: "error".into(), text, hint: String::new(), file: file.to_string(), line: 0, column: 0 }
+}
+
+/// Every source file of the tenant, compiled. Issue #54: the sweep takes one compile permit and
+/// holds it for the whole run, so a saturated daemon costs this one wait rather than one per file —
+/// the error page fetches `/__sl/check`, and it is the page that has to explain a failure.
+pub fn check_tenant(engine: &Engine, t: &Arc<Tenant>) -> Value {
+    let sources: Vec<String> = t.list().into_iter().map(|e| e.path).filter(|p| is_source(p)).collect();
+    let files = sources.len();
+    let swept = engine.sweep(|| {
+        let mut diagnostics = Vec::new();
+        for path in &sources {
+            match engine.build(t, path, Kind::Module) {
+                Ok(b) => diagnostics.extend(b.warnings.iter().cloned()),
+                Err(be) if be.diagnostics.is_empty() => diagnostics.push(diag(path, be.message)),
+                Err(be) => diagnostics.extend(be.diagnostics),
             }
         }
-    }
+        diagnostics
+    });
+    // A sweep that never got a permit is a saturated daemon, not a project with nothing wrong: the
+    // one refusal is the answer, and it is what the error overlay shows.
+    let diagnostics = swept.unwrap_or_else(|be| vec![diag("", be.message)]);
     let errors = diagnostics.iter().filter(|d| d.severity == "error").count();
     json!({ "files": files, "errors": errors, "diagnostics": diagnostics })
 }
@@ -364,8 +374,69 @@ pub async fn check(AxState(st): AxState<State>, Path(id): Path<String>) -> Respo
         Err(r) => return r,
     };
     let st2 = st.clone();
-    match tokio::task::spawn_blocking(move || check_tenant(&st2, &t)).await {
+    match tokio::task::spawn_blocking(move || check_tenant(&st2.engine, &t)).await {
         Ok(out) => Json(out).into_response(),
         Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{Duration, Instant};
+
+    use super::check_tenant;
+    use crate::metrics::Metrics;
+    use crate::store::{Base, Store, Tenant, UpdateKind};
+    use crate::transform::{Config, Engine};
+
+    fn tenant(files: &[(&str, &str)]) -> Arc<Tenant> {
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let store = Store::new(None, u64::MAX);
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("examples/starter");
+        store.add_base(Base::load("starter", &root).unwrap());
+        let id = format!("acme{}", SEQ.fetch_add(1, Ordering::Relaxed));
+        let t = store.create_tenant(&id, "starter").unwrap();
+        for (path, body) in files {
+            t.write(path, body.as_bytes().to_vec(), UpdateKind::from_path(path)).unwrap();
+        }
+        t
+    }
+
+    fn engine(limit: usize, wait: Duration) -> Engine {
+        Engine::gated(Config { cache_bytes: 1 << 20, ..Config::default() }, Arc::new(Metrics::default()), limit, wait, 8)
+    }
+
+    #[test]
+    fn check_names_the_file_that_does_not_compile() {
+        let t = tenant(&[("src/pages/bad.astro", "---\nconst n = ;\n---\n")]);
+        let engine = engine(2, Duration::from_millis(50));
+        let out = check_tenant(&engine, &t);
+        assert!(out["files"].as_u64().unwrap() > 1, "{out}");
+        assert_eq!(out["errors"], 1, "{out}");
+        let named = out["diagnostics"].as_array().unwrap().iter().any(|d| d["file"] == "src/pages/bad.astro" && d["severity"] == "error");
+        assert!(named, "{out}");
+        assert_eq!(engine.compile_stats().running, 0, "the sweep gave its permit back");
+    }
+
+    /// Issue #54: `check` took a permit per source file, so with every permit busy the page that
+    /// exists to explain a failure waited the queue deadline once per file — the slowest thing on
+    /// the site, exactly when the site is already broken. One wait now answers for the whole sweep.
+    #[test]
+    fn check_on_a_saturated_daemon_waits_once_not_once_per_file() {
+        let t = tenant(&[]);
+        let wait = Duration::from_millis(100);
+        // a gate no compile can pass: every permit is busy, for as long as the test needs it
+        let engine = engine(0, wait);
+        let started = Instant::now();
+        let out = check_tenant(&engine, &t);
+        let files = out["files"].as_u64().unwrap();
+        assert!(files >= 5, "the starter example has source files to sweep: {files}");
+        assert!(started.elapsed() < wait * 3, "{files} files took {:?}", started.elapsed());
+        assert_eq!(out["errors"], 1, "one refusal, not one per file: {out}");
+        assert!(out["diagnostics"][0]["text"].as_str().unwrap().contains("waited 100 ms"), "{out}");
+        assert_eq!(engine.compile_stats().refused, 1);
     }
 }

--- a/src/http/chats.rs
+++ b/src/http/chats.rs
@@ -148,6 +148,12 @@ pub fn evictable(newest_first: &[Conversation], cap: usize, keep: &str) -> Vec<S
 /// Disk is the store when the tenant has a data directory; the map holds everything otherwise.
 pub struct Chats {
     mem: RwLock<HashMap<String, BTreeMap<String, Conversation>>>,
+    /// What each tenant's conversations weigh, `<tenant> → <chat id> → bytes`. Seeded from the
+    /// store the first time a tenant is touched and moved by every save and delete after that, so
+    /// `usage` answers from memory: `/api/stats` is polled every five seconds by every open editor,
+    /// and a directory walk per tenant per poll is O(tenants) of disk on the endpoint whose numbers
+    /// say this daemon's cost does not grow with tenant count (#60).
+    sizes: RwLock<HashMap<String, BTreeMap<String, u64>>>,
     cap: usize,
     window: usize,
 }
@@ -160,7 +166,7 @@ impl Default for Chats {
 
 impl Chats {
     pub fn new(cap: usize, window: usize) -> Chats {
-        Chats { mem: RwLock::new(HashMap::new()), cap: cap.max(1), window: window.max(2) }
+        Chats { mem: RwLock::new(HashMap::new()), sizes: RwLock::new(HashMap::new()), cap: cap.max(1), window: window.max(2) }
     }
 
     /// Turns `for_model` replays in full; see `DEFAULT_WINDOW_TURNS`.
@@ -187,16 +193,43 @@ impl Chats {
     }
 
     pub fn save(&self, t: &Tenant, chat: &Conversation) -> io::Result<()> {
+        self.seed(t)?;
+        let raw = serde_json::to_vec(chat)?;
+        let bytes = raw.len() as u64;
         match dir(t) {
             Some(dir) => {
                 std::fs::create_dir_all(&dir)?;
-                std::fs::write(dir.join(format!("{}.json", chat.id)), serde_json::to_vec(chat)?)?;
+                std::fs::write(dir.join(format!("{}.json", chat.id)), &raw)?;
             }
             None => {
                 self.mem.write().unwrap().entry(t.id.clone()).or_default().insert(chat.id.clone(), chat.clone());
             }
         }
+        self.sizes.write().unwrap().entry(t.id.clone()).or_default().insert(chat.id.clone(), bytes);
         self.evict(t, &chat.id)
+    }
+
+    /// The bytes each of a tenant's conversations holds, read once and then maintained. A tenant
+    /// already seeded is left alone, so this is one directory walk per tenant per process.
+    fn seed(&self, t: &Tenant) -> io::Result<()> {
+        if self.sizes.read().unwrap().contains_key(&t.id) {
+            return Ok(());
+        }
+        let seeded: BTreeMap<String, u64> = match dir(t) {
+            Some(dir) => {
+                let mut out = BTreeMap::new();
+                for entry in chat_files(&dir)? {
+                    out.insert(chat_id(&entry), entry.metadata()?.len());
+                }
+                out
+            }
+            None => match self.mem.read().unwrap().get(&t.id) {
+                Some(held) => held.iter().map(|(id, c)| (id.clone(), serialized_bytes(c))).collect(),
+                None => BTreeMap::new(),
+            },
+        };
+        self.sizes.write().unwrap().entry(t.id.clone()).or_insert(seeded);
+        Ok(())
     }
 
     /// Brings the tenant back under the cap after a save. The count is taken first because it
@@ -218,21 +251,13 @@ impl Chats {
         }
     }
 
-    /// What the tenant's conversations hold: the size of the files under `<data-dir>/<id>/chats/`,
-    /// or what the in-memory ones would serialize to.
+    /// What the tenant's conversations hold, from the counters rather than the disk: the tenant is
+    /// walked once, on the first call, and every save and delete after that moves the numbers.
+    /// `/api/stats` and `/metrics` are the callers, and the editor polls the first every 5 s.
     pub fn usage(&self, t: &Tenant) -> io::Result<(usize, u64)> {
-        match dir(t) {
-            Some(dir) => {
-                let mut out = (0usize, 0u64);
-                for entry in chat_files(&dir)? {
-                    out = (out.0 + 1, out.1 + entry.metadata()?.len());
-                }
-                Ok(out)
-            }
-            None => Ok(self.mem.read().unwrap().get(&t.id).map_or((0, 0), |m| {
-                m.values().fold((0, 0), |(n, bytes), c| (n + 1, bytes + serde_json::to_vec(c).map_or(0, |v| v.len() as u64)))
-            })),
-        }
+        self.seed(t)?;
+        let sizes = self.sizes.read().unwrap();
+        Ok(sizes.get(&t.id).map_or((0, 0), |held| (held.len(), held.values().sum())))
     }
 
     /// Newest first. A conversation file that cannot be read fails the listing rather than
@@ -259,18 +284,36 @@ impl Chats {
         if !valid_id(id) {
             return Ok(false);
         }
-        let Some(dir) = dir(t) else { return Ok(self.mem.write().unwrap().get_mut(&t.id).is_some_and(|m| m.remove(id).is_some())) };
-        match std::fs::remove_file(dir.join(format!("{id}.json"))) {
-            Ok(()) => Ok(true),
-            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(false),
-            Err(e) => Err(e),
+        self.seed(t)?;
+        let removed = match dir(t) {
+            Some(dir) => match std::fs::remove_file(dir.join(format!("{id}.json"))) {
+                Ok(()) => true,
+                Err(e) if e.kind() == io::ErrorKind::NotFound => false,
+                Err(e) => return Err(e),
+            },
+            None => self.mem.write().unwrap().get_mut(&t.id).is_some_and(|m| m.remove(id).is_some()),
+        };
+        if removed && let Some(held) = self.sizes.write().unwrap().get_mut(&t.id) {
+            held.remove(id);
         }
+        Ok(removed)
     }
 
-    /// A deleted tenant takes its data directory with it; the in-memory map has to be told.
+    /// A deleted tenant takes its data directory with it; the in-memory map has to be told, and so
+    /// do the counters, or a tenant re-created with the same id would start from the old numbers.
     pub fn forget(&self, tenant: &str) {
         self.mem.write().unwrap().remove(tenant);
+        self.sizes.write().unwrap().remove(tenant);
     }
+}
+
+/// What a conversation weighs in the store: exactly the bytes `save` writes for it.
+fn serialized_bytes(c: &Conversation) -> u64 {
+    serde_json::to_vec(c).map_or(0, |v| v.len() as u64)
+}
+
+fn chat_id(entry: &std::fs::DirEntry) -> String {
+    entry.file_name().to_string_lossy().trim_end_matches(".json").to_string()
 }
 
 fn dir(t: &Tenant) -> Option<PathBuf> {
@@ -521,6 +564,40 @@ mod tests {
     fn usage_is_zero_for_a_tenant_that_has_never_chatted() {
         let (t, root) = tenant(true);
         assert_eq!(Chats::default().usage(&t).unwrap(), (0, 0));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    /// Issue #60: `/api/stats` walked every tenant's chats directory, and the editor polls it every
+    /// five seconds. The counters answer instead — proved here by taking the directory away — and
+    /// they still agree with the files after a save, an evict and a restore onto a fresh daemon.
+    #[test]
+    fn usage_is_counted_in_memory_and_still_matches_the_files() {
+        let (t, root) = tenant(true);
+        let chats = Chats::new(2, 8);
+        for i in 0..3 {
+            let mut c = conversation(&format!("c{i}"), 2);
+            c.updated = 1000 + i as u64;
+            chats.save(&t, &c).unwrap();
+        }
+        let counted = chats.usage(&t).unwrap();
+        assert_eq!(counted.0, 2, "the third save evicted the oldest");
+
+        let stored = super::dir(&t).unwrap();
+        let on_disk: (usize, u64) = std::fs::read_dir(&stored)
+            .unwrap()
+            .map(|e| e.unwrap().metadata().unwrap().len())
+            .fold((0, 0), |(n, bytes), len| (n + 1, bytes + len));
+        assert_eq!(counted, on_disk, "the counters and the files agree");
+
+        // A daemon that has never seen this tenant seeds itself from the same directory.
+        assert_eq!(Chats::new(2, 8).usage(&t).unwrap(), counted);
+
+        // And once they are warm the directory is not read again: it is not even there.
+        std::fs::remove_dir_all(&stored).unwrap();
+        assert_eq!(chats.usage(&t).unwrap(), counted);
+
+        chats.forget(&t.id);
+        assert_eq!(chats.usage(&t).unwrap(), (0, 0), "a deleted tenant starts from nothing");
         let _ = std::fs::remove_dir_all(&root);
     }
 }

--- a/src/http/preview.rs
+++ b/src/http/preview.rs
@@ -131,7 +131,7 @@ pub async fn check(AxState(st): AxState<State>, Extension(id): Extension<TenantI
         Err(r) => return r,
     };
     let st2 = st.clone();
-    let out = match tokio::task::spawn_blocking(move || check_tenant(&st2, &t)).await {
+    let out = match tokio::task::spawn_blocking(move || check_tenant(&st2.engine, &t)).await {
         Ok(out) => out,
         Err(e) => return err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
     };

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -113,6 +113,9 @@ pub struct Snapshot {
     pub cache_bytes: u64,
     pub cache_hits: u64,
     pub cache_misses: u64,
+    pub cache_coalesced: u64,
+    pub chat_conversations: u64,
+    pub chat_bytes: u64,
     pub sse_subscribers: u64,
     pub sass_running: u64,
     pub sass_runaway: u64,
@@ -171,6 +174,21 @@ pub fn render(s: &Snapshot) -> String {
     scalar(&mut out, "sandbox_lite_cache_bytes", "gauge", "Bytes retained by the transform cache.", s.cache_bytes);
     scalar(&mut out, "sandbox_lite_cache_hits_total", "counter", "Transform cache lookups that found an entry.", s.cache_hits);
     scalar(&mut out, "sandbox_lite_cache_misses_total", "counter", "Transform cache lookups that had to compile.", s.cache_misses);
+    scalar(
+        &mut out,
+        "sandbox_lite_cache_coalesced_total",
+        "counter",
+        "Transform cache misses that waited on a compile of the same key already running; subtract these from the misses to get the compiles.",
+        s.cache_coalesced,
+    );
+    scalar(&mut out, "sandbox_lite_chats", "gauge", "Stored conversations across every tenant.", s.chat_conversations);
+    scalar(
+        &mut out,
+        "sandbox_lite_chat_bytes",
+        "gauge",
+        "Bytes those conversations hold; they are outside the tenant quota.",
+        s.chat_bytes,
+    );
     scalar(&mut out, "sandbox_lite_sse_subscribers", "gauge", "Open live-reload event streams across every tenant.", s.sse_subscribers);
 
     scalar(&mut out, "sandbox_lite_sass_running", "gauge", "Sass compilations in flight.", s.sass_running);
@@ -313,6 +331,9 @@ mod tests {
             cache_bytes: 8192,
             cache_hits: 10,
             cache_misses: 3,
+            cache_coalesced: 2,
+            chat_conversations: 4,
+            chat_bytes: 9001,
             sse_subscribers: 1,
             sass_running: 1,
             sass_runaway: 2,
@@ -366,6 +387,15 @@ sandbox_lite_cache_hits_total 10
 # HELP sandbox_lite_cache_misses_total Transform cache lookups that had to compile.
 # TYPE sandbox_lite_cache_misses_total counter
 sandbox_lite_cache_misses_total 3
+# HELP sandbox_lite_cache_coalesced_total Transform cache misses that waited on a compile of the same key already running; subtract these from the misses to get the compiles.
+# TYPE sandbox_lite_cache_coalesced_total counter
+sandbox_lite_cache_coalesced_total 2
+# HELP sandbox_lite_chats Stored conversations across every tenant.
+# TYPE sandbox_lite_chats gauge
+sandbox_lite_chats 4
+# HELP sandbox_lite_chat_bytes Bytes those conversations hold; they are outside the tenant quota.
+# TYPE sandbox_lite_chat_bytes gauge
+sandbox_lite_chat_bytes 9001
 # HELP sandbox_lite_sse_subscribers Open live-reload event streams across every tenant.
 # TYPE sandbox_lite_sse_subscribers gauge
 sandbox_lite_sse_subscribers 1
@@ -504,6 +534,9 @@ sandbox_lite_compile_seconds_count{kind="url"} 0
             cache_bytes: 0,
             cache_hits: 0,
             cache_misses: 0,
+            cache_coalesced: 0,
+            chat_conversations: 0,
+            chat_bytes: 0,
             sse_subscribers: 0,
             sass_running: 0,
             sass_runaway: 0,

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -32,7 +32,9 @@ pub struct Diag {
     pub column: u32,
 }
 
-#[derive(Debug)]
+/// Clone so one compile can answer every caller that waited on it: the followers of an in-flight
+/// build get the leader's failure, diagnostics and all, rather than compiling again to rediscover it.
+#[derive(Debug, Clone)]
 pub struct BuildError {
     pub status: u16,
     pub message: String,
@@ -251,6 +253,9 @@ pub struct CacheStats {
     pub bytes: usize,
     pub hits: u64,
     pub misses: u64,
+    /// Misses that waited on a compile of the same key already running instead of starting a second
+    /// one, so `misses - coalesced` is what the daemon actually compiled.
+    pub coalesced: u64,
 }
 
 struct Cache {
@@ -259,6 +264,7 @@ struct Cache {
     bytes: usize,
     hits: u64,
     misses: u64,
+    coalesced: u64,
 }
 
 /// How long a compile waits for a permit before its request is refused. Long enough to absorb the
@@ -421,6 +427,50 @@ impl Gate {
     }
 }
 
+/// A compile of one cache key that other callers may wait on. Issue #55: `build` looked the cache
+/// up, queued for a permit and did not look again, so N simultaneous requests for one cold module
+/// each compiled it. The results are identical — the cache is content-addressed — so what the herd
+/// costs is CPU and permits, precisely when the daemon is busiest.
+#[derive(Default)]
+struct Inflight {
+    done: Mutex<Option<Result<Arc<Built>, BuildError>>>,
+    ready: Condvar,
+}
+
+/// What a caller asking for a key gets: the right to compile it and answer for it, the right to
+/// compile it for itself alone, or the answer the compile already running for it gave.
+enum Join<'a> {
+    Lead(Lead<'a>),
+    Solo,
+    Waited(Result<Arc<Built>, BuildError>),
+}
+
+/// The one caller compiling a key. Its drop takes the key out of the map and wakes everyone
+/// waiting, so a panic on the way through hands them an answer rather than leaving them there.
+struct Lead<'a> {
+    engine: &'a Engine,
+    key: u128,
+    flight: Arc<Inflight>,
+}
+
+impl Lead<'_> {
+    fn settle(&self, outcome: &Result<Arc<Built>, BuildError>) {
+        *self.flight.done.lock().unwrap() = Some(outcome.clone());
+    }
+}
+
+impl Drop for Lead<'_> {
+    fn drop(&mut self) {
+        self.engine.inflight.lock().unwrap().remove(&self.key);
+        let mut done = self.flight.done.lock().unwrap();
+        if done.is_none() {
+            *done = Some(Err(BuildError::busy("the compile this request was waiting on ended without an answer".into())));
+        }
+        drop(done);
+        self.flight.ready.notify_all();
+    }
+}
+
 /// Marks the thread running a permitted compile, and restores the flag on the way out so a thread
 /// that builds again afterwards queues for a permit of its own.
 struct Compiling(bool);
@@ -449,6 +499,9 @@ pub struct Engine(Arc<EngineInner>);
 pub struct EngineInner {
     pub cfg: Config,
     cache: Mutex<Cache>,
+    /// Cache keys being compiled right now, so the second caller for one waits instead of
+    /// duplicating the compile and the permit it costs.
+    inflight: Mutex<HashMap<u128, Arc<Inflight>>>,
     /// The JS each `.astro` module last compiled to, so a write can be told apart from an edit that
     /// only moved a `<style>` block. Written by every module build, read once per write.
     last_js: Mutex<HashMap<(String, String), u128>>,
@@ -471,11 +524,20 @@ impl Engine {
         Engine::with_gate(cfg, metrics, gate)
     }
 
+    /// An engine whose compile gate is built to order. Neither the queue deadline nor the runaway
+    /// cap is a flag, and a limit of zero — a gate no compile can ever pass — is how a test says
+    /// "every permit is busy" without holding one.
+    #[cfg(test)]
+    pub(crate) fn gated(cfg: Config, metrics: Arc<Metrics>, limit: usize, wait: Duration, max_runaway: usize) -> Engine {
+        Engine::with_gate(cfg, metrics, Gate::new(limit, wait, max_runaway))
+    }
+
     fn with_gate(cfg: Config, metrics: Arc<Metrics>, gate: Gate) -> Engine {
         let sass = scss::Sass::new(cfg.sass_timeout);
         Engine(Arc::new(EngineInner {
             cfg,
-            cache: Mutex::new(Cache { map: HashMap::new(), order: VecDeque::new(), bytes: 0, hits: 0, misses: 0 }),
+            cache: Mutex::new(Cache { map: HashMap::new(), order: VecDeque::new(), bytes: 0, hits: 0, misses: 0, coalesced: 0 }),
+            inflight: Mutex::new(HashMap::new()),
             last_js: Mutex::new(HashMap::new()),
             sass,
             gate,
@@ -494,7 +556,7 @@ impl Engine {
 
     pub fn stats(&self) -> CacheStats {
         let c = self.cache.lock().unwrap();
-        CacheStats { entries: c.map.len(), bytes: c.bytes, hits: c.hits, misses: c.misses }
+        CacheStats { entries: c.map.len(), bytes: c.bytes, hits: c.hits, misses: c.misses, coalesced: c.coalesced }
     }
 
     pub fn sass_stats(&self) -> scss::SassStats {
@@ -503,6 +565,35 @@ impl Engine {
 
     pub fn compile_stats(&self) -> CompileStats {
         self.gate.stats()
+    }
+
+    /// Either the right to compile `key`, or the answer the compile already running for it gave.
+    /// The wait is bounded by what the leader is bounded by — its permit deadline and its compile
+    /// deadline — and its failure is the follower's failure, so nobody is left holding the key.
+    ///
+    /// A thread that is already compiling under a permit never waits: the leader takes the key
+    /// before it takes a permit, so it may be queueing for the very permit this thread is holding —
+    /// a sweep, or the module build a `?type=style` compile makes from inside itself. Such a thread
+    /// compiles the key for itself instead, which is the duplicate the cache has always tolerated.
+    fn join(&self, key: u128) -> Join<'_> {
+        if COMPILING.get() {
+            return Join::Solo;
+        }
+        let mut map = self.inflight.lock().unwrap();
+        let Some(running) = map.get(&key).cloned() else {
+            let flight = Arc::<Inflight>::default();
+            map.insert(key, flight.clone());
+            return Join::Lead(Lead { engine: self, key, flight });
+        };
+        drop(map);
+        self.cache.lock().unwrap().coalesced += 1;
+        let mut done = running.done.lock().unwrap();
+        loop {
+            if let Some(outcome) = done.clone() {
+                return Join::Waited(outcome);
+            }
+            done = running.ready.wait(done).unwrap();
+        }
     }
 
     fn cached(&self, key: u128) -> Option<Arc<Built>> {
@@ -533,6 +624,19 @@ impl Engine {
                 c.bytes -= b.retained_bytes();
             }
         }
+    }
+
+    /// Runs a whole-project compile — `check` — under a single permit taken once, held for the
+    /// sweep and given back at the end. Issue #54: `check` builds every source file of a tenant, and
+    /// a permit per file means that on a saturated daemon the error page waits the queue deadline
+    /// once per file. A maintenance sweep should cost one place in the queue, not one per file.
+    ///
+    /// The per-file compile deadline is untouched: each build inside still runs on its own thread
+    /// with its own wall clock, so one unfinishable file does not take the sweep with it.
+    pub fn sweep<T>(&self, f: impl FnOnce() -> T) -> Result<T, BuildError> {
+        let _permit = self.gate.enter().map_err(BuildError::busy)?;
+        let _compiling = Compiling::enter();
+        Ok(f())
     }
 
     pub fn build(&self, tenant: &Arc<Tenant>, path: &str, kind: Kind) -> Result<Arc<Built>, BuildError> {
@@ -566,6 +670,29 @@ impl Engine {
             return Ok(b);
         }
         self.within_caps(path, kind, &data)?;
+        let lead = match self.join(key) {
+            Join::Lead(lead) => Some(lead),
+            Join::Solo => None,
+            Join::Waited(outcome) => return outcome,
+        };
+        let outcome = self.compile_once(tenant, path, kind, data, site, key);
+        if let Some(lead) = lead {
+            lead.settle(&outcome);
+        }
+        outcome
+    }
+
+    /// The compile itself, under a permit: the caller holds the key while this runs, so this is the
+    /// only thread compiling it however many requests are waiting.
+    fn compile_once(
+        &self,
+        tenant: &Arc<Tenant>,
+        path: &str,
+        kind: Kind,
+        data: Arc<[u8]>,
+        site: Option<String>,
+        key: u128,
+    ) -> Result<Arc<Built>, BuildError> {
         let _permit = self.gate.enter().map_err(|e| BuildError::busy(format!("{path}: {e}")))?;
         let started = Instant::now();
         let compiled = self.bounded(tenant, path, kind, data, site);
@@ -1212,6 +1339,67 @@ mod tests {
         let e = build_err(engine.build(&t, "src/b.scss", Kind::Module));
         assert_eq!(e.status, 503);
         assert!(e.message.contains("past their deadline"), "{}", e.message);
+        assert_eq!(engine.compile_stats().refused, 1);
+    }
+
+    /// Issue #55: `build` looked the cache up, queued for a permit and did not look again, so N
+    /// simultaneous requests for one cold module each compiled it. Four ask at once; one compiles,
+    /// and the three that waited are counted as waits rather than as hits.
+    #[test]
+    fn a_burst_on_one_cold_module_compiles_it_once() {
+        let t = tenant_with("src/slow.scss", &slow_source());
+        let metrics = Arc::new(crate::metrics::Metrics::default());
+        let cfg = Config { compile_timeout: Duration::from_secs(1), ..capped(CAP) };
+        let engine = Engine::gated(cfg, metrics.clone(), 4, Duration::from_millis(50), MAX_RUNAWAY_COMPILES);
+
+        std::thread::scope(|scope| {
+            let leader = scope.spawn(|| engine.build(&t, "src/slow.scss", Kind::Module).err().map(|e| e.message));
+            let deadline = Instant::now() + Duration::from_secs(5);
+            while engine.compile_stats().running < 1 && Instant::now() < deadline {
+                std::thread::yield_now();
+            }
+            let followers: Vec<_> =
+                (0..3).map(|_| scope.spawn(|| engine.build(&t, "src/slow.scss", Kind::Module).err().map(|e| e.message))).collect();
+            let first = leader.join().unwrap();
+            for f in followers {
+                assert_eq!(f.join().unwrap(), first, "a follower answers with what the one compile produced");
+            }
+        });
+
+        let cache = engine.stats();
+        assert_eq!((cache.misses, cache.coalesced), (4, 3), "four lookups missed, three of them waited");
+        assert_eq!(metrics.compiles()[0].count(), 1, "one compile, not four");
+        assert_eq!(engine.compile_stats().running, 0);
+    }
+
+    /// Issue #54: `check` builds every source file of a tenant, and a permit per file meant that on
+    /// a saturated daemon the error page waited the queue deadline once per file. The sweep takes
+    /// one permit and holds it; the builds inside take none, so a gate emptied under them still lets
+    /// every file through.
+    #[test]
+    fn a_sweep_compiles_every_file_under_one_permit() {
+        let files = ["src/a.ts", "src/b.ts", "src/c.ts"];
+        let t = tenant(&[(files[0], "export const a = 1;\n"), (files[1], "export const b = 2;\n"), (files[2], "export const c = 3;\n")]);
+        let engine = engine_gated(capped(CAP), 1, Duration::from_millis(50));
+        let built = engine
+            .sweep(|| {
+                engine.gate.limit.store(0, Ordering::Relaxed);
+                files.map(|p| engine.build(&t, p, Kind::Module).is_ok())
+            })
+            .unwrap();
+        assert_eq!(built, [true, true, true]);
+        assert_eq!(engine.compile_stats().refused, 0, "the sweep queued once and nothing inside it queued again");
+    }
+
+    /// And when it cannot have that one permit it says so once, after one wait.
+    #[test]
+    fn a_saturated_sweep_is_refused_once_not_once_per_file() {
+        let engine = engine_bounded(capped(CAP), 0, Duration::from_millis(100), MAX_RUNAWAY_COMPILES);
+        let started = Instant::now();
+        let e = engine.sweep(|| 0u8).unwrap_err();
+        assert_eq!(e.status, 503);
+        assert!(e.message.contains("waited 100 ms"), "{}", e.message);
+        assert!(started.elapsed() < Duration::from_secs(1), "the sweep waited {:?}", started.elapsed());
         assert_eq!(engine.compile_stats().refused, 1);
     }
 


### PR DESCRIPTION
Closes #54
Closes #55
Closes #60

Three requests that pay for work nobody asked them to do. One kind of defect,
so one pull request.

## #54 — the error page could wait the compile deadline once per file

A module that does not compile is answered `500` with `{"error","diagnostics"}`,
and the browser hides that body behind "failed to fetch dynamically imported
module", so `shell.js` asked `/__sl/check` instead — which compiles every source
file of the tenant, each taking a compile permit since #53. On a daemon whose
permits are all busy, the page that exists to explain a failure waited the
five-second queue deadline once per file.

Both halves are fixed, separately:

- `shell.js` re-fetches the module URLs it can name — the page module it tried
  to import, and any `/__sl/m/` URL in the error's message or stack — and reads
  the diagnostics out of the first 500 body that carries them. `/__sl/check` is
  the fallback, for a failure no module body explains.
- `check_tenant` runs inside a new `Engine::sweep`, which takes **one** permit
  and holds it for the whole project. The builds inside take none. A sweep that
  cannot have that permit waits once and answers with that one refusal as its
  diagnostic, rather than multiplying the deadline by the file count. The
  per-file compile deadline is untouched: each build still gets its own thread
  and its own wall clock.

## #55 — a burst on one cold module compiled it more than once

`Engine::build` looked the cache up, queued for a permit and did not look again.
`Engine::inflight` is a map of the keys being compiled: the second caller waits
on the first and takes its answer, `BuildError` included (hence `BuildError:
Clone`). The `Lead` guard removes the key and wakes the waiters on its way out,
panic or not, so nobody waits on a compile that will never answer.

The wait is counted as `coalesced`, apart from a hit, so `misses - coalesced` is
still what the daemon compiled — `/api/stats` (`cache.coalesced`) and `/metrics`
(`sandbox_lite_cache_coalesced_total`) both carry it.

One caller never waits: a thread already compiling under a permit — a sweep, or
the module build a `?type=style` compile makes from inside itself. The leader
takes the key *before* it takes a permit, so it may be queueing for the very
permit that thread is holding; it compiles the key for itself instead, which is
the duplicate the cache has always tolerated.

## #60 — `/api/stats` walked every tenant's chats directory

`Chats` now holds what each tenant's conversations weigh, `<tenant> → <chat id>
→ bytes`, seeded from the store the first time a tenant is touched and moved by
every save and delete. `usage` reads that, so neither `/api/stats` nor
`/metrics` lists a directory — and `/metrics` gained the two gauges
(`sandbox_lite_chats`, `sandbox_lite_chat_bytes`) the issue asked for.

The cap is the deliberate exception: `evict` still counts the directory on a
save, because it decides which files to delete and must see what another
writer left there. `docs/multi-node.md` says what that means across nodes.

## Tests

All in the suite CI runs:

- `a_burst_on_one_cold_module_compiles_it_once` — four concurrent requests for
  one cold module: four misses, three coalesced, one compile in the histogram.
- `a_sweep_compiles_every_file_under_one_permit` — the gate is emptied to zero
  permits *inside* the sweep and every file still builds, with no refusals.
- `a_saturated_sweep_is_refused_once_not_once_per_file`.
- `check_on_a_saturated_daemon_waits_once_not_once_per_file` — `check_tenant`
  against a gate no compile can pass answers in one wait, over the starter
  example's 19 source files, with the refusal as its single diagnostic.
- `check_names_the_file_that_does_not_compile`.
- `usage_is_counted_in_memory_and_still_matches_the_files` — the counters equal
  the files after a save, an evict and a restore onto a fresh `Chats`, and still
  answer once the directory has been deleted, which is what proves no directory
  read.
- `e2e/error-overlay.spec.ts` asserts the overlay renders its diagnostic without
  the page ever requesting `/__sl/check`.

CI: https://github.com/productdevbook/sandbox-lite/actions/runs/34064754323

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
