### PR TITLE
preview: run the tenant's middleware

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -169,7 +169,9 @@ exact.
    keeps `/__sl/m/` and `/__sl/raw/` off a tenant's dotfiles. Otherwise it
    answers `assets/shell.html` with `%TENANT%`, `%VERSION%` (the tenant's
    version), `%ASSETS%` (a hash of `astro.js`, `shell.js`, `live.js`),
-   `%TOKEN%`/`%TOKENQ%` (the preview token, empty without `--preview-secret`)
+   `%TOKEN%`/`%TOKENQ%` (the preview token, empty without `--preview-secret`),
+   `%MIDDLEWARE%` (`routes::middleware`: the tenant's `src/middleware.{mjs,js,mts,ts}`
+   or `src/middleware/index.*`, in Vite's resolution order, or `null`)
    and `%ENV%` filled in, `Cache-Control: no-store`. `%ENV%` is
    `import.meta.env`: `DEV`, `PROD`, `MODE`, `SSR`, `BASE_URL`, `SITE` (from
    `sandbox-lite.json`), `ASSETS_PREFIX`, and the `PUBLIC_*` lines of the
@@ -207,7 +209,17 @@ exact.
 6. **Static paths.** If the route has params and the module exports
    `getStaticPaths`, the shell calls it with its own `paginate`, keeps the
    entry whose params equal the matched ones, and uses its `props`.
-7. **Render.** `experimental_AstroContainer.create({ resolve, astroConfig })`
+7. **Middleware.** When `%MIDDLEWARE%` names a file, the shell imports it and
+   passes its `onRequest` to the container as `manifest.middleware`, which
+   `createManifest` takes over its own no-op — the same seam an SSR build uses.
+   `renderToResponse` runs it through `handleMiddleware` for a page and an
+   endpoint alike, so `context.locals` is the object the page reads as
+   `Astro.locals`, and a `Response` the middleware returns instead of calling
+   `next()` is the response. A file that exports no `onRequest` is an error
+   overlay rather than a middleware that silently does nothing. `sequence`
+   composes in `assets/shims/astro-middleware.js`; what it does not do is
+   rewrite between handlers — see README, "What the preview does not do".
+8. **Render.** `experimental_AstroContainer.create({ resolve, astroConfig })`
    — `resolve` maps ids the runtime asks for (island component paths,
    `astro:*`) to daemon URLs. `/__sl/renderers.json` lists framework renderers
    (`resolve::renderers`: `@astrojs/react`, `@astrojs/preact`, `@astrojs/vue`
@@ -222,7 +234,7 @@ exact.
    `routeType: "endpoint"`, which runs its `GET` (or `ALL`) handler with an
    `APIContext` — `request`, `params`, `props`, `url`, `site`, `redirect`,
    `cookies`, `locals`. No renderers are registered for it: nothing renders.
-8. **Document.** A `3xx` with `Location` becomes `location.replace`. A response
+9. **Document.** A `3xx` with `Location` becomes `location.replace`. A response
    that is not `text/html` (an endpoint's XML, JSON or text) is shown escaped in
    a `<pre>` under its status and content-type, JSON pretty-printed. A `4xx` or
    `5xx` with an empty body becomes an error overlay naming the status rather
@@ -235,7 +247,7 @@ exact.
    `</head>`, and `document.write` replaces the shell. If Tailwind was seen,
    its browser build is loaded from jsDelivr. The `data-sl` key is what lets a
    later CSS write find the block again — see "CSS without a reload".
-9. **Errors.** Any exception renders an error page with the daemon's
+10. **Errors.** Any exception renders an error page with the daemon's
    diagnostics; a missing route lists the routes. Where those diagnostics come
    from is issue #54: a module that does not compile is answered `500` with
    `{"error", "diagnostics"}`, and the browser hides that body behind "failed

--- a/README.md
+++ b/README.md
@@ -482,8 +482,23 @@ e2e/                   Playwright suite for the browser side: every example page
   ones against the component's own URL: `./Other.vue` works, `./other` (no
   extension) does not.
 - **Non-`GET` requests.** A visitor navigates, so only an endpoint's `GET` (or
-  `ALL`) handler ever runs and the request carries no body. `src/middleware.ts`
-  is not loaded, and `astro:actions` answers `SERVICE_UNAVAILABLE`.
+  `ALL`) handler ever runs and the request carries no body, and `astro:actions`
+  answers `SERVICE_UNAVAILABLE`.
+- **A middleware rewrite, and its cookies.** `src/middleware.{ts,js}` (or
+  `src/middleware/index.{ts,js}`) is loaded and its `onRequest` runs before
+  every page and every endpoint, so `Astro.locals`, `next()` and the response it
+  answers with, a `Response` the middleware returns itself, `context.redirect()`
+  and `sequence()` all behave as they do under `astro dev`. Two things do not.
+  A **rewrite** — `context.rewrite("/other")`, or `next("/other")` — cannot:
+  the container is handed the one route the URL matched and knows no other, so
+  the rewrite reaches no page and the render fails. `sandbox-lite check` reports
+  a middleware that names `rewrite`, so the gap is visible before a page shows
+  it. **Cookies** are the other one: the preview renders the page in the
+  browser, so the request the middleware sees carries no `Cookie` header, and
+  what it sets on the response never becomes a `Set-Cookie` — the response is
+  written into the document rather than sent over the wire. A middleware
+  redirect for a path with no page in `src/pages` does not run either: the shell
+  matches the route first, and answers "no matching page".
 - **Less/Stylus.** Sass works; other preprocessors are passed through untouched.
 - **`content.config.ts` loaders.** The config is read statically, never
   executed: `glob({ pattern, base })` and `file(path)` with literal arguments

