### PR TITLE
ratchets: scan the whole file, and say what the checks do not prove

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,11 @@ error away, and `src/shared_fixtures.rs` fails when a test builds `AppState`, a 
 `Config` or an `Engine` field by field. Tests build those through `AppState::for_tests()` and
 `Engine::for_tests*()` and say only the value they need (`..AppState::for_tests()` for the rest),
 so that a field added to one of them is a single edit and cannot break a fixture in a pull
-request its author never saw.
+request its author never saw. Both read text rather than an AST, and each catches only the
+spellings listed at the top of its own file: `silent_failures.rs` over every line up to a
+file's `#[cfg(test)] mod`, `shared_fixtures.rs` over every line from it. Neither is a proof
+that the class is absent, and each says at the top of the file what it does not prove — read
+that before closing an issue on the strength of a green run.
 
 Beyond what CI can see:
 

--- a/src/shared_fixtures.rs
+++ b/src/shared_fixtures.rs
@@ -17,6 +17,20 @@
 //!
 //! `TOLERATED` may only shrink. Each entry carries the reason spelling the fields out is right
 //! there, and adding one is a decision to be argued for in review — not a way to get to green.
+//!
+//! What a green run does **not** prove:
+//!
+//! - That every fixture delegates. It proves that no line inside a test module opens an `AppState`
+//!   or a `Config` literal without a `..`, and that neither engine constructor is named there. A
+//!   fixture built by a helper that spells the fields out somewhere this scan does not read is not
+//!   caught, and neither is a shared type nobody added to `SHARED`.
+//! - That the `#[cfg(test)] impl` blocks are the only place the fields are spelled out. Those two
+//!   blocks are skipped because they sit *above* their file's test module and the scan starts at
+//!   it — position, not intent. One written below the module would be flagged like any fixture.
+//! - That a literal was read to its end. `literal` trusts rustfmt to close a multi-line literal at
+//!   the opening line's indentation; where that does not hold the literal is read short and its
+//!   `..` missed, which fails the run rather than passing it. That is the right direction for a
+//!   guess to fail in, and it is a guess.
 
 use std::path::Path;
 
@@ -33,6 +47,9 @@ const TOLERATED: [(&str, &str); 0] = [];
 
 /// The test code of one file as `(1-based line number, text)`: everything from the `#[cfg(test)]`
 /// that opens a test module, or every line when the file is a module compiled only under test.
