### PR TITLE
tests: one fixture constructor, so a new field stops breaking other people's branches

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,6 +103,14 @@ Formatting follows `rustfmt.toml` (140 columns). Clippy warnings are errors.
 test for the transform pipeline. CI also starts the daemon, creates a tenant
 with `curl`, and fetches one module, `routes.json` and the shell.
 
+Two of those tests read the crate's own source rather than run it, and each keeps a tolerated
+list that may only shrink: `src/silent_failures.rs` fails when code on a request path throws an
+error away, and `src/shared_fixtures.rs` fails when a test builds `AppState`, a transform
+`Config` or an `Engine` field by field. Tests build those through `AppState::for_tests()` and
+`Engine::for_tests*()` and say only the value they need (`..AppState::for_tests()` for the rest),
+so that a field added to one of them is a single edit and cannot break a fixture in a pull
+request its author never saw.
+
 Beyond what CI can see:
 
 - If you touched `src/transform/`, `src/resolve.rs`, `assets/shell.js` or a

--- a/src/http/ai.rs
+++ b/src/http/ai.rs
@@ -595,7 +595,6 @@ mod tests {
 
     use super::*;
     use crate::store::{Base, Store};
-    use crate::transform::{Config, Engine};
 
     const TEST_QUOTA: u64 = 1 << 20;
 
@@ -699,23 +698,14 @@ mod tests {
         store.add_base(Base::load("test", &base_dir).unwrap());
         store.create_tenant("acme", "test").unwrap();
         let (api_base, seen) = upstream(turns).await;
-        let metrics = Arc::new(crate::metrics::Metrics::default());
         let st = Arc::new(AppState {
             store,
-            engine: Engine::new(Config { cache_bytes: 1 << 20, ..Config::default() }, metrics.clone()),
-            metrics,
-            chats: super::super::chats::Chats::default(),
-            domain: "localhost".into(),
-            port: 4321,
             model: "test-model".into(),
             api_key: Some("test-key".into()),
             api_base,
-            api_token: None,
-            preview_secret: None,
-            cookie_samesite: super::super::SameSite::Lax,
             chrome,
             shots,
-            started: Instant::now(),
+            ..AppState::for_tests()
         });
         Fixture { st, seen, root }
     }
@@ -853,24 +843,7 @@ mod tests {
         assert_eq!(status, StatusCode::NOT_FOUND);
         assert_eq!(serde_json::from_str::<Value>(&body).unwrap()["error"], "unknown chat");
 
-        let metrics = Arc::new(crate::metrics::Metrics::default());
-        let broken = Arc::new(AppState {
-            store: Store::new(None, TEST_QUOTA),
-            engine: Engine::new(Config { cache_bytes: 1 << 20, ..Config::default() }, metrics.clone()),
-            metrics,
-            chats: super::super::chats::Chats::default(),
-            domain: "localhost".into(),
-            port: 4321,
-            model: "m".into(),
-            api_key: Some("k".into()),
-            api_base: "http://127.0.0.1:1".into(),
-            api_token: None,
-            preview_secret: None,
-            cookie_samesite: super::super::SameSite::Lax,
-            chrome: None,
-            shots: super::super::ai::Shots::default(),
-            started: Instant::now(),
-        });
+        let broken = Arc::new(AppState { store: Store::new(None, TEST_QUOTA), api_key: Some("k".into()), ..AppState::for_tests() });
         broken.store.add_base(Base::load("test", &f.root.join("base")).unwrap());
         broken.store.create_tenant("acme", "test").unwrap();
         let (status, body) = post_chat(&broken, None, ask("hi", None)).await;

--- a/src/http/archive.rs
+++ b/src/http/archive.rs
@@ -240,7 +240,6 @@ pub async fn import(AxState(st): AxState<State>, Path(id): Path<String>, RawQuer
 mod tests {
     use std::path::PathBuf;
     use std::sync::Arc;
-    use std::time::Instant;
 
     use axum::body::Body;
     use axum::http::Request;
@@ -249,7 +248,6 @@ mod tests {
     use super::*;
     use crate::http::AppState;
     use crate::store::{Base, Store};
-    use crate::transform::{Config, Engine};
 
     struct Fixture {
         app: axum::Router,
@@ -279,24 +277,7 @@ mod tests {
         store.add_base(Base::load("b", &root.join("base")).unwrap());
         store.create_tenant("a", "b").unwrap();
         store.create_tenant("bb", "b").unwrap();
-        let metrics = Arc::new(crate::metrics::Metrics::default());
-        let state = Arc::new(AppState {
-            store,
-            engine: Engine::new(Config { cache_bytes: 1 << 20, ..Config::default() }, metrics.clone()),
-            metrics,
-            chats: crate::http::chats::Chats::default(),
-            domain: "localhost".into(),
-            port: 4321,
-            model: "m".into(),
-            api_key: None,
-            api_base: "http://127.0.0.1:1".into(),
-            api_token: None,
-            preview_secret: None,
-            cookie_samesite: crate::http::SameSite::Lax,
-            chrome: None,
-            shots: crate::http::ai::Shots::default(),
-            started: Instant::now(),
-        });
+        let state = Arc::new(AppState { store, ..AppState::for_tests() });
         Fixture { app: crate::http::app(state.clone()), state, root }
     }
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -298,40 +298,53 @@ pub fn mime(path: &str) -> &'static str {
     }
 }
 
+/// The state every fixture starts from, so that a field added to `AppState` is one edit here rather
+/// than one in each test that builds one. A fixture that needs a different value says only that
+/// value: `AppState { api_key: Some("k".into()), ..AppState::for_tests() }`.
 #[cfg(test)]
-mod tests {
-    use std::path::PathBuf;
-    use std::sync::Arc;
-    use std::time::Instant;
-
-    use axum::body::Body;
-    use axum::http::header::{LOCATION, SET_COOKIE};
-    use axum::http::{HeaderName, Request, StatusCode};
-    use tower::ServiceExt;
-
-    use super::{AppState, SameSite, State, app, chats, constant_time_eq, preview_token, tenant_from_host};
-    use crate::metrics::Metrics;
-    use crate::store::Store;
-    use crate::transform::{Config, Engine};
-
-    fn state_for(store: Store, api_token: Option<&str>, preview_secret: Option<&str>) -> State {
-        let metrics = Arc::new(Metrics::default());
-        Arc::new(AppState {
-            store,
-            engine: Engine::new(Config { cache_bytes: 1 << 20, ..Config::default() }, metrics.clone()),
-            metrics,
+impl AppState {
+    pub fn for_tests() -> AppState {
+        let engine = Engine::for_tests();
+        AppState {
+            store: Store::new(None, u64::MAX),
+            metrics: engine.metrics(),
+            engine,
             chats: chats::Chats::default(),
             domain: "localhost".into(),
             port: 4321,
             model: "m".into(),
             api_key: None,
             api_base: "http://127.0.0.1:1".into(),
+            api_token: None,
+            preview_secret: None,
+            cookie_samesite: SameSite::Lax,
+            chrome: None,
+            shots: ai::Shots::default(),
+            started: Instant::now(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    use axum::body::Body;
+    use axum::http::header::{LOCATION, SET_COOKIE};
+    use axum::http::{HeaderName, Request, StatusCode};
+    use tower::ServiceExt;
+
+    use super::{AppState, SameSite, State, app, constant_time_eq, preview_token, tenant_from_host};
+    use crate::store::Store;
+
+    fn state_for(store: Store, api_token: Option<&str>, preview_secret: Option<&str>) -> State {
+        Arc::new(AppState {
+            store,
             api_token: api_token.map(str::to_string),
             preview_secret: preview_secret.map(str::to_string),
             cookie_samesite: SameSite::default_for(preview_secret),
-            chrome: None,
-            shots: super::ai::Shots::default(),
-            started: Instant::now(),
+            ..AppState::for_tests()
         })
     }
 

--- a/src/http/preview.rs
+++ b/src/http/preview.rs
@@ -342,7 +342,6 @@ pub async fn page(AxState(st): AxState<State>, Extension(id): Extension<TenantId
 mod tests {
     use std::path::Path;
     use std::sync::Arc;
-    use std::time::Instant;
 
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
@@ -350,10 +349,8 @@ mod tests {
     use tower::ServiceExt;
 
     use super::percent_decode;
-    use crate::http::{AppState, SameSite, app, chats};
-    use crate::metrics::Metrics;
+    use crate::http::{AppState, app};
     use crate::store::{Base, Store, UpdateKind};
-    use crate::transform::{Config, Engine};
 
     #[test]
     fn percent_decode_takes_any_string() {
@@ -365,7 +362,6 @@ mod tests {
     }
 
     fn starter_app(files: &[(&str, &str)]) -> axum::Router {
-        let metrics = Arc::new(Metrics::default());
         let store = Store::new(None, u64::MAX);
         let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("examples/starter");
         store.add_base(Base::load("starter", &root).unwrap());
@@ -373,23 +369,7 @@ mod tests {
         for (path, body) in files {
             t.write(path, body.as_bytes().to_vec(), UpdateKind::from_path(path)).unwrap();
         }
-        app(Arc::new(AppState {
-            store,
-            engine: Engine::new(Config { cache_bytes: 1 << 20, ..Config::default() }, metrics.clone()),
-            metrics,
-            chats: chats::Chats::default(),
-            shots: crate::http::ai::Shots::default(),
-            domain: "localhost".into(),
-            port: 4321,
-            model: "m".into(),
-            api_key: None,
-            api_base: "http://127.0.0.1:1".into(),
-            api_token: None,
-            preview_secret: None,
-            cookie_samesite: SameSite::Lax,
-            chrome: None,
-            started: Instant::now(),
-        }))
+        app(Arc::new(AppState { store, ..AppState::for_tests() }))
     }
 
     async fn collection(app: &axum::Router, name: &str) -> (StatusCode, Value) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,8 @@ mod transform;
 #[cfg(test)]
 mod proptests;
 #[cfg(test)]
+mod shared_fixtures;
+#[cfg(test)]
 mod silent_failures;
 
 use std::path::PathBuf;

--- a/src/proptests.rs
+++ b/src/proptests.rs
@@ -96,7 +96,7 @@ fn css() -> impl Strategy<Value = String> {
 /// The stack `Engine::build` gives every parser; running one here on the 2 MiB test-thread stack
 /// aborts the whole test binary instead of failing a case.
 fn parser_stack<T: Send>(f: impl FnOnce() -> T + Send) -> T {
-    let engine = Engine::new(Config::default(), std::sync::Arc::new(crate::metrics::Metrics::default()));
+    let engine = Engine::for_tests_with(Config::default());
     engine.on_parser_stack(f).expect("compiler thread")
 }
 

--- a/src/shared_fixtures.rs
+++ b/src/shared_fixtures.rs
@@ -1,0 +1,212 @@
+//! Issue #51, made permanent: a check that reads this crate's own source for a test fixture that
+//! builds `AppState`, a transform `Config` or an `Engine` field by field. Each such literal is a
+//! place a field added to the type has to be edited, and missing one is how `Config::sass_timeout`
+//! turned `main` red — two pull requests, each green on its own branch.
+//!
+//! Test code builds these through `AppState::for_tests` and `Engine::for_tests*`, and a fixture that
+//! needs a different value says only that value: `AppState { store, ..AppState::for_tests() }`. So
+//! the rule, inside a `#[cfg(test)] mod` and over the whole of a module `main.rs` compiles only
+//! under test: a literal of one of these types must hand the rest of its fields to the shared
+//! constructor with `..`, and `Engine::new` and `Engine::with_gate` must not be named at all. Both
+//! are named once, in the `#[cfg(test)] impl` blocks that sit outside the test modules and are the
+//! one place a new argument is edited.
+//!
+//! Production code is out of scope. `main.rs` names every field of `AppState` and every field of
+//! `Config` once, on purpose: that literal is what the flags mean, and the compiler stops there
+//! anyway when a field is added.
+//!
+//! `TOLERATED` may only shrink. Each entry carries the reason spelling the fields out is right
+//! there, and adding one is a decision to be argued for in review — not a way to get to green.
+
+use std::path::Path;
+
+use crate::silent_failures::{rust_files, src_dir};
+
+/// Types a fixture used to spell out. A literal of one of these in test code must carry a `..`.
+const SHARED: [&str; 2] = ["AppState", "Config"];
+
+/// The engine constructors, whose argument lists a fixture used to repeat.
+const ENGINE_CTORS: [&str; 2] = ["Engine::new(", "Engine::with_gate("];
+
+/// Every site the rule catches that is right as it stands, with the reason it is.
+const TOLERATED: [(&str, &str); 0] = [];
+
+/// The test code of one file as `(1-based line number, text)`: everything from the `#[cfg(test)]`
+/// that opens a test module, or every line when the file is a module compiled only under test.
+fn test_lines(text: &str, whole_file: bool) -> Vec<(usize, String)> {
+    let lines: Vec<&str> = text.lines().collect();
+    let opens_test_mod = |i: usize| {
+        lines[i].trim() == "#[cfg(test)]"
+            && lines.get(i + 1).is_some_and(|next| next.trim_start().starts_with("mod ") && !next.trim_end().ends_with(';'))
+    };
+    let start = if whole_file {
+        0
+    } else {
+        match (0..lines.len()).find(|i| opens_test_mod(*i)) {
+            Some(i) => i,
+            None => return Vec::new(),
+        }
+    };
+    lines[start..].iter().enumerate().map(|(i, line)| (start + i + 1, (*line).to_string())).collect()
+}
+
+/// `Type {` on `line`, opening a literal: not the tail of a longer name, and not a definition, an
+/// `impl` header or a return type.
+fn opens_literal(line: &str, ty: &str) -> bool {
+    let trimmed = line.trim_start();
+    if ["struct ", "pub struct ", "impl ", "fn ", "pub fn "].iter().any(|item| trimmed.starts_with(item)) {
+        return false;
+    }
+    let needle = format!("{ty} {{");
+    line.match_indices(&needle).any(|(at, _)| {
+        let before = &line[..at];
+        !before.chars().next_back().is_some_and(|c| c.is_alphanumeric() || c == '_') && !before.trim_end().ends_with("->")
+    })
+}
+
+/// The literal that opens on `lines[i]`: that line alone when its braces close on it, otherwise down
+/// to the line that closes it at the opening line's indentation. rustfmt puts the close there, and a
+/// brace count would have to know which braces are inside a string.
+fn literal(lines: &[(usize, String)], i: usize) -> String {
+    let open = &lines[i].1;
+    if open.matches('{').count() == open.matches('}').count() {
+        return open.clone();
+    }
+    let indent = open.len() - open.trim_start().len();
+    let mut body = open.clone();
+    for (_, line) in &lines[i + 1..] {
+        body.push('\n');
+        body.push_str(line);
+        if line.trim_start().starts_with('}') && line.len() - line.trim_start().len() <= indent {
+            break;
+        }
+    }
+    body
+}
+
+/// Whether a literal hands its remaining fields to a constructor. The `..` has to be the literal's
+/// own last element — a nested `Config { cache_bytes, ..Config::default() }` inside a state literal
+/// that lists all fifteen of its own does not make that state literal safe, and reading the body for
+/// any `..` at all is how this rule first missed every one of them.
+fn delegates(body: &str) -> bool {
+    match body.lines().count() {
+        1 => body.contains(".."),
+        _ => body.lines().any(|line| line.trim_start().starts_with("..")),
+    }
+}
+
+/// Every construction in `lines` that a field added to one of these types would break.
+fn field_by_field(lines: &[(usize, String)]) -> Vec<(usize, String)> {
+    let mut out = Vec::new();
+    for (i, (number, line)) in lines.iter().enumerate() {
+        let calls_ctor = ENGINE_CTORS.iter().any(|ctor| line.contains(ctor));
+        let spells_out = SHARED.iter().any(|ty| opens_literal(line, ty)) && !delegates(&literal(lines, i));
+        if calls_ctor || spells_out {
+            out.push((*number, line.trim().to_string()));
+        }
+    }
+    out
+}
+
+/// The modules `main.rs` compiles only under test; every line of those files is test code.
+fn test_only_modules() -> Vec<String> {
+    let text = std::fs::read_to_string(src_dir().join("main.rs")).expect("main.rs is readable");
+    let lines: Vec<&str> = text.lines().collect();
+    lines
+        .windows(2)
+        .filter(|pair| pair[0].trim() == "#[cfg(test)]")
+        .filter_map(|pair| pair[1].trim().strip_prefix("mod ").and_then(|name| name.strip_suffix(';')).map(str::to_string))
+        .collect()
+}
+
+#[test]
+fn no_fixture_lists_the_fields_of_a_shared_type() {
+    let mut files = Vec::new();
+    rust_files(&src_dir(), &mut files);
+    files.sort();
+    assert!(files.len() > 10, "the walk found only {} files, so it is not reading the crate", files.len());
+
+    let whole_file = test_only_modules();
+    assert!(!whole_file.is_empty(), "no `#[cfg(test)] mod x;` in main.rs, so the test-only modules are not being read");
+
+    let mut scanned = 0;
+    let mut found = Vec::new();
+    for path in &files {
+        if path.ends_with("shared_fixtures.rs") {
+            continue;
+        }
+        let stem = path.file_stem().unwrap_or_default().to_string_lossy().into_owned();
+        let text = std::fs::read_to_string(path).expect("a readable source file");
+        let lines = test_lines(&text, whole_file.contains(&stem));
+        scanned += lines.len();
+        for (number, line) in field_by_field(&lines) {
+            found.push((relative(path), number, line));
+        }
+    }
+    assert!(scanned > 1000, "only {scanned} lines of test code were read, so the scan is not finding the test modules");
+
+    let unexplained: Vec<String> = found
+        .iter()
+        .filter(|(_, _, line)| !TOLERATED.iter().any(|(tolerated, _)| tolerated == line))
+        .map(|(file, number, line)| format!("  {file}:{number}: {line}"))
+        .collect();
+    assert!(
+        unexplained.is_empty(),
+        "these fixtures name fields or constructor arguments a later pull request will add to — build them with \
+         `AppState::for_tests()` / `Engine::for_tests*()` and say only the values that matter, or add the line to \
+         TOLERATED in src/shared_fixtures.rs with the reason:\n{}",
+        unexplained.join("\n")
+    );
+
+    // The list may only shrink: an entry nothing matches any more is a fixture that was fixed, and
+    // leaving it behind lets the next one of that shape in without review.
+    let stale: Vec<&str> =
+        TOLERATED.iter().map(|(line, _)| *line).filter(|tolerated| !found.iter().any(|(_, _, line)| line == tolerated)).collect();
+    assert!(stale.is_empty(), "TOLERATED entries that match nothing any more — delete them:\n  {}", stale.join("\n  "));
+}
+
+#[test]
+fn the_rule_catches_the_fixtures_it_was_written_for() {
+    // src/http/archive.rs before this change, cut short.
+    let was = numbered(&[
+        "        let metrics = Arc::new(crate::metrics::Metrics::default());",
+        "        let state = Arc::new(AppState {",
+        "            store,",
+        "            engine: Engine::new(Config { cache_bytes: 1 << 20, ..Config::default() }, metrics.clone()),",
+        "            chats: crate::http::chats::Chats::default(),",
+        "            started: Instant::now(),",
+        "        });",
+    ]);
+    assert_eq!(field_by_field(&was).len(), 2, "the state literal and the `Engine::new` inside it");
+
+    // and what replaced it, plus the two forms that say only what they need
+    assert!(field_by_field(&numbered(&["        let state = Arc::new(AppState { store, ..AppState::for_tests() });"])).is_empty());
+    assert!(field_by_field(&numbered(&["        Config { cache_bytes: 8 << 20, max_source_bytes, ..Config::default() }"])).is_empty());
+    assert_eq!(field_by_field(&numbered(&["        Engine::with_gate(cfg, metrics, gate)"])).len(), 1);
+
+    // a definition, an impl header and a return type are not literals, and neither is a longer name
+    assert!(field_by_field(&numbered(&["pub struct AppState {", "    pub store: Store,", "}"])).is_empty());
+    assert!(field_by_field(&numbered(&["impl Default for Config {", "    fn default() -> Config {", "    }", "}"])).is_empty());
+    assert!(field_by_field(&numbered(&["    fn capped(max: usize) -> Config {", "        cfg", "    }"])).is_empty());
+    assert!(field_by_field(&numbered(&["    let c = SassConfig { timeout, threads };"])).is_empty());
+}
+
+#[test]
+fn only_test_code_is_read() {
+    // `#[cfg(test)] mod proptests;` declares a module, it does not open one: what follows it in
+    // main.rs is the daemon's own `AppState`, which names every field on purpose.
+    let declared = "#[cfg(test)]\nmod proptests;\n\nlet state = Arc::new(http::AppState {\n    store,\n});\n";
+    assert!(test_lines(declared, false).is_empty());
+    assert_eq!(test_lines(declared, true).len(), 6);
+
+    let module = "fn serve() {}\n\n#[cfg(test)]\nmod tests {\n    fn state() {}\n}\n";
+    assert_eq!(test_lines(module, false).first().map(|(number, _)| *number), Some(3));
+}
+
+fn relative(path: &Path) -> String {
+    path.strip_prefix(src_dir()).unwrap_or(path).display().to_string()
+}
+
+fn numbered(lines: &[&str]) -> Vec<(usize, String)> {
+    lines.iter().enumerate().map(|(i, line)| (i + 1, (*line).to_string())).collect()
+}

--- a/src/silent_failures.rs
+++ b/src/silent_failures.rs
@@ -59,11 +59,11 @@ const TOLERATED: [(&str, &str); 8] = [
     ("let _ = self.events.send(format!(", "a broadcast with no subscribers, which is the normal state of a tenant nobody is previewing"),
 ];
 
-fn src_dir() -> PathBuf {
+pub fn src_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("src")
 }
 
-fn rust_files(dir: &Path, out: &mut Vec<PathBuf>) {
+pub fn rust_files(dir: &Path, out: &mut Vec<PathBuf>) {
     for entry in std::fs::read_dir(dir).expect("src is readable") {
         let path = entry.expect("a readable directory entry").path();
         if path.is_dir() {

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -869,6 +869,29 @@ pub fn is_source(path: &str) -> bool {
     ) && path.starts_with("src/")
 }
 
+/// Every engine a test builds comes from here: `Engine::new` and `Engine::with_gate` are named in
+/// this block and nowhere under `#[cfg(test)] mod`, so an argument added to either is one edit.
+#[cfg(test)]
+impl Engine {
+    pub fn for_tests() -> Engine {
+        Engine::for_tests_with(Config { cache_bytes: 1 << 20, ..Config::default() })
+    }
+
+    pub fn for_tests_with(cfg: Config) -> Engine {
+        Engine::new(cfg, Arc::new(Metrics::default()))
+    }
+
+    /// Neither the queue deadline nor the runaway cap is a flag, so tests build the gate directly.
+    pub fn for_tests_gated(cfg: Config, limit: usize, wait: Duration, max_runaway: usize) -> Engine {
+        Engine::with_gate(cfg, Arc::new(Metrics::default()), Gate::new(limit, wait, max_runaway))
+    }
+
+    /// So a fixture's state records into the same metrics as the engine inside it, as the daemon does.
+    pub fn metrics(&self) -> Arc<Metrics> {
+        self.metrics.clone()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -896,7 +919,7 @@ mod tests {
     }
 
     fn engine() -> Engine {
-        Engine::new(Config { cache_bytes: 1 << 20, ..Config::default() }, Arc::new(crate::metrics::Metrics::default()))
+        Engine::for_tests()
     }
 
     fn served(engine: &Engine, tenant: &Arc<Tenant>) -> String {
@@ -906,21 +929,19 @@ mod tests {
     const CAP: usize = 64 << 10;
 
     fn engine_capped(max_source_bytes: usize) -> Engine {
-        Engine::new(capped(max_source_bytes), Arc::new(crate::metrics::Metrics::default()))
+        Engine::for_tests_with(capped(max_source_bytes))
     }
 
     fn tenant_with(path: &str, source: &str) -> Arc<Tenant> {
         tenant(&[(path, source)])
     }
 
-    /// Neither the queue deadline nor the runaway cap is a flag, so tests build the gate directly.
     fn engine_gated(cfg: Config, limit: usize, wait: Duration) -> Engine {
         engine_bounded(cfg, limit, wait, MAX_RUNAWAY_COMPILES)
     }
 
     fn engine_bounded(cfg: Config, limit: usize, wait: Duration, max_runaway: usize) -> Engine {
-        let metrics = Arc::new(crate::metrics::Metrics::default());
-        Engine::with_gate(cfg, metrics, Gate::new(limit, wait, max_runaway))
+        Engine::for_tests_gated(cfg, limit, wait, max_runaway)
     }
 
     fn capped(max_source_bytes: usize) -> Config {


### PR DESCRIPTION
Closes #51

`Engine::new` had six test call sites and the `AppState` literal five, each naming every field of
the type. That is why a field added by one pull request kept breaking a fixture added by another,
both green on their own branches: `Config::sass_timeout` (#35 + #36) turned `main` red, and
`Engine::new`'s metrics argument did it again.

## One place per type

- `Engine::for_tests()`, `Engine::for_tests_with(cfg)` and `Engine::for_tests_gated(cfg, limit,
  wait, max_runaway)` in `src/transform/mod.rs` name `Engine::new` and `Engine::with_gate` once
  each. A new argument to either is one edit.
- `AppState::for_tests()` in `src/http/mod.rs` names the state's fifteen fields once, and hands the
  engine's `Metrics` to the state around it, as `main.rs` does.
- Every fixture goes through them and says only the value it needs: `AppState { store,
  ..AppState::for_tests() }` in `archive.rs` and `preview.rs`, and in `ai.rs` the four values that
  test actually depends on. `grep` finds no test literal that lists the fields.

Production is untouched. `main.rs` still names every field of `AppState` and of `Config` once —
that literal is what the flags mean, and the compiler stops there when a field is added.

## The rule, and what it catches

`src/shared_fixtures.rs`, in the shape `src/silent_failures.rs` established: it reads the crate's
own source and fails when test code opens an `AppState` or transform `Config` literal whose last
element is not a `..`, or names `Engine::new` / `Engine::with_gate` at all. Its scope is
`#[cfg(test)] mod` blocks plus the modules `main.rs` compiles only under test; `TOLERATED` carries a
reason per entry and the test also fails on an entry that matches nothing, so the list can only
shrink.

**Measured before committing to it: 14 sites on `origin/main`** — five `AppState` literals, eight
`Engine::new` calls and one `Engine::with_gate` — and **0 on this branch**, so `TOLERATED` is
empty. A handful rather than fifty: the rule is narrow enough to be a rule.

Measuring also corrected it. Its first form asked whether the literal body contained a `..`
anywhere and caught only 9 of the 14: every state literal held a nested
`Config { cache_bytes: 1 << 20, ..Config::default() }`, which made all five state literals look
safe. The `..` now has to be the literal's own last element, and two unit tests in that file pin the
old `archive.rs` fixture as caught, the new one as clean, and a definition, an `impl` header, a
`-> Config {` return type and `SassConfig { … }` as not literals of these types.

`CONTRIBUTING.md` gains a paragraph naming both source-reading tests, verified against what they do
rather than against this issue.

## CI

Green on `test` and `e2e` at the current head (408dc0c, rebased onto main):
https://github.com/productdevbook/sandbox-lite/actions/runs/34065633302

## Noticed, not fixed

- `src/silent_failures.rs` stops reading a file at its first *indented* `#[cfg(test)]`, not at its
  test module. In `src/transform/mod.rs` that is line 152, so 743 lines of the crate's largest
  production module are never scanned by the #48 rule, and in `main.rs` 286 lines. Nothing
  swallow-shaped sits in either gap today (I counted: 0), so it is a claim wider than the proof
  rather than a live bug.
- This change moves that cutoff 24 lines earlier in `src/http/mod.rs` — the `#[cfg(test)] impl
  AppState` block sits before `mod tests`, which is where `clippy::items_after_test_module` wants
  it. Those 24 lines are the test constructor and contain nothing the #48 rule looks for.
- `Engine::for_tests()` builds a `Store` that a fixture overriding `store` throws away. Both are
  cheap (no data dir, no threads), but it is waste that a `Default` on `Store` would remove.
- The gate helpers in `src/transform/mod.rs`'s tests (`engine_gated`, `engine_bounded`) are now
  one-line pass-throughs to `Engine::for_tests_gated`; they read better inlined, but that is churn
  across a dozen tests for no safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L