--- a/assets/shell.html
+++ b/assets/shell.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="referrer" content="no-referrer">
 <title>preview</title>
-<script>window.__sl = { tenant: "%TENANT%", version: %VERSION%, assets: "%ASSETS%", token: "%TOKEN%", env: %ENV% }; globalThis.__sl_env = window.__sl.env;
+<script>window.__sl = { tenant: "%TENANT%", version: %VERSION%, assets: "%ASSETS%", token: "%TOKEN%", middleware: %MIDDLEWARE%, env: %ENV% }; globalThis.__sl_env = window.__sl.env;
 // A framed preview is cross-site and never gets the cookie, so every /__sl/ URL this page builds carries the token.
 globalThis.__sl_url = (u) => (window.__sl.token && typeof u === "string" && u.startsWith("/") ? `${u}${u.includes("?") ? "&" : "?"}sl_token=${window.__sl.token}` : u);</script>
 <script type="module" src="/__sl/live.js%TOKENQ%"></script>

--- a/assets/shell.js
+++ b/assets/shell.js
@@ -126,6 +126,13 @@ async function addRenderers(container) {
   container.addServerRenderer({ name: "astro:jsx", renderer: jsx.default });
 }
 
+// Astro loads `src/middleware.{ts,js}` and runs its `onRequest` before every page and endpoint. The
+// container takes it the way the SSR manifest does: `createManifest` prefers `manifest.middleware`
+// over its own no-op, and `renderToResponse` calls `handleMiddleware` for both route types.
+function middlewareManifest(onRequest) {
+  return { middleware: () => ({ onRequest }) };
+}
+
 function headExtras() {
   const blocks = [];
   let tailwind = false;
@@ -203,6 +210,17 @@ async function main() {
   if (!hit) return showError({ title: "404 — no matching page", message: `Nothing in src/pages matches ${location.pathname}`, routes });
   const endpoint = hit.route.kind === "endpoint";
   const astro = await import(slUrl("/__sl/astro.js"));
+  let onRequest;
+  if (sl.middleware) {
+    const middleware = await importModule(`/__sl/m/${sl.middleware}?v=${V}`);
+    if (typeof middleware.onRequest !== "function") {
+      return showError({
+        title: "Middleware without onRequest",
+        message: `${sl.middleware} exports no onRequest function, so nothing of it would run. Astro calls the onRequest export before every page and endpoint.`,
+      });
+    }
+    onRequest = middleware.onRequest;
+  }
   const mod = await importModule(`/__sl/m/${hit.route.component}?v=${V}`);
   if (endpoint) {
     if (typeof mod.GET !== "function" && typeof mod.ALL !== "function") {
@@ -220,7 +238,11 @@ async function main() {
     props = entry.props || {};
     params = entry.params;
   }
-  const container = await astro.experimental_AstroContainer.create({ resolve: resolveId, astroConfig: sl.env.SITE ? { site: sl.env.SITE } : undefined });
+  const container = await astro.experimental_AstroContainer.create({
+    resolve: resolveId,
+    astroConfig: sl.env.SITE ? { site: sl.env.SITE } : undefined,
+    manifest: onRequest ? middlewareManifest(onRequest) : undefined,
+  });
   // An endpoint renders no components, so the framework renderers are not worth fetching.
   if (!endpoint) await addRenderers(container);
   // the token is the daemon's, not the page's: Astro.url must not show it

--- a/assets/shims/astro-middleware.js
+++ b/assets/shims/astro-middleware.js
@@ -1,4 +1,23 @@
 export const defineMiddleware = (fn) => fn;
-export const sequence = (...fns) => fns[0];
+
+// Astro's own `sequence`, minus the rewrite bookkeeping it does between handlers: the container
+// resolves a rewrite against the one route it was asked to render, so `next(payload)` is carried to
+// the container's own `next` instead (README, "What the preview does not do").
+export function sequence(...handlers) {
+  const filtered = handlers.filter(Boolean);
+  const last = filtered.length - 1;
+  if (last < 0) return (_context, next) => next();
+  return (context, next) => {
+    let carried;
+    const apply = (i) =>
+      filtered[i](context, async (payload) => {
+        if (i === last) return next(payload ?? carried);
+        if (payload !== undefined) carried = payload;
+        return apply(i + 1);
+      });
+    return apply(0);
+  };
+}
+
 export const createContext = () => ({});
 export const trySerializeLocals = (v) => JSON.stringify(v);

--- a/e2e/middleware.spec.ts
+++ b/e2e/middleware.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from './fixtures';
+
+test.describe('starter middleware', () => {
+  test('a page reads what the middleware put in locals', async ({ daemon, page }) => {
+    const site = await daemon.tenant('starter-locals', 'starter');
+    await page.goto(site.url('/members?token=lumen'));
+    await expect(page).toHaveTitle('Members · Lumen Studio');
+    await expect(page.locator('h1')).toHaveText('Welcome back to Lumen Studio');
+    await expect(page.locator('.locals')).toHaveAttribute('data-studio', 'Lumen Studio');
+  });
+
+  test('a middleware redirect sends the browser on before the page renders', async ({ daemon, page }) => {
+    const site = await daemon.tenant('starter-gate', 'starter');
+    await page.goto(site.url('/members'));
+    await expect(page).toHaveURL(site.url('/about'));
+    await expect(page.locator('h1')).toHaveText('About the studio');
+  });
+
+  test('an endpoint runs behind the middleware too', async ({ daemon, page }) => {
+    const site = await daemon.tenant('starter-mw-endpoint', 'starter');
+    await site.write(
+      'src/pages/api/studio.json.ts',
+      `export function GET({ locals }) {
+  return new Response(JSON.stringify({ studio: locals.studio }), { headers: { "content-type": "application/json" } });
+}
+`,
+    );
+    await page.goto(site.url('/api/studio.json'));
+    await expect(page.locator('h1')).toHaveText('200');
+    const body = await page.locator('pre').textContent();
+    expect(JSON.parse(body ?? '')).toEqual({ studio: 'Lumen Studio' });
+  });
+
+  test('middleware can change the response next() answers with', async ({ daemon, page }) => {
+    const site = await daemon.tenant('starter-mw-response', 'starter');
+    await site.write(
+      'src/middleware.ts',
+      `export const onRequest = async (context, next) => {
+  const response = await next();
+  const html = await response.text();
+  return new Response(html.replace("Design that ships.", "Rewritten on the way out"), response);
+};
+`,
+    );
+    await page.goto(site.url('/'));
+    await expect(page.locator('h1')).toHaveText('Rewritten on the way out');
+  });
+
+  test('a middleware that exports no onRequest says so', async ({ daemon, page }) => {
+    const site = await daemon.tenant('starter-mw-silent', 'starter');
+    await site.write('src/middleware.ts', 'export const handler = (context, next) => next();\n');
+    await page.goto(site.url('/'));
+    await expect(page.locator('h1')).toHaveText('Middleware without onRequest');
+    await expect(page.locator('pre')).toContainText('src/middleware.ts exports no onRequest function');
+  });
+});

--- a/examples/starter/src/env.d.ts
+++ b/examples/starter/src/env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="astro/client" />
+
+declare namespace App {
+  interface Locals {
+    studio: string;
+  }
+}

--- a/examples/starter/src/middleware.ts
+++ b/examples/starter/src/middleware.ts
@@ -1,0 +1,17 @@
+import { defineMiddleware, sequence } from "astro:middleware";
+
+// One place decides what every page and endpoint can read off Astro.locals.
+const studio = defineMiddleware((context, next) => {
+  context.locals.studio = "Lumen Studio";
+  return next();
+});
+
+// The members area is behind a link the studio hands out; everyone else is sent to the about page.
+const members = defineMiddleware((context, next) => {
+  if (context.url.pathname === "/members" && context.url.searchParams.get("token") !== "lumen") {
+    return context.redirect("/about", 302);
+  }
+  return next();
+});
+
+export const onRequest = sequence(studio, members);

--- a/examples/starter/src/pages/members.astro
+++ b/examples/starter/src/pages/members.astro
@@ -1,0 +1,13 @@
+---
+import Layout from "../layouts/Layout.astro";
+
+// Set in src/middleware.ts, before this page ran.
+const { studio } = Astro.locals;
+---
+<Layout title="Members" description="What the studio shares with the people it works with">
+  <h1>Welcome back to {studio}</h1>
+  <p class="locals" data-studio={studio}>
+    The name above is <code>Astro.locals.studio</code>, put there by <code>src/middleware.ts</code>.
+    Without the link the studio hands out, the same middleware sends you to the about page instead.
+  </p>
+</Layout>

--- a/src/check.rs
+++ b/src/check.rs
@@ -18,6 +18,7 @@ pub struct Report {
     pub sass: usize,
     pub mdx: usize,
     pub endpoints: usize,
+    pub middleware: Option<String>,
     pub integrations: Vec<String>,
     pub bare_imports: BTreeSet<String>,
 }
@@ -38,6 +39,7 @@ impl Report {
             "sass": self.sass,
             "mdx": self.mdx,
             "endpoints": self.endpoints,
+            "middleware": self.middleware,
             "integrations": self.integrations,
             "bare_imports": self.bare_imports,
         })
@@ -75,6 +77,7 @@ pub fn inspect(dir: &Path) -> Result<Report, String> {
         sass: 0,
         mdx: 0,
         endpoints: 0,
+        middleware: None,
         integrations: package_deps(&tenant)?.into_iter().map(|(n, _)| n).filter(|n| n.starts_with("@astrojs/")).collect(),
         bare_imports: BTreeSet::new(),
     };
@@ -82,6 +85,24 @@ pub fn inspect(dir: &Path) -> Result<Report, String> {
     // preview cannot disagree about what an endpoint is: `routes::route` also takes `.mjs`/`.mts`
     // and skips any `_`-prefixed segment (issue #76).
     report.endpoints = crate::routes::build(&tenant).iter().filter(|r| r.kind == "endpoint").count();
+    // Issue #87: the preview loads the middleware and runs its `onRequest`, but the container is
+    // given the one route the URL matched, so a rewrite resolves against that route alone and
+    // reaches no other page. A project that depends on one is told here rather than at render time.
+    // The file is compiled with every other source below, which is where a read failure is reported.
+    report.middleware = crate::routes::middleware(&tenant).map(str::to_string);
+    if let Some(path) = &report.middleware
+        && let Ok(Some(text)) = tenant.read_text(path)
+        && text.contains("rewrite")
+    {
+        report.diagnostics.push(Diag {
+            severity: "warning".into(),
+            text: "names `rewrite`, which the preview cannot do: it renders one route at a time".into(),
+            hint: "a rewrite in middleware renders as a failure, not as the other page".into(),
+            file: path.clone(),
+            line: 0,
+            column: 0,
+        });
+    }
     for entry in tenant.list() {
         let path = entry.path;
         // Every `.mdx` file, not only the routed ones: a collection entry is MDX the preview has to
@@ -157,12 +178,13 @@ pub fn run(dirs: &[std::path::PathBuf], json: bool) -> i32 {
             println!("  {:<7} {loc} — {}{}", d.severity, d.text, if d.hint.is_empty() { String::new() } else { format!(" ({})", d.hint) });
         }
         println!(
-            "  islands {}  import.meta.glob {}  sass {}  mdx {}  endpoints {}  integrations [{}]  npm imports [{}]",
+            "  islands {}  import.meta.glob {}  sass {}  mdx {}  endpoints {}  middleware {}  integrations [{}]  npm imports [{}]",
             r.islands,
             r.globs,
             r.sass,
             r.mdx,
             r.endpoints,
+            r.middleware.as_deref().unwrap_or("none"),
             r.integrations.join(", "),
             r.bare_imports.iter().cloned().collect::<Vec<_>>().join(", ")
         );

--- a/src/http/preview.rs
+++ b/src/http/preview.rs
@@ -363,8 +363,12 @@ pub async fn page(AxState(st): AxState<State>, Extension(id): Extension<TenantId
     };
     let token = st.preview_secret.as_deref().map(|s| super::preview_token(s, &t.id)).unwrap_or_default();
     let token_query = if token.is_empty() { String::new() } else { format!("?sl_token={token}") };
+    // The path is one of `routes::MIDDLEWARE_FILES`, so it needs no escaping; `null` is a tenant
+    // with no middleware, which is what tells the shell to render without one.
+    let middleware = crate::routes::middleware(&t).map_or_else(|| "null".to_string(), |path| format!("\"{path}\""));
     let html = SHELL_HTML
         .replace("%TENANT%", &t.id)
+        .replace("%MIDDLEWARE%", &middleware)
         .replace("%VERSION%", &t.version().to_string())
         .replace("%ASSETS%", asset_version())
         .replace("%TOKENQ%", &token_query)
@@ -420,6 +424,24 @@ mod tests {
         let (status, body) = collection(&starter_app(&[]), "posts").await;
         assert_eq!(status, StatusCode::OK);
         assert!(!body["entries"].as_array().unwrap().is_empty());
+    }
+
+    /// Issue #87: the shell page is where the browser is told which file to load as the middleware.
+    /// A placeholder left unsubstituted is a script that does not parse and a preview that renders
+    /// nothing at all, so this reads the served page rather than the template.
+    #[tokio::test]
+    async fn the_shell_names_the_middleware_the_tenant_has() {
+        let app = starter_app(&[]);
+        let req = Request::builder().uri("/").header("host", "acme.localhost").body(Body::empty()).unwrap();
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(res.into_body(), usize::MAX).await.unwrap();
+        let body = String::from_utf8_lossy(&body).into_owned();
+        assert!(body.contains("middleware: \"src/middleware.ts\""), "{body}");
+        // every `%NAME%` the template carries, read off the template itself
+        for name in super::SHELL_HTML.split('%').skip(1).step_by(2) {
+            assert!(!body.contains(&format!("%{name}%")), "%{name}% was not substituted");
+        }
     }
 
     async fn strip_ts(app: &axum::Router, query: &str, script: &str) -> (StatusCode, String) {

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -13,6 +13,25 @@ pub struct Route {
     key: Vec<u8>,
 }
 
+/// Where Astro looks for the middleware, in Vite's resolution order — which is what decides the
+/// answer for a project that has more than one of them.
+const MIDDLEWARE_FILES: [&str; 8] = [
+    "src/middleware.mjs",
+    "src/middleware.js",
+    "src/middleware.mts",
+    "src/middleware.ts",
+    "src/middleware/index.mjs",
+    "src/middleware/index.js",
+    "src/middleware/index.mts",
+    "src/middleware/index.ts",
+];
+
+/// The tenant's middleware, whose `onRequest` runs before every page and endpoint. `None` is a
+/// project that has none, which is most of them.
+pub fn middleware(tenant: &Tenant) -> Option<&'static str> {
+    MIDDLEWARE_FILES.into_iter().find(|path| tenant.exists(path))
+}
+
 pub fn build(tenant: &Tenant) -> Vec<Route> {
     let mut routes: Vec<Route> = tenant.list().iter().filter_map(|e| route(&e.path)).collect();
     routes.sort_by(|a, b| a.key.cmp(&b.key).then(b.key.len().cmp(&a.key.len())).then(a.route.cmp(&b.route)));
@@ -109,7 +128,29 @@ fn escape(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use super::*;
+    use crate::store::{Base, Store, UpdateKind};
+
+    /// Issue #87: `shell.js` loads exactly this file and hands its `onRequest` to the container, so
+    /// which file it is has to be the one Astro would have loaded.
+    #[test]
+    fn the_middleware_is_the_file_astro_would_load() {
+        let store = Store::new(None, u64::MAX);
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("examples/starter");
+        store.add_base(Base::load("starter", &root).unwrap());
+        let t = store.create_tenant("acme", "starter").unwrap();
+        assert_eq!(middleware(&t), Some("src/middleware.ts"));
+
+        let body = b"export const onRequest = (context, next) => next();\n".to_vec();
+        t.write("src/middleware.js", body, UpdateKind::from_path("src/middleware.js")).unwrap();
+        assert_eq!(middleware(&t), Some("src/middleware.js"), "Vite resolves .js before .ts");
+
+        let bare = store.create_tenant("none", "starter").unwrap();
+        bare.delete("src/middleware.ts").unwrap();
+        assert_eq!(middleware(&bare), None, "a project with no middleware renders without one");
+    }
 
     fn of(path: &str) -> (String, &'static str, String) {
         let r = route(path).unwrap_or_else(|| panic!("{path} is not a route"));


### PR DESCRIPTION
Closes #87

`assets/shims/astro-middleware.js` returned the first handler from `sequence` and nothing imported the tenant's `src/middleware.ts`, so a theme that sets `Astro.locals`, returns a response of its own or redirects rendered as though it had no middleware — the wrong page, with nothing said about it.

## The seam

The container has one already, and it is the same one an SSR build uses. In `assets/astro.js`:

- `createManifest(manifest, renderers, middleware, site)` sets `middleware: manifest?.middleware ?? middlewareInstance`, so a manifest passed to `experimental_AstroContainer.create({ manifest })` wins over the container's no-op;
- `renderToResponse` always ends in `handleMiddleware(state, handlePages)`, for `routeType: "page"` and `"endpoint"` alike;
- `getMiddleware` reads `(await manifest.middleware()).onRequest`, and `callMiddleware` gives it the `APIContext` whose `locals` is the very object `createAstroPagePartial` hands the page as `Astro.locals`.

So:

- **`src/routes.rs`** — `routes::middleware` finds the file Astro would load: `src/middleware.{mjs,js,mts,ts}` or `src/middleware/index.*`, in Vite's resolution order (which is what decides it for a project carrying two).
- **`src/http/preview.rs`** — `preview::page` names it in the shell as `%MIDDLEWARE%` (`null` for a project with none). A test reads the *served* page and asserts every `%NAME%` the template carries is substituted, since a leftover placeholder is a script that does not parse.
- **`assets/shell.js`** — imports it and passes `{ middleware: () => ({ onRequest }) }` as the container's manifest. A file that exports no `onRequest` is an error overlay ("Middleware without onRequest"), not a middleware that quietly does nothing.
- **`assets/shims/astro-middleware.js`** — `sequence` composes for real: each handler's `next` runs the next handler, and the last one's reaches the container's.

`context.locals`, `next()` and the response it answers with, a `Response` the middleware returns itself, `context.redirect()` and `sequence()` now behave as they do under `astro dev`, for endpoints too.

## What it still does not do

Named in README's limits list rather than left to be discovered:

- **A rewrite.** The container is handed the one route the URL matched (`#insertRoute`) and `tryRewrite` resolves against `manifest.routes`, which holds only that one — a rewrite falls through to `DEFAULT_404_ROUTE` and `getComponentByRoute` throws. `sandbox-lite check` now reports the middleware it found and warns when that file names `rewrite`, so the gap is visible before a page shows it.
- **Cookies.** The preview renders in the browser: the request the middleware sees carries no `Cookie` header, and what it sets on the response never becomes a `Set-Cookie`, because the response is written into the document rather than sent over the wire.
- **A redirect for a path with no page.** `shell.js` matches the route table first and answers "no matching page", so middleware never runs for it — unlike `astro dev`.

## Acceptance

`examples/starter` gains `src/middleware.ts` (`sequence` of a handler that sets `locals.studio` and one that gates `/members`), `src/pages/members.astro` rendering `Astro.locals.studio`, and `src/env.d.ts` declaring `App.Locals`. `e2e/middleware.spec.ts` covers: locals on a page, the middleware redirect, an endpoint behind the middleware, a middleware that changes the response `next()` answered with, and the missing-`onRequest` overlay.

CI run: [34084045534](https://github.com/productdevbook/sandbox-lite/actions/runs/34084045534) — green on `ebce8d8`: fmt, clippy `-D warnings`, `cargo test`, the release build, `sandbox-lite check` over all five examples, the smoke test, `bench/mem.sh`, the dev-server comparison, and Playwright (37 passed, the five middleware specs among them)

## Noticed, did not fix

- **Middleware does not run for a path with no page.** The shell needs a route to render before it can call the container, so a middleware that redirects an unrouted URL (a moved permalink, an auth gate on a path the theme does not ship) does nothing here. Fixing it means rendering an empty route through the container and deciding what a 404 means when middleware answers it — a change to the 404 path, not to this one. Named in README.
- **`context.rewrite()` / `next("/path")`.** Above. Supporting it means matching the route table again inside the shell and re-rendering with the new component, which is a second render loop.
- **The `rewrite` warning is a text scan** of the middleware file. A rewrite reached through a helper in another module is invisible to it, and a comment naming `rewrite` is a false positive. It is a warning, and `sandbox-lite check` still exits 0 on it.
- **`/__sl/check` does not report the middleware**; only the CLI `sandbox-lite check` does. `http::api::check_tenant` — which the error overlay and the AI tool `check_site` use — has no census fields at all, so adding one there is a wider change.
- **`createContext` and `trySerializeLocals`** in the `astro:middleware` shim are still stubs (`{}` and `JSON.stringify`). Nothing in the preview calls them; a real `createContext` needs a manifest to build the context from.
- **`.d.ts` files are compiled like any other source.** `src/env.d.ts` is counted in `files` and served as an (empty) module. Harmless, but nothing imports it and nothing needs to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