+/// Everything above that module is out of scope — including the `#[cfg(test)] impl` blocks, which
+/// is why they may spell the fields out. `silent_failures.rs` skips those same blocks from the
+/// other side, so they are the one part of the crate neither check reads.
 fn test_lines(text: &str, whole_file: bool) -> Vec<(usize, String)> {
     let lines: Vec<&str> = text.lines().collect();
     let opens_test_mod = |i: usize| {

--- a/src/silent_failures.rs
+++ b/src/silent_failures.rs
@@ -6,10 +6,25 @@
 //! (`as_str`, `strip_prefix`, `find`) is not error handling at all, and flagging it would bury the
 //! twenty lines that matter under a hundred that do not. So a line is flagged only when it names a
 //! source that can genuinely fail *and* a form that discards what it failed with. Test code is out
-//! of scope: everything from a file's first `#[cfg(test)]` is skipped.
+//! of scope: the scan ends at the file's own `#[cfg(test)] mod`, and skips the item any other
+//! `#[cfg(test)]` applies to rather than the rest of the file.
 //!
 //! `TOLERATED` may only shrink. Each entry carries the reason the default is the right answer
 //! there, and adding one is a decision to be argued for in review — not a way to get to green.
+//!
+//! What a green run does **not** prove:
+//!
+//! - That no failure is swallowed. It proves that no line matches one of these nine `FALLIBLE`
+//!   spellings together with one of these seven `DISCARDS`. A fallible call behind a helper's own
+//!   name, or a discard spelled across two lines, is invisible to a rule that reads text a line at
+//!   a time — as is any operation nobody has added to `FALLIBLE`.
+//! - Anything about code a `#[cfg(test)]` guards, `silent_failures.rs` itself, or a crate this one
+//!   depends on. Only `src/**.rs` is read. It reads too much in one direction as well: the modules
+//!   `main.rs` compiles only under test carry no `#[cfg(test)]` of their own, so `proptests.rs` and
+//!   `shared_fixtures.rs` are scanned as production. A catch there is a confusing message, not a
+//!   missed swallow.
+//! - That a tolerated line is still right. `TOLERATED` is keyed by text, so the reason is checked
+//!   by a reader in review and by nothing else.
 //!
 //! `DISCARDS` grows when a form gets past it. `Result::into_iter().flatten()` did: it reads as
 //! iteration rather than as error handling, and it is how `Chats::count` and `Chats::usage` turned
@@ -74,14 +89,56 @@ pub fn rust_files(dir: &Path, out: &mut Vec<PathBuf>) {
     }
 }
 
-/// The lines of `path` before its first `#[cfg(test)]`, as (1-based line number, trimmed text).
-fn production_lines(path: &Path) -> Vec<(usize, String)> {
-    let text = std::fs::read_to_string(path).expect("a readable source file");
-    text.lines()
-        .take_while(|line| !line.trim_start().starts_with("#[cfg(test)]"))
-        .enumerate()
-        .map(|(i, line)| (i + 1, line.trim().to_string()))
-        .collect()
+/// The production lines of one file as (1-based line number, trimmed text). The scan ends at the
+/// file's own test module — a `#[cfg(test)]` at column zero over a `mod` that opens a body — and
+/// skips only the item any other `#[cfg(test)]` applies to: a test-only `impl`, a `mod x;`
+/// declaration, a `static` inside a `thread_local!`, a statement inside a function. Stopping at the
+/// attribute itself, as this did until #83, left everything below `transform/mod.rs`'s first
+/// indented one unread.
+fn production_lines(text: &str) -> Vec<(usize, String)> {
+    let lines: Vec<&str> = text.lines().collect();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < lines.len() {
+        if lines[i].trim() != "#[cfg(test)]" {
+            out.push((i + 1, lines[i].trim().to_string()));
+            i += 1;
+            continue;
+        }
+        let attr = indent(lines[i]);
+        let mut item = i + 1;
+        while lines.get(item).is_some_and(|line| line.trim_start().starts_with("#[")) {
+            item += 1;
+        }
+        match lines.get(item) {
+            None => break,
+            Some(line) if attr == 0 && line.trim_start().starts_with("mod ") && !line.trim_end().ends_with(';') => break,
+            Some(_) => i = end_of_item(&lines, item, attr) + 1,
+        }
+    }
+    out
+}
+
+/// The last line of the item starting at `lines[at]`, under an attribute indented by `attr`. A
+/// block ends at the `}` rustfmt puts back at the attribute's own indentation; anything else ends
+/// at its `;`. Reading the end wrong resumes the scan inside test code, where a catch is a visible
+/// false positive rather than a silent gap.
+fn end_of_item(lines: &[&str], at: usize, attr: usize) -> usize {
+    let last = lines.len().saturating_sub(1);
+    for (i, line) in lines.iter().enumerate().skip(at) {
+        if line.matches('{').count() > line.matches('}').count() {
+            let closes = |k: &usize| lines[*k].trim_start().starts_with('}') && indent(lines[*k]) <= attr;
+            return (i + 1..lines.len()).find(closes).unwrap_or(last);
+        }
+        if line.trim_end().ends_with(';') {
+            return i;
+        }
+    }
+    last
+}
+
+fn indent(line: &str) -> usize {
+    line.len() - line.trim_start().len()
 }
 
 fn is_swallow(line: &str) -> bool {
@@ -95,17 +152,22 @@ fn no_new_swallowed_failures() {
     files.sort();
     assert!(files.len() > 10, "the walk found only {} files, so it is not reading the crate", files.len());
 
+    let mut scanned = 0;
     let mut found = Vec::new();
     for path in &files {
         if path.ends_with("silent_failures.rs") {
             continue;
         }
-        for (number, line) in production_lines(path) {
+        let text = std::fs::read_to_string(path).expect("a readable source file");
+        let lines = production_lines(&text);
+        scanned += lines.len();
+        for (number, line) in lines {
             if is_swallow(&line) {
                 found.push((path.strip_prefix(src_dir()).unwrap_or(path).display().to_string(), number, line));
             }
         }
     }
+    assert!(scanned > 7000, "only {scanned} lines of production code were read, so the scan is stopping short of the test modules");
 
     let unexplained: Vec<String> = found
         .iter()
@@ -124,6 +186,27 @@ fn no_new_swallowed_failures() {
     let stale: Vec<&str> =
         TOLERATED.iter().map(|(line, _)| *line).filter(|tolerated| !found.iter().any(|(_, _, line)| line == tolerated)).collect();
     assert!(stale.is_empty(), "TOLERATED entries that match nothing any more — delete them:\n  {}", stale.join("\n  "));
+}
+
+#[test]
+fn a_cfg_test_item_does_not_hide_the_rest_of_the_file() {
+    let numbers = |text: &str| production_lines(text).iter().map(|(number, _)| *number).collect::<Vec<_>>();
+
+    // an attribute inside a function skips its statement, not the rest of the file
+    let inside = "fn a() {\n    #[cfg(test)]\n    SPAWNED.set(1);\n    let b = 2;\n}\n";
+    assert_eq!(numbers(inside), vec![1, 4, 5]);
+
+    // a test-only `impl` in the middle of a file skips its block, and the file goes on
+    let block = "fn a() {}\n\n#[cfg(test)]\nimpl Engine {\n    fn for_tests() {}\n}\n\nfn b() {}\n";
+    assert_eq!(numbers(block), vec![1, 2, 7, 8]);
+
+    // `#[cfg(test)] mod x;` declares a module, it does not open one: main.rs goes on below it
+    let declared = "#[cfg(test)]\nmod proptests;\n\nfn main() {}\n";
+    assert_eq!(numbers(declared), vec![3, 4]);
+
+    // and the test module itself ends the scan
+    let module = "fn a() {}\n\n#[cfg(test)]\nmod tests {\n    fn t() {}\n}\n";
+    assert_eq!(numbers(module), vec![1, 2]);
 }
 
 #[test]


### PR DESCRIPTION
Closes #83

`silent_failures.rs` stopped reading a file at its first `#[cfg(test)]`, wherever that attribute
happened to sit. In `transform/mod.rs` the first one is indented, inside a `thread_local!` on line
154, so everything below it went unread; in `main.rs` a `#[cfg(test)] mod proptests;` declaration on
line 9 cut off the rest of the daemon. The check reads as a guarantee about every request-answering
path, and issues get closed on the strength of it.

The scan now ends at the file's own test module — a `#[cfg(test)]` at column zero over a `mod` that
opens a body — and skips only the item any other `#[cfg(test)]` applies to: a test-only `impl`, a
`mod x;` declaration, a `static` inside a `thread_local!`, a statement inside a function. A
`#[cfg(test)] impl Foo` mid-file no longer blinds the rest of it.

## Counts, on identical source

| | before | after |
|---|---|---|
| production lines read | 6968 | 8094 |
| `src/transform/mod.rs` | 153 | 991 |
| `src/main.rs` | 8 | 295 |
| `src/http/mod.rs` | 303 | 304 |
| lines the rule catches | 9 | 9 |
| entries in `TOLERATED` | 8 | 8 |

**The widened scope found nothing real.** The same 9 lines are caught, all of them already explained
by the 8 `TOLERATED` entries (one entry covers the two identical `tx.send` lines in `http/ai.rs`);
no line became newly visible and none was lost. `TOLERATED` did not grow — that is the point of
reporting the count rather than only the pass. On this branch the figure is 8111 rather than 8094,
because the doc-comment lines this PR adds to `shared_fixtures.rs` are themselves scanned as
production code (see the noticed list).

A floor on the lines read now fails the test if the scan ever narrows again, and four cases pin the
shapes: an attribute over a statement, a `#[cfg(test)] impl` mid-file, a `mod x;` declaration, and
the test module itself.

## `shared_fixtures.rs`

It reads from the test module downwards, so an attribute cannot blind it — measured over the same
tree it reads 3920 lines of test code, finds 0 fixtures, and no multi-line literal runs off the end
looking for its closing brace. Its shape is not broken, but the guesses under it were unstated, so
both files now carry a "what a green run does not prove" section, and CONTRIBUTING.md says the same
in one sentence:

- the rules read text, not an AST — a swallow behind a helper's name or split over two lines is
  invisible, and `FALLIBLE`, `DISCARDS` and `SHARED` are fixed lists of spellings;
- the two `#[cfg(test)] impl` blocks are skipped by where they sit, not by intent — one written
  below its test module would be flagged like any fixture;
- a literal's extent is a rustfmt assumption; where it does not hold the literal is read short and
  the run fails rather than passes;
- `proptests.rs` and `shared_fixtures.rs` are read as production code by `silent_failures.rs`.

## CI

[Run 34077963982](https://github.com/productdevbook/sandbox-lite/actions/runs/34077963982) is green on `47b4763`: `test` (`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test`, the release build, `sandbox-lite check` over the five examples, the daemon smoke test, `bench/mem.sh` and `bench/vs-astro-dev.sh`) and `e2e` (Playwright).

## Noticed, did not fix

- `silent_failures.rs` scans `proptests.rs` and `shared_fixtures.rs` as production: they are
  `#[cfg(test)] mod x;` in `main.rs` and carry no attribute of their own. Over-scanning, so a catch
  there is a confusing message rather than a missed swallow. `shared_fixtures.rs` already computes
  that list of module names; sharing it would close this.
- The `#[cfg(test)] impl` blocks in `http/mod.rs` and `transform/mod.rs` are read by neither check,
  and only because both sit above their file's test module. Documented, not made deliberate.
- `end_of_item` ends a block at the `}` rustfmt puts at the attribute's indentation, the same guess
  `literal` makes in `shared_fixtures.rs`. A `}` at column zero inside a raw string in a skipped
  block would resume the scan early — a visible false positive, not a silent gap.
- The scan ends at the first column-zero `#[cfg(test)] mod`; production code written below a test
  module would not be read. No file in `src/` does that today.
- `TOLERATED` is keyed by the whole line, so reformatting a tolerated line fails the test twice over
  — once as unexplained, once as stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
