### PR TITLE
editor: create, rename, delete and upload files

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -248,7 +248,20 @@ exact.
    `<body data-sl-overlay>` is how `live.js` knows not to swap CSS into them.
 
 The editor (`assets/editor.html`) is the other client: it embeds the preview
-in an `<iframe>` and edits files through `/api/t/{id}/file/{path}`.
+in an `<iframe>` and creates, edits, renames, deletes and uploads files
+through `/api/t/{id}/file/{path}`. Two things about that surface:
+
+- There is no rename endpoint. The editor writes the new path and then deletes
+  the old one, and says so in the dialog; if the delete fails the file is left
+  at both paths and the message says which one to remove by hand.
+- A refusal is shown as the daemon wrote it — `bad path` from `clean_path`, the
+  quota sentence behind the 413 — because "failed" tells a customer nothing
+  about what to do next. The one message the editor writes itself is for a path
+  the URL parser rewrites (`..`), which never reaches the daemon at all.
+
+Every value that reaches the DOM goes through `esc()` or `textContent`;
+`tests/editor-escaping.mjs` fails the build otherwise, and a file may be named
+anything the daemon accepts.
 
 ## The transform engine (`src/transform/mod.rs`)
 

--- a/assets/editor.html
+++ b/assets/editor.html
@@ -20,10 +20,19 @@ button:disabled{opacity:.5;cursor:default}
 #tabs{display:flex;gap:2px;padding:6px 8px 0;border-bottom:1px solid var(--line);background:var(--panel)}
 #tabs button{border-radius:6px 6px 0 0;border-bottom:none;background:transparent}
 #tabs button.active{background:var(--bg);border-color:var(--line)}
-#files{overflow:auto;padding:6px 0;border-bottom:1px solid var(--line)}
-#files div{padding:2px 10px;cursor:pointer;white-space:nowrap;font-family:ui-monospace,Menlo,monospace;font-size:12px;color:var(--muted)}
-#files div:hover{background:#1b2030;color:var(--text)}#files div.active{background:#22293a;color:var(--text)}
-#files div.modified::after{content:" ●";color:var(--warn)}
+#filePane{display:flex;flex-direction:column;min-height:0;border-bottom:1px solid var(--line)}
+#fileBar{display:flex;gap:4px;padding:6px 8px;border-bottom:1px solid var(--line);background:var(--panel)}
+#fileBar button{padding:3px 7px}
+#fileMsg{padding:5px 10px;font-size:12px;color:var(--muted);border-bottom:1px solid var(--line);white-space:pre-wrap;word-break:break-word}
+#fileMsg.bad{color:var(--err)}
+#files{overflow:auto;padding:6px 0;flex:1}
+#files summary{padding:3px 10px;cursor:pointer;color:var(--muted);font:600 11px/1.4 ui-monospace,Menlo,monospace;letter-spacing:.3px;position:sticky;top:0;background:var(--bg);user-select:none}
+#files summary:hover{color:var(--text)}
+#files summary .count{color:#4a5163;margin-left:6px;font-weight:400}
+#files div[data-path]{padding:2px 10px 2px 24px;cursor:pointer;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;font-family:ui-monospace,Menlo,monospace;font-size:12px;color:var(--muted)}
+#files div[data-path]:hover{background:#1b2030;color:var(--text)}#files div[data-path].active{background:#22293a;color:var(--text)}
+#files div[data-path].modified::after{content:" ●";color:var(--warn)}
+#files.drop{outline:2px dashed var(--accent);outline-offset:-4px}
 #editorWrap{display:flex;flex-direction:column;min-height:0}
 #editorWrap .bar{display:flex;align-items:center;gap:8px;padding:6px 10px;border-bottom:1px solid var(--line);color:var(--muted);font-family:ui-monospace,Menlo,monospace;font-size:12px}
 #editor{flex:1;resize:none;border:none;border-radius:0;background:#0b0d13;padding:10px 12px;font:12.5px/1.5 ui-monospace,Menlo,Consolas,monospace;tab-size:2;white-space:pre;overflow:auto;outline:none}
@@ -47,6 +56,10 @@ iframe{width:100%;height:100%;border:none;background:#fff}
 .hidden{display:none!important}
 dialog{background:var(--panel);color:var(--text);border:1px solid var(--line);border-radius:10px;padding:16px;min-width:320px}
 dialog form{display:grid;gap:8px}dialog::backdrop{background:rgba(0,0,0,.5)}
+dialog .note{color:var(--muted);font-size:12px;max-width:46ch}
+dialog code{font-family:ui-monospace,Menlo,monospace;color:var(--text);word-break:break-all}
+dialog .row{display:flex;gap:6px;justify-content:flex-end}
+dialog label input{width:100%}
 </style>
 </head>
 <body>
@@ -60,7 +73,17 @@ dialog form{display:grid;gap:8px}dialog::backdrop{background:rgba(0,0,0,.5)}
 </header>
 <section id="left">
   <div id="tabs"><button class="active" data-tab="files">Files</button><button data-tab="chat">Chat</button></div>
-  <div id="files"></div>
+  <div id="filePane">
+    <div id="fileBar">
+      <button id="newFile">+ file</button>
+      <button id="uploadFile" title="upload into public/, or drop files on the list">↑ upload</button>
+      <button id="renameFile" disabled>rename</button>
+      <button id="deleteFile" disabled>delete</button>
+      <input type="file" id="picker" multiple hidden>
+    </div>
+    <div id="fileMsg" hidden></div>
+    <div id="files"></div>
+  </div>
   <div id="editorWrap">
     <div class="bar"><span id="fileName">no file</span><span id="saveState" style="margin-left:auto"></span></div>
     <textarea id="editor" spellcheck="false" placeholder="Pick a file on the left. Edits are saved as you type; the preview reloads itself."></textarea>
@@ -75,10 +98,12 @@ dialog form{display:grid;gap:8px}dialog::backdrop{background:rgba(0,0,0,.5)}
   <div class="bar"><span style="color:var(--muted)">preview</span><input id="path" value="/"><button id="go">Go</button><button id="reload">↻</button><button id="openTab">open ↗</button></div>
   <div id="frameWrap"><div id="empty"><div>No tenant yet.</div><button class="primary" id="emptyNew">Create one from a base project</button></div><iframe id="frame" class="hidden"></iframe></div>
 </section>
-<dialog id="dlg"><form method="dialog"><b>New tenant</b><label>id <input id="dlgId" placeholder="acme" pattern="[a-z0-9][a-z0-9-]*" required></label><label>base <select id="dlgBase"></select></label><div style="display:flex;gap:6px;justify-content:flex-end"><button value="cancel">Cancel</button><button value="ok" class="primary">Create</button></div></form></dialog>
+<dialog id="dlg"><form method="dialog"><b>New tenant</b><label>id <input id="dlgId" placeholder="acme" pattern="[a-z0-9][a-z0-9-]*" required></label><label>base <select id="dlgBase"></select></label><div class="row"><button value="cancel">Cancel</button><button value="ok" class="primary">Create</button></div></form></dialog>
+<dialog id="pathDlg"><form method="dialog"><b id="pathDlgTitle">New file</b><label>path <input id="pathDlgInput" required autocomplete="off" spellcheck="false"></label><div class="note" id="pathDlgNote"></div><div class="row"><button value="cancel" formnovalidate>Cancel</button><button value="ok" class="primary" id="pathDlgOk">Create</button></div></form></dialog>
+<dialog id="delDlg"><form method="dialog"><b>Delete file</b><div class="note">Delete <code id="delDlgPath"></code>? The preview stops serving it at once, and nothing here brings it back.</div><div class="row"><button value="cancel">Cancel</button><button value="ok" class="primary">Delete</button></div></form></dialog>
 <script>
 const $ = (s) => document.querySelector(s);
-const state = { stats: null, tenants: [], tenant: null, file: null, dirty: false, es: null, chatId: null, busy: false, saving: null };
+const state = { stats: null, tenants: [], tenant: null, file: null, files: [], collapsed: new Set(), dirty: false, es: null, chatId: null, busy: false, saving: null };
 const BINARY = /\.(png|jpe?g|gif|webp|avif|ico|woff2?|ttf|otf|mp4|webm|mp3|pdf|wasm|zip)$/i;
 const encPath = (p) => p.split("/").map(encodeURIComponent).join("/");
 const esc = (v) => String(v).replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&#39;");
@@ -86,15 +111,27 @@ let apiToken = "";
 try { apiToken = localStorage.getItem("sl_api_token") || ""; } catch {}
 const authHeaders = () => (apiToken ? { authorization: `Bearer ${apiToken}` } : {});
 const withToken = (url) => (apiToken ? url + (url.includes("?") ? "&" : "?") + "token=" + encodeURIComponent(apiToken) : url);
+// The daemon says why it refused — a bad path, the tenant quota, a file it could not write — and
+// that sentence is the only thing worth showing; `r.statusText` is what is left when it says nothing.
+const failure = async (r) => {
+  let m = r.statusText || `HTTP ${r.status}`;
+  try { const e = (await r.json()).error; if (e) m = typeof e === "string" ? e : JSON.stringify(e); } catch {}
+  return new Error(m);
+};
 const api = async (method, url, body, raw) => {
   const r = await fetch(url, { method, headers: { ...authHeaders(), ...(body !== undefined && !raw ? { "content-type": "application/json" } : {}) }, body: body === undefined ? undefined : raw ? body : JSON.stringify(body) });
   if (r.status === 401) {
     const t = prompt("This daemon requires an API token (--api-token):", apiToken);
     if (t) { apiToken = t; try { localStorage.setItem("sl_api_token", t); } catch {} return api(method, url, body, raw); }
   }
-  if (!r.ok) { let m = r.statusText; try { m = (await r.json()).error || m; } catch {} throw new Error(m); }
+  if (!r.ok) throw await failure(r);
   const ct = r.headers.get("content-type") || "";
   return ct.includes("json") ? r.json() : r.text();
+};
+const apiBlob = async (url) => {
+  const r = await fetch(url, { headers: authHeaders() });
+  if (!r.ok) throw await failure(r);
+  return r.blob();
 };
 const previewUrl = (id, path = "/") => {
   const t = state.tenants.find((x) => x.id === id);
@@ -126,13 +163,13 @@ async function loadTenants(selectId) {
   sel.replaceChildren(...state.tenants.map((t) => new Option(`${t.id} (${t.base})`, t.id)));
   const id = selectId || state.tenant || (state.tenants[0] && state.tenants[0].id);
   if (id && state.tenants.some((t) => t.id === id)) { sel.value = id; await selectTenant(id); }
-  else { state.tenant = null; $("#frame").classList.add("hidden"); $("#empty").classList.remove("hidden"); $("#files").replaceChildren(); }
+  else { state.tenant = null; state.file = null; state.files = []; $("#frame").classList.add("hidden"); $("#empty").classList.remove("hidden"); $("#files").replaceChildren(); fileButtons(); }
 }
 
 async function selectTenant(id) {
   if (state.tenant === id) return;
-  state.tenant = id; state.file = null; state.chatId = null; clearMsgs();
-  $("#editor").value = ""; $("#fileName").textContent = "no file";
+  state.tenant = id; state.file = null; state.files = []; state.chatId = null; state.collapsed.clear(); clearMsgs(); clearNote();
+  $("#editor").value = ""; $("#editor").disabled = false; $("#fileName").textContent = "no file"; fileButtons();
   $("#empty").classList.add("hidden"); $("#frame").classList.remove("hidden");
   $("#frame").src = previewUrl(id, $("#path").value || "/");
   if (state.es) state.es.close();
@@ -147,26 +184,62 @@ async function selectTenant(id) {
   await loadChats();
 }
 
+const dirOf = (path) => (path.includes("/") ? path.slice(0, path.lastIndexOf("/")) : "");
+
+// Grouped by directory: `examples/starter` is 28 files and a flat list of them is a wall of
+// identical prefixes. Every label is set as text, never as markup — a file may be named anything.
+function renderFiles(files) {
+  const groups = new Map();
+  for (const f of files) {
+    const dir = dirOf(f.path);
+    if (!groups.has(dir)) groups.set(dir, []);
+    groups.get(dir).push(f);
+  }
+  const boxes = [];
+  for (const [dir, entries] of groups) {
+    const box = document.createElement("details");
+    box.dataset.dir = dir;
+    box.open = !state.collapsed.has(dir);
+    const head = document.createElement("summary");
+    head.textContent = dir === "" ? "/" : dir + "/";
+    const count = document.createElement("span");
+    count.className = "count"; count.textContent = entries.length;
+    head.appendChild(count);
+    box.appendChild(head);
+    for (const f of entries) {
+      const d = document.createElement("div");
+      d.dataset.path = f.path;
+      d.textContent = dir === "" ? f.path : f.path.slice(dir.length + 1);
+      d.title = `${f.path} · ${f.size} bytes`;
+      if (f.modified) d.classList.add("modified");
+      if (f.path === state.file) d.classList.add("active");
+      box.appendChild(d);
+    }
+    boxes.push(box);
+  }
+  $("#files").replaceChildren(...boxes);
+}
+
 async function loadFiles() {
   if (!state.tenant) return;
   const { files } = await api("GET", `/api/t/${state.tenant}/files`);
-  $("#files").replaceChildren(...files.map((f) => {
-    const d = document.createElement("div");
-    d.dataset.path = f.path; d.textContent = f.path; d.title = `${f.size} bytes`;
-    if (f.modified) d.classList.add("modified");
-    if (f.path === state.file) d.classList.add("active");
-    return d;
-  }));
+  state.files = files;
+  renderFiles(files);
+  fileButtons();
 }
 
 async function openFile(path, silent) {
   if (state.dirty && !silent && !confirm("Discard unsaved edits?")) return;
   state.file = path; state.dirty = false;
-  $("#files").querySelectorAll("div").forEach((d) => d.classList.toggle("active", d.dataset.path === path));
+  state.collapsed.delete(dirOf(path));
+  const group = $("#files").querySelector(`[data-dir="${CSS.escape(dirOf(path))}"]`);
+  if (group) group.open = true;
+  $("#files").querySelectorAll("[data-path]").forEach((d) => d.classList.toggle("active", d.dataset.path === path));
   $("#fileName").textContent = path;
+  fileButtons();
   if (BINARY.test(path)) { $("#editor").value = "(binary file)"; $("#editor").disabled = true; return; }
   $("#editor").disabled = false;
-  $("#editor").value = await api("GET", `/api/t/${state.tenant}/file/${encPath(path)}`);
+  $("#editor").value = await api("GET", fileUrl(path));
   $("#saveState").textContent = "";
 }
 
@@ -175,7 +248,7 @@ async function save() {
   if (!state.file || !state.tenant) return;
   const path = state.file, body = $("#editor").value;
   $("#saveState").textContent = "saving…";
-  try { await api("PUT", `/api/t/${state.tenant}/file/${encPath(path)}`, body, true); state.dirty = false; $("#saveState").textContent = "saved"; }
+  try { await putFile(path, body); state.dirty = false; $("#saveState").textContent = "saved"; }
   catch (e) { $("#saveState").textContent = "save failed: " + e.message; }
 }
 $("#editor").addEventListener("input", () => { state.dirty = true; $("#saveState").textContent = "…"; clearTimeout(saveTimer); saveTimer = setTimeout(save, 350); });
@@ -184,12 +257,175 @@ $("#editor").addEventListener("keydown", (e) => {
   if (e.key === "Tab") { e.preventDefault(); const t = e.target, s = t.selectionStart; t.setRangeText("  ", s, t.selectionEnd, "end"); t.dispatchEvent(new Event("input")); }
 });
 $("#files").addEventListener("click", (e) => { const d = e.target.closest("[data-path]"); if (d) openFile(d.dataset.path); });
+// `toggle` does not bubble, so the listener has to catch it on the way down.
+$("#files").addEventListener("toggle", (e) => {
+  const box = e.target;
+  if (box.dataset.dir === undefined) return;
+  if (box.open) state.collapsed.delete(box.dataset.dir); else state.collapsed.add(box.dataset.dir);
+}, true);
+
+function note(text, bad) {
+  const m = $("#fileMsg");
+  m.textContent = text; m.hidden = !text; m.classList.toggle("bad", !!bad);
+}
+const clearNote = () => note("");
+const fail = (text) => note(text, true);
+function fileButtons() {
+  const on = !!state.tenant;
+  $("#newFile").disabled = !on; $("#uploadFile").disabled = !on;
+  $("#renameFile").disabled = !on || !state.file; $("#deleteFile").disabled = !on || !state.file;
+}
+
+const ask = (dlg) => new Promise((resolve) => {
+  dlg.addEventListener("close", () => resolve(dlg.returnValue === "ok"), { once: true });
+  dlg.showModal();
+});
+
+async function askPath({ title, note: hint, value, ok }) {
+  $("#pathDlgTitle").textContent = title;
+  $("#pathDlgNote").textContent = hint;
+  $("#pathDlgOk").textContent = ok;
+  const input = $("#pathDlgInput");
+  input.value = value;
+  if (!(await ask($("#pathDlg")))) return null;
+  return input.value.trim();
+}
+
+// A path is sent as it was typed: the URL parser resolves "." and ".." away before fetch sends
+// anything, so a path the daemon would refuse would otherwise land on a different file entirely.
+function fileUrl(path) {
+  const url = `/api/t/${state.tenant}/file/${encPath(path)}`;
+  if (new URL(url, location.href).pathname !== url) {
+    throw new Error(`the browser rewrites '${path}' into another path before it can be sent, so the daemon never sees it: use a path with no '.' or '..' segment`);
+  }
+  return url;
+}
+const putFile = (path, body) => api("PUT", fileUrl(path), body, true);
+const delFile = (path) => api("DELETE", fileUrl(path));
+
+const stem = (path) => path.slice(path.lastIndexOf("/") + 1).replace(/\.[^.]*$/, "");
+const TEMPLATES = {
+  astro: (p) => `---\nconst title = ${JSON.stringify(stem(p))};\n---\n\n<h1>{title}</h1>\n<p>A new page. Edit it here; the preview follows.</p>\n`,
+  md: (p) => `---\ntitle: ${JSON.stringify(stem(p))}\n---\n\n# ${stem(p)}\n\nWrite here.\n`,
+  css: () => `:root {\n  /* custom properties go here */\n}\n`,
+  ts: (p) => `export const ${stem(p).replace(/[^A-Za-z0-9_$]/g, "_")} = {};\n`,
+  json: () => `{\n}\n`,
+};
+TEMPLATES.mdx = TEMPLATES.md;
+TEMPLATES.js = TEMPLATES.ts;
+TEMPLATES.mjs = TEMPLATES.ts;
+const template = (path) => {
+  const ext = path.includes(".") ? path.slice(path.lastIndexOf(".") + 1).toLowerCase() : "";
+  return (TEMPLATES[ext] || (() => ""))(path);
+};
+
+async function newFile() {
+  if (!state.tenant) return;
+  clearNote();
+  const path = await askPath({
+    title: "New file",
+    note: "A path inside the project. The daemon decides what it will accept; an extension it knows is seeded with a starting point.",
+    value: "src/pages/",
+    ok: "Create",
+  });
+  if (!path) return;
+  if (state.files.some((f) => f.path === path)) return fail(`${path} already exists — open it instead, or pick another path`);
+  try { await putFile(path, new Blob([template(path)], { type: "text/plain" })); }
+  catch (e) { return fail(`${path} was not created: ${e.message}`); }
+  await loadFiles();
+  await openFile(path, true);
+  note(`created ${path}`);
+}
+
+async function renameFile() {
+  const from = state.file;
+  if (!from || !state.tenant) return;
+  clearNote();
+  const to = await askPath({
+    title: "Rename file",
+    note: "A rename is two steps: the new path is written, then the old one is deleted. If the second step fails the file is left at both paths, and this says so rather than reporting a rename that did not happen.",
+    value: from,
+    ok: "Rename",
+  });
+  if (!to || to === from) return;
+  if (state.files.some((f) => f.path === to)) return fail(`${to} already exists — nothing was renamed`);
+  let bytes;
+  try { bytes = await apiBlob(fileUrl(from)); }
+  catch (e) { return fail(`${from} was not renamed: reading it failed: ${e.message}`); }
+  try { await putFile(to, bytes); }
+  catch (e) { return fail(`${from} was not renamed: writing ${to} failed: ${e.message}`); }
+  try { await delFile(from); }
+  catch (e) {
+    await loadFiles();
+    return fail(`${to} was written, but deleting ${from} failed, so the file now exists at both paths and you have to delete ${from} yourself. The daemon said: ${e.message}`);
+  }
+  await loadFiles();
+  await openFile(to, true);
+  note(`renamed ${from} → ${to}; the copy at ${from} is gone`);
+}
+
+async function deleteFile() {
+  const path = state.file;
+  if (!path || !state.tenant) return;
+  clearNote();
+  $("#delDlgPath").textContent = path;
+  if (!(await ask($("#delDlg")))) return;
+  try { await delFile(path); }
+  catch (e) { return fail(`${path} was not deleted: ${e.message}`); }
+  state.file = null; state.dirty = false;
+  $("#editor").value = ""; $("#editor").disabled = false; $("#fileName").textContent = "no file"; $("#saveState").textContent = "";
+  await loadFiles();
+  note(`deleted ${path}`);
+}
+
+// Uploads land in public/ unless they were dropped onto another directory's group.
+async function upload(files, dir) {
+  if (!state.tenant || !files.length) return;
+  clearNote();
+  const target = dir === undefined || dir === null ? "public" : dir;
+  const done = [];
+  for (const f of files) {
+    const path = target === "" ? f.name : `${target}/${f.name}`;
+    try { await putFile(path, f); }
+    catch (e) {
+      await loadFiles();
+      return fail(`${path} was not uploaded: ${e.message}${done.length ? ` (${done.join(", ")} did land)` : ""}`);
+    }
+    done.push(path);
+  }
+  await loadFiles();
+  note(`uploaded ${done.join(", ")}`);
+}
+
+$("#newFile").onclick = newFile;
+$("#renameFile").onclick = renameFile;
+$("#deleteFile").onclick = deleteFile;
+$("#uploadFile").onclick = () => $("#picker").click();
+$("#picker").addEventListener("change", async (e) => {
+  const files = [...e.target.files];
+  e.target.value = "";
+  await upload(files);
+});
+const dropDir = (target) => {
+  const row = target.closest("[data-path]");
+  if (row) return dirOf(row.dataset.path);
+  const box = target.closest("[data-dir]");
+  return box ? box.dataset.dir : null;
+};
+$("#files").addEventListener("dragover", (e) => { e.preventDefault(); $("#files").classList.add("drop"); });
+$("#files").addEventListener("dragleave", (e) => { if (!$("#files").contains(e.relatedTarget)) $("#files").classList.remove("drop"); });
+$("#files").addEventListener("drop", async (e) => {
+  e.preventDefault();
+  $("#files").classList.remove("drop");
+  const files = [...(e.dataTransfer ? e.dataTransfer.files : [])];
+  if (files.length) await upload(files, dropDir(e.target));
+});
 $("#tenant").addEventListener("change", (e) => selectTenant(e.target.value));
 $("#tabs").addEventListener("click", (e) => {
   const b = e.target.closest("button"); if (!b) return;
   $("#tabs").querySelectorAll("button").forEach((x) => x.classList.toggle("active", x === b));
   const chat = b.dataset.tab === "chat";
-  $("#chat").classList.toggle("visible", chat); $("#files").classList.toggle("hidden", chat); $("#editorWrap").classList.toggle("hidden", chat);
+  $("#chat").classList.toggle("visible", chat); $("#filePane").classList.toggle("hidden", chat); $("#editorWrap").classList.toggle("hidden", chat);
 });
 const openDialog = async () => {
   const bases = await api("GET", "/api/bases");

--- a/e2e/editor-files.spec.ts
+++ b/e2e/editor-files.spec.ts
@@ -1,0 +1,205 @@
+import { crc32, deflateSync } from 'node:zlib';
+
+import type { Page } from '@playwright/test';
+
+import { type Daemon, startDaemon } from './daemon';
+import { expect, test } from './fixtures';
+
+// A real 1×1 PNG, built here rather than committed: what the upload has to carry is bytes that
+// survive the round trip, and a fixture in the repository would only prove the file was read.
+function pixelPng(): Buffer {
+  const chunk = (type: string, body: Buffer): Buffer => {
+    const length = Buffer.alloc(4);
+    length.writeUInt32BE(body.length);
+    const typed = Buffer.concat([Buffer.from(type, 'ascii'), body]);
+    const crc = Buffer.alloc(4);
+    crc.writeUInt32BE(crc32(typed));
+    return Buffer.concat([length, typed, crc]);
+  };
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(1, 0);
+  ihdr.writeUInt32BE(1, 4);
+  ihdr[8] = 8; // bit depth
+  ihdr[9] = 2; // truecolour
+  const idat = deflateSync(Buffer.from([0, 0x6e, 0xa8, 0xfe]));
+  const signature = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  return Buffer.concat([signature, chunk('IHDR', ihdr), chunk('IDAT', idat), chunk('IEND', Buffer.alloc(0))]);
+}
+
+const row = (path: string) => `#files [data-path="${path}"]`;
+
+// The picker is a hidden <input type=file> behind the upload button, which is how a person reaches it.
+async function pick(page: Page, file: { name: string; mimeType: string; buffer: Buffer }): Promise<void> {
+  const chooser = page.waitForEvent('filechooser');
+  await page.click('#uploadFile');
+  await (await chooser).setFiles(file);
+}
+
+test('a file is created, previewed, renamed, uploaded to and deleted from the editor', async ({ daemon, page }) => {
+  const site = await daemon.tenant('editor-files', 'starter');
+  await page.goto(`${daemon.api}/`);
+  await page.selectOption('#tenant', 'editor-files');
+  await expect(page.locator(row('src/pages/index.astro'))).toBeVisible();
+  // grouped by directory: the row shows the name and the group shows the path it is under
+  await expect(page.locator(row('src/pages/index.astro'))).toHaveText('index.astro');
+  await expect(page.locator('#files details[data-dir="src/pages"] summary')).toContainText('src/pages/');
+
+  await page.click('#newFile');
+  await page.fill('#pathDlgInput', 'src/pages/e2e-new.astro');
+  await page.click('#pathDlgOk');
+  await expect(page.locator(row('src/pages/e2e-new.astro'))).toHaveText('e2e-new.astro');
+  await expect(page.locator('#fileMsg')).toHaveText('created src/pages/e2e-new.astro');
+  await expect(page.locator('#editor')).toHaveValue(/^---\nconst title = "e2e-new";\n---\n/);
+
+  await page.fill('#path', '/e2e-new');
+  await page.click('#go');
+  await expect(page.frameLocator('#frame').locator('h1')).toHaveText('e2e-new', { timeout: 15_000 });
+  // back to a page that outlives the rename: the preview reloads on every write, and a frame left
+  // on the old path would fetch a route that no longer exists.
+  await page.fill('#path', '/');
+  await page.click('#go');
+  await expect(page.frameLocator('#frame').locator('h1')).toHaveText('Design that ships.');
+
+  await page.click('#renameFile');
+  await expect(page.locator('#pathDlgNote')).toContainText('two steps');
+  await page.fill('#pathDlgInput', 'src/pages/e2e-renamed.astro');
+  await page.click('#pathDlgOk');
+  await expect(page.locator(row('src/pages/e2e-renamed.astro'))).toBeVisible();
+  await expect(page.locator(row('src/pages/e2e-new.astro'))).toHaveCount(0);
+  await expect(page.locator('#fileMsg')).toContainText('renamed src/pages/e2e-new.astro → src/pages/e2e-renamed.astro');
+
+  await page.fill('#path', '/e2e-renamed');
+  await page.click('#go');
+  await expect(page.frameLocator('#frame').locator('h1'), 'the content moved with the path').toHaveText('e2e-new');
+  await page.fill('#path', '/');
+  await page.click('#go');
+
+  const png = pixelPng();
+  await pick(page, { name: 'e2e-pixel.png', mimeType: 'image/png', buffer: png });
+  await expect(page.locator('#fileMsg')).toHaveText('uploaded public/e2e-pixel.png');
+  await expect(page.locator(row('public/e2e-pixel.png'))).toHaveText('e2e-pixel.png');
+  await expect(page.locator(row('public/e2e-pixel.png'))).toHaveAttribute('title', `public/e2e-pixel.png · ${png.length} bytes`);
+  const served = await fetch(site.url('/e2e-pixel.png'));
+  expect(served.status).toBe(200);
+  expect(served.headers.get('content-type')).toBe('image/png');
+  expect(Buffer.from(await served.arrayBuffer()).equals(png), 'the bytes the preview serves are the bytes uploaded').toBe(true);
+
+  await page.click(row('public/e2e-pixel.png'));
+  await expect(page.locator('#fileName')).toHaveText('public/e2e-pixel.png');
+  await page.click('#deleteFile');
+  await expect(page.locator('#delDlgPath')).toHaveText('public/e2e-pixel.png');
+  await page.click('#delDlg button[value="ok"]');
+  await expect(page.locator(row('public/e2e-pixel.png'))).toHaveCount(0);
+  await expect(page.locator('#fileMsg')).toHaveText('deleted public/e2e-pixel.png');
+
+  await page.click(row('src/pages/e2e-renamed.astro'));
+  await page.click('#deleteFile');
+  await expect(page.locator('#delDlgPath')).toHaveText('src/pages/e2e-renamed.astro');
+  await page.click('#delDlg button[value="ok"]');
+  await expect(page.locator(row('src/pages/e2e-renamed.astro'))).toHaveCount(0);
+  await expect(page.locator('#fileName'), 'the deleted file is no longer open').toHaveText('no file');
+  // every step is in the list: what was created and renamed is gone, the base project is untouched
+  await expect(page.locator(row('src/pages/index.astro'))).toBeVisible();
+  await expect(page.locator(row('public/favicon.svg'))).toBeVisible();
+});
+
+test('a dropped file lands in the directory it was dropped on, and in public/ otherwise', async ({ daemon, page }) => {
+  await daemon.tenant('editor-drop', 'starter');
+  await page.goto(`${daemon.api}/`);
+  await page.selectOption('#tenant', 'editor-drop');
+  await expect(page.locator(row('src/styles/tokens.css'))).toBeVisible();
+
+  const drop = (selector: string, name: string, text: string) =>
+    page.evaluate(
+      ({ selector, name, text }) => {
+        const target = document.querySelector(selector)!;
+        const data = new DataTransfer();
+        data.items.add(new File([text], name, { type: 'text/plain' }));
+        for (const type of ['dragover', 'drop']) {
+          target.dispatchEvent(new DragEvent(type, { bubbles: true, cancelable: true, dataTransfer: data }));
+        }
+      },
+      { selector, name, text },
+    );
+
+  await drop(row('src/styles/tokens.css'), 'dropped.css', '.dropped { color: red }\n');
+  await expect(page.locator(row('src/styles/dropped.css'))).toBeVisible();
+  await expect(page.locator('#fileMsg')).toHaveText('uploaded src/styles/dropped.css');
+
+  await drop('#files', 'dropped.txt', 'dropped on the list itself\n');
+  await expect(page.locator(row('public/dropped.txt'))).toBeVisible();
+  await expect(page.locator('#fileMsg')).toHaveText('uploaded public/dropped.txt');
+});
+
+test('a file named like markup is text in the list, in the dialog and in the message', async ({ daemon, page }) => {
+  await daemon.tenant('editor-hostile', 'starter');
+  await page.goto(`${daemon.api}/`);
+  await page.selectOption('#tenant', 'editor-hostile');
+  const hostile = '<img src=x onerror=alert(1)>.astro';
+
+  await page.click('#newFile');
+  await page.fill('#pathDlgInput', hostile);
+  await page.click('#pathDlgOk');
+  await expect(page.locator(row(hostile))).toHaveText(hostile);
+  await expect(page.locator('#fileMsg')).toHaveText(`created ${hostile}`);
+  await expect(page.locator('#files img'), 'the name is a label, not markup').toHaveCount(0);
+
+  await page.click('#deleteFile');
+  await expect(page.locator('#delDlgPath')).toHaveText(hostile);
+  await expect(page.locator('#delDlg img')).toHaveCount(0);
+  await page.click('#delDlg button[value="ok"]');
+  await expect(page.locator(row(hostile))).toHaveCount(0);
+  await expect(page.locator('#fileMsg')).toHaveText(`deleted ${hostile}`);
+});
+
+test("a path the daemon refuses is reported in the daemon's own words", async ({ daemon, page, browserLog }) => {
+  await daemon.tenant('editor-badpath', 'starter');
+  await page.goto(`${daemon.api}/`);
+  await page.selectOption('#tenant', 'editor-badpath');
+
+  await page.click('#newFile');
+  await page.fill('#pathDlgInput', 'src/pages/a\\b.astro');
+  await page.click('#pathDlgOk');
+  // `bad path` is what src/store.rs::clean_path makes the API say; the editor adds only the context.
+  await expect(page.locator('#fileMsg')).toHaveText('src/pages/a\\b.astro was not created: bad path');
+  await expect(page.locator('#fileMsg')).toHaveClass(/bad/);
+  // not row(): a backslash inside a CSS attribute selector is an escape, so the name is matched as text
+  await expect(page.locator('#files')).not.toContainText('a\\b.astro');
+
+  // A path the URL parser would rewrite never reaches the daemon, and saying "bad path" there would
+  // be putting words in its mouth.
+  await page.click('#newFile');
+  await page.fill('#pathDlgInput', 'src/pages/../../escape.astro');
+  await page.click('#pathDlgOk');
+  await expect(page.locator('#fileMsg')).toContainText('the browser rewrites');
+
+  const { failedRequests } = browserLog.take();
+  expect(failedRequests.filter((r) => r.includes(': 400')), 'the refusal was a 400 from the daemon').toHaveLength(1);
+});
+
+test.describe('tenant quota', () => {
+  let quotaDaemon: Daemon;
+
+  test.beforeAll(async () => {
+    quotaDaemon = await startDaemon(['--tenant-quota-mb', '1']);
+    await quotaDaemon.tenant('editor-quota', 'starter');
+  });
+
+  test.afterAll(async () => {
+    await quotaDaemon?.stop();
+  });
+
+  test('an upload past the quota reports the 413 the daemon sent', async ({ page, browserLog }) => {
+    await page.goto(`${quotaDaemon.api}/`);
+    await page.selectOption('#tenant', 'editor-quota');
+    await expect(page.locator(row('src/pages/index.astro'))).toBeVisible();
+
+    await pick(page, { name: 'too-big.bin', mimeType: 'application/octet-stream', buffer: Buffer.alloc(2 << 20, 7) });
+    await expect(page.locator('#fileMsg')).toContainText('public/too-big.bin was not uploaded: tenant quota exceeded');
+    await expect(page.locator('#fileMsg')).toContainText('--tenant-quota-mb');
+    await expect(page.locator(row('public/too-big.bin'))).toHaveCount(0);
+
+    const { failedRequests } = browserLog.take();
+    expect(failedRequests.filter((r) => r.includes(': 413'))).toHaveLength(1);
+  });
+});

--- a/e2e/editor-files.spec.ts
+++ b/e2e/editor-files.spec.ts
@@ -3,7 +3,7 @@ import { crc32, deflateSync } from 'node:zlib';
 import type { Page } from '@playwright/test';
 
 import { type Daemon, startDaemon } from './daemon';
-import { expect, test } from './fixtures';
+import { type BrowserLog, expect, test } from './fixtures';
 
 // A real 1×1 PNG, built here rather than committed: what the upload has to carry is bytes that
 // survive the round trip, and a fixture in the repository would only prove the file was read.
@@ -28,6 +28,15 @@ function pixelPng(): Buffer {
 
 const row = (path: string) => `#files [data-path="${path}"]`;
 
+// Every write reloads the framed preview, and that navigation cancels the frame's live-reload
+// stream and whatever the previous document still had in flight. A cancelled request is not a
+// failed one, so the run is clean once they are taken out; nothing else is tolerated.
+function expectCleanBesidesTheFrameReloading(log: BrowserLog): void {
+  const { consoleErrors, failedRequests } = log.take();
+  expect(consoleErrors, 'console errors').toEqual([]);
+  expect(failedRequests.filter((r) => !r.endsWith('net::ERR_ABORTED')), 'failed requests').toEqual([]);
+}
+
 // The picker is a hidden <input type=file> behind the upload button, which is how a person reaches it.
 async function pick(page: Page, file: { name: string; mimeType: string; buffer: Buffer }): Promise<void> {
   const chooser = page.waitForEvent('filechooser');
@@ -35,7 +44,7 @@ async function pick(page: Page, file: { name: string; mimeType: string; buffer: 
   await (await chooser).setFiles(file);
 }
 
-test('a file is created, previewed, renamed, uploaded to and deleted from the editor', async ({ daemon, page }) => {
+test('a file is created, previewed, renamed, uploaded to and deleted from the editor', async ({ daemon, page, browserLog }) => {
   const site = await daemon.tenant('editor-files', 'starter');
   await page.goto(`${daemon.api}/`);
   await page.selectOption('#tenant', 'editor-files');
@@ -101,9 +110,10 @@ test('a file is created, previewed, renamed, uploaded to and deleted from the ed
   // every step is in the list: what was created and renamed is gone, the base project is untouched
   await expect(page.locator(row('src/pages/index.astro'))).toBeVisible();
   await expect(page.locator(row('public/favicon.svg'))).toBeVisible();
+  expectCleanBesidesTheFrameReloading(browserLog);
 });
 
-test('a dropped file lands in the directory it was dropped on, and in public/ otherwise', async ({ daemon, page }) => {
+test('a dropped file lands in the directory it was dropped on, and in public/ otherwise', async ({ daemon, page, browserLog }) => {
   await daemon.tenant('editor-drop', 'starter');
   await page.goto(`${daemon.api}/`);
   await page.selectOption('#tenant', 'editor-drop');
@@ -129,9 +139,10 @@ test('a dropped file lands in the directory it was dropped on, and in public/ ot
   await drop('#files', 'dropped.txt', 'dropped on the list itself\n');
   await expect(page.locator(row('public/dropped.txt'))).toBeVisible();
   await expect(page.locator('#fileMsg')).toHaveText('uploaded public/dropped.txt');
+  expectCleanBesidesTheFrameReloading(browserLog);
 });
 
-test('a file named like markup is text in the list, in the dialog and in the message', async ({ daemon, page }) => {
+test('a file named like markup is text in the list, in the dialog and in the message', async ({ daemon, page, browserLog }) => {
   await daemon.tenant('editor-hostile', 'starter');
   await page.goto(`${daemon.api}/`);
   await page.selectOption('#tenant', 'editor-hostile');
@@ -150,6 +161,7 @@ test('a file named like markup is text in the list, in the dialog and in the mes
   await page.click('#delDlg button[value="ok"]');
   await expect(page.locator(row(hostile))).toHaveCount(0);
   await expect(page.locator('#fileMsg')).toHaveText(`deleted ${hostile}`);
+  expectCleanBesidesTheFrameReloading(browserLog);
 });
 
 test("a path the daemon refuses is reported in the daemon's own words", async ({ daemon, page, browserLog }) => {


### PR DESCRIPTION
Closes #86

The editor listed a tenant's files and edited the ones that already existed.
Adding a page, renaming one, removing one or putting an image in `public/`
meant `curl` — the daemon has supported all four since the file endpoint
existed. This is that surface.

## What it does

- **New file** (`+ file`): a path dialog, seeded by extension — `.astro` gets a
  frontmatter fence and an element, `.md`/`.mdx` frontmatter with a title,
  `.css`/`.ts`/`.js`/`.json` a first line worth keeping. A path that already
  exists is refused before anything is sent; anything else is the daemon's call.
- **Rename**: `PUT` the new path, `DELETE` the old one. The dialog says that is
  what a rename is *before* it runs, and if the delete fails the message says
  the file now exists at both paths and names the one to remove by hand.
- **Delete**: a dialog naming the path, with the path set as text.
- **Upload**: the picker writes into `public/`; a drop onto the list does too,
  unless it lands on another directory's group, in which case it goes there.
- **The file list is grouped by directory**, one group per directory with a
  count and a heading that stays put while the list scrolls. Collapsed groups
  are remembered across the reloads the SSE stream triggers.

## The two constraints

**Nothing reaches the DOM unescaped.** Every label, message and dialog value is
set with `textContent`; the one pre-existing `innerHTML` sink is untouched.
`node tests/editor-escaping.mjs` passes, and an e2e test creates
`<img src=x onerror=alert(1)>.astro` and asserts it is text in the list, in the
delete dialog and in both messages, with `#files img` and `#delDlg img` empty.

**Refusals arrive in the daemon's own words.** The error extraction in `api()`
is now shared by every call, so `bad path` from `clean_path` and the quota
sentence behind the 413 (`… the quota is 1048576 bytes (--tenant-quota-mb)`)
are what the user reads, with only "`X` was not created:" as context. The e2e
suite asserts both against a real daemon, the second against one started with
`--tenant-quota-mb 1`.

There is one message the editor writes itself, and it is deliberate: the URL
parser resolves `.` and `..` segments away before `fetch` sends anything, so a
path like `src/pages/../../escape.astro` would silently `PUT` to a *different*
file. `fileUrl()` checks that the URL it built survives `new URL()` and refuses
if it did not — the daemon never sees such a path, and saying "bad path" there
would be putting words in its mouth.

## Tests

`e2e/editor-files.spec.ts`, five specs against a real daemon in Chromium: the
create → preview → rename → preview → upload → delete round trip (asserting the
list after every step and that the uploaded bytes are the bytes `public/`
serves back), drop targeting, the hostile filename, the refused path, and the
quota's 413. The PNG is built in the test from `zlib.crc32`/`deflateSync`
rather than committed, because what an upload has to carry is bytes.

`ARCHITECTURE.md` gains the two facts a reader cannot get from the code: that
there is no rename endpoint, and why a refusal is quoted rather than summarised.

CI: green on
[run 34084221769](https://github.com/productdevbook/sandbox-lite/actions/runs/34084221769)
(fmt, clippy `-D warnings`, tests, editor-escaping, release build, `check`,
smoke, `bench/mem.sh 100`, the dev-server comparison, 41 Playwright tests).
The first run was red for one reason, worth recording: an editor-driven write
reloads the framed preview, and that navigation cancels the frame's live-reload
stream, which the shared `BrowserLog` fixture counted as a failed request. The
spec now asserts the log itself minus `net::ERR_ABORTED`, and lets every other
status fail the test.

## Noticed, did not fix

- **The "New tenant" dialog cannot be cancelled while its id field is empty.**
  Both of its buttons submit the form, and the field is `required`, so Cancel
  is blocked by validation until you type something. The new file dialog's
  Cancel carries `formnovalidate`; `#dlg` predates this change and was left
  alone.
- **An upload of several files is one `PUT` each**, so a run that hits the quota
  half way leaves the earlier files written. The message names what did land.
  `Tenant::write_many` would make it atomic, but no HTTP route exposes it.
- **Groups are one level deep**, keyed by the whole directory path, so
  `src/content` and `src/content/posts` are siblings rather than nested. That is
  legible at thirty files; a project with a deep tree would want indentation.
- **Dropping a directory does nothing and says nothing.** `dataTransfer.files`
  has no bytes for a folder, so the loop uploads nothing and reports nothing.
- **A renamed base file leaves a tombstone plus a full copy in the overlay**, so
  renaming a large base file costs its size against the tenant quota. That is
  how `Tenant::delete` works for base files and is not new here.
- **The rest of the editor still reports failures through `alert()`** — creating
  and deleting a tenant, deleting a conversation. Only the file surface got the
  inline message line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
