### PR TITLE
store: decide and act under one lock, and report a torn delete

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -104,8 +104,9 @@ limit `docs/multi-node.md` sets out. It answers `NoTenant::Unknown` when
 neither the map nor the data directory holds the id and `NoTenant::Failed(why)`
 when `<data-dir>/<id>` is there and would not load — recording it the way
 `restore` does — so the HTTP layer can answer 404 for a tenant that never
-existed and 500 with the reason for one that could not be loaded. `Store::tenant`
-is `resolve(…).ok()`, for the callers that only need to know whether it is here.
+existed and 500 with the reason for one that could not be loaded. Every caller in
+the daemon reports that reason, so `resolve` is the whole of the read path;
+`Store::tenant`, `resolve(…).ok()`, is `#[cfg(test)]` and only tests ask it.
 `--no-persist` keeps everything in memory.
 
 Because that fallback makes the data directory as much a source of tenants as
@@ -116,6 +117,21 @@ refuses an id whose directory is already there even when it cannot build a
 tenant from it — its base may not be loaded on this node. `Store::tenants` is
 the exception, and stays a list of what this daemon has loaded: it answers
 `/api/tenants`, `/api/stats` and `/metrics`, none of which act on a tenant.
+
+Each of them decides and acts under one acquisition of the `tenants` write
+lock, held across the directory work: `create_tenant` refuses, writes
+`tenant.json` and inserts under it; `remove_tenant` drops the entry and removes
+`<data-dir>/<id>` before releasing it; and a `resolve` miss re-reads the
+directory under it too, re-checking the map first. Deciding under one
+acquisition and mutating under another was two races reachable over HTTP —
+eight creates of one id all answered 201, and a delete that raced a request put
+the tenant back in the map from a directory that was about to go (issue #92).
+`tenants` is the outermost of the store's locks: `bases`, `failed` and a
+tenant's own `overlay` are taken under it and never the other way about, and
+neither the transform cache nor the compile gate can be held while it is taken,
+since the engine is handed an `Arc<Tenant>` and never sees the `Store`. The
+cost is that a delete or a restore-from-disk holds off every other lookup for
+as long as its directory work takes.
 
 ### Reloading a base
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -391,15 +391,14 @@ impl Tenant {
         Ok(Applied { version: self.bump("update", "", UpdateKind::Module), written, deleted: removed })
     }
 
-    pub fn delete(&self, path: &str) -> io::Result<u64> {
+    pub fn delete(&self, path: &str) -> Result<u64, WriteError> {
         // held across the disk work, as a write is: the file leaves the directory and the tombstone
         // list is rewritten before the overlay hears about it, and a failure puts both back
         let mut overlay = self.overlay.write().unwrap();
         let tombstone = self.base.read().unwrap().get(path).is_some();
         let mut staged = Staged::new(self.dir.as_deref());
         if let Err(cause) = stage_delete(&mut staged, &overlay, path, tombstone) {
-            staged.rollback();
-            return Err(cause);
+            return Err(staged.undo(cause));
         }
         if tombstone {
             overlay.insert(path.to_string(), None);
@@ -822,10 +821,15 @@ impl Store {
             return Err("tenant id must be lowercase letters, digits and dashes".into());
         }
         let base = self.base(base_name).ok_or_else(|| format!("unknown base '{base_name}'"))?;
+        // One acquisition for the whole operation — the refusal, the directory and the insert. Taken
+        // and released around the check, two callers of one id both read "not there" and both went
+        // on to write `tenant.json` and insert, so all of them were told 201 and all but the last
+        // held a tenant this node does not serve (issue #92).
+        let mut tenants = self.tenants.write().unwrap();
         // the data directory as well as the map: a tenant another node created exists, and creating
-        // over its directory would hide the files already in it. `tenant` alone would miss one whose
+        // over its directory would hide the files already in it. The map alone would miss one whose
         // base this node has not loaded, which is exactly when the map is empty of it.
-        if self.tenant(id).is_some() || self.tenant_dir(id).is_some() {
+        if tenants.contains_key(id) || self.tenant_dir(id).is_some() {
             return Err(format!("tenant '{id}' already exists"));
         }
         let dir = self.data_dir.as_ref().map(|d| d.join(id));
@@ -835,7 +839,7 @@ impl Store {
                 .map_err(|e| e.to_string())?;
         }
         let tenant = Arc::new(Tenant::new(id.to_string(), base, dir, self.tenant_quota));
-        self.tenants.write().unwrap().insert(id.to_string(), tenant.clone());
+        tenants.insert(id.to_string(), tenant.clone());
         Ok(tenant)
     }
 
@@ -850,6 +854,14 @@ impl Store {
         if let Some(t) = self.tenants.read().unwrap().get(id).cloned() {
             return Ok(t);
         }
+        // A miss reads the directory under the write lock, not around it: `remove_tenant` holds the
+        // same lock from the drop to the last file, so what this reads back is a tenant that is
+        // still there rather than one being deleted behind it (issue #92). The lock is re-checked
+        // because a create or another miss may have won it first.
+        let mut tenants = self.tenants.write().unwrap();
+        if let Some(t) = tenants.get(id).cloned() {
+            return Ok(t);
+        }
         if self.tenant_dir(id).is_none() {
             return Err(NoTenant::Unknown);
         }
@@ -857,7 +869,8 @@ impl Store {
             Ok(t) => {
                 self.failed.write().unwrap().remove(id);
                 let restored = Arc::new(t);
-                Ok(self.tenants.write().unwrap().entry(id.to_string()).or_insert(restored).clone())
+                tenants.insert(id.to_string(), restored.clone());
+                Ok(restored)
             }
             Err(e) => {
                 self.failed.write().unwrap().insert(id.to_string(), e.clone());
@@ -866,6 +879,10 @@ impl Store {
         }
     }
 
+    /// `resolve` for a test that only asks whether the tenant is here. Nothing in the daemon calls
+    /// it: every caller there reports *why* a tenant is missing, and `create_tenant` — the last one
+    /// that did not — now asks the map it already holds the lock on.
+    #[cfg(test)]
     pub fn tenant(&self, id: &str) -> Option<Arc<Tenant>> {
         self.resolve(id).ok()
     }
@@ -921,8 +938,13 @@ impl Store {
     /// `404`, or the next request would restore it and serve it again. `Ok(false)` is a tenant
     /// neither memory nor the data directory holds. A data directory that survives the delete is an
     /// error: it answered 204 and the tenant comes back at the next restore.
+    ///
+    /// The map's write lock is held across the directory removal. Released after the drop, the
+    /// directory was still there for `resolve` to rebuild the tenant from and put back in the map,
+    /// so a 204 left a tenant serving traffic from a directory that was about to go (issue #92).
     pub fn remove_tenant(&self, id: &str) -> io::Result<bool> {
-        let dropped = self.tenants.write().unwrap().remove(id);
+        let mut tenants = self.tenants.write().unwrap();
+        let dropped = tenants.remove(id);
         self.failed.write().unwrap().remove(id);
         let dir = dropped.as_ref().and_then(|t| t.dir.clone()).or_else(|| self.tenant_dir(id));
         let mut held = dropped.is_some();
@@ -1286,5 +1308,101 @@ mod tests {
         assert!(!is_private_path(".well-known/security.txt"));
         assert!(!is_private_path("src/pages/index.astro"));
         assert_eq!(clean_path("/.env").as_deref(), Some(".env"));
+    }
+
+    /// Issue #92: the check and the mutation used to sit under two acquisitions of the `tenants`
+    /// lock, so eight threads creating one id were all told it was theirs. Seven of them held a
+    /// tenant — its own overlay, its own version, its own event channel — that the store did not
+    /// serve.
+    #[test]
+    fn one_create_of_an_id_wins_and_every_other_caller_is_refused() {
+        let root = temp("create-race");
+        seed(root.join("theme").join(PAGE), "<h1>base</h1>\n");
+        let data = root.join("data");
+        let store = Arc::new(Store::new(Some(data.clone()), 1 << 20));
+        store.add_base(Base::load("theme", &root.join("theme")).unwrap());
+
+        let gun = Arc::new(std::sync::Barrier::new(8));
+        let racing: Vec<_> = (0..8)
+            .map(|_| {
+                let (store, gun) = (store.clone(), gun.clone());
+                std::thread::spawn(move || {
+                    gun.wait();
+                    store.create_tenant("acme", "theme")
+                })
+            })
+            .collect();
+        let answers: Vec<Result<Arc<Tenant>, String>> = racing.into_iter().map(|t| t.join().unwrap()).collect();
+
+        let created: Vec<&Arc<Tenant>> = answers.iter().filter_map(|a| a.as_ref().ok()).collect();
+        assert_eq!(created.len(), 1, "exactly one create may be told it made the tenant");
+        for refused in answers.iter().filter_map(|a| a.as_ref().err()) {
+            assert!(refused.contains("already exists"), "the losers are refused, not served: {refused}");
+        }
+        assert!(Arc::ptr_eq(&store.tenant("acme").unwrap(), created[0]), "and the winner is the tenant the store serves");
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    /// Issue #92: `remove_tenant` dropped the map entry, released the lock and only then removed the
+    /// directory. A request in that gap read the tenant back off disk and put it in the map, so a
+    /// 204 left it answering from a directory that was about to go — for ever, since a later write
+    /// recreates `files/` without `tenant.json` and `restore` skips such a directory.
+    #[test]
+    fn a_tenant_deleted_while_a_request_resolves_it_stays_deleted() {
+        let root = temp("remove-race");
+        seed(root.join("theme").join(PAGE), "<h1>base</h1>\n");
+        let data = root.join("data");
+        let store = Arc::new(Store::new(Some(data.clone()), 1 << 20));
+        store.add_base(Base::load("theme", &root.join("theme")).unwrap());
+
+        for round in 0..200 {
+            store.create_tenant("acme", "theme").unwrap();
+            let gun = Arc::new(std::sync::Barrier::new(2));
+            let (remover, requester) = (store.clone(), store.clone());
+            let (start, also) = (gun.clone(), gun);
+            let removing = std::thread::spawn(move || {
+                start.wait();
+                remover.remove_tenant("acme").unwrap()
+            });
+            let resolving = std::thread::spawn(move || {
+                also.wait();
+                requester.tenant("acme")
+            });
+            assert!(removing.join().unwrap(), "the delete answered 204, round {round}");
+            resolving.join().unwrap();
+            assert!(store.tenant("acme").is_none(), "so nothing may serve it afterwards, round {round}");
+            assert!(!data.join("acme").exists(), "and its data directory is gone, round {round}");
+        }
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    /// Issue #96: `delete` is the third writer, and its undo can fail like the other two. It used to
+    /// answer `io::Result`, which cannot say so — the paths its rollback could not put back went on
+    /// the floor and the caller read the bare cause as "your file is still there".
+    #[test]
+    fn a_delete_whose_undo_fails_names_the_paths_that_are_neither_way() {
+        let dir = temp("torn-delete");
+        let t = tenant(1 << 20, Some(dir.clone()));
+        t.write("a.txt", b"one".to_vec(), UpdateKind::Module).unwrap();
+        // `stage_delete` moves the file aside and then rewrites the tombstone list; the undo rewrites
+        // it back. A mode that refuses both is the failure and the failed undo in one.
+        let list = dir.join("deleted.json");
+        std::fs::write(&list, b"[]").unwrap();
+        let mut mode = std::fs::metadata(&list).unwrap().permissions();
+        mode.set_readonly(true);
+        std::fs::set_permissions(&list, mode).unwrap();
+        if std::fs::OpenOptions::new().write(true).open(&list).is_ok() {
+            // running as root, where the mode is not enforced and the write this needs cannot fail
+            eprintln!("skipped: this process can write a read-only file, so a failed undo cannot be staged");
+            std::fs::remove_dir_all(&dir).unwrap();
+            return;
+        }
+
+        let err = t.delete("a.txt").unwrap_err();
+        let WriteError::Torn { cause, paths } = &err else { panic!("a delete whose undo failed must be Torn, not {err:?}") };
+        assert!(paths.iter().any(|p| p.contains("deleted.json")), "naming what it could not put back: {paths:?}");
+        assert!(err.to_string().contains(&cause.to_string()), "and the cause survives: {err}");
+        assert!(err.to_string().contains("neither what they were"), "{err}");
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 }


### PR DESCRIPTION
Closes #92

Closes #96

Both issues are one sentence apart: a decision taken outside a lock that mutates inside it, and a writer whose error type cannot say what happened. Two files change, `src/store.rs` and `ARCHITECTURE.md`.

## #92 — decide and act under one acquisition

`remove_tenant` dropped the map entry, released the lock, and only then removed `<data-dir>/<id>`. A `resolve` in that gap missed the map, found the directory, rebuilt the tenant and put it back — so a 204 left the tenant answering every request from a directory that was gone, and the first write to it recreated `files/` without `tenant.json`, which `Store::restore` skips for ever. `create_tenant` checked the map and the directory, released the lock, wrote `tenant.json` and inserted: eight concurrent creates of one id were all told 201, and seven callers held a `Tenant` — its own overlay, its own version, its own broadcast channel — that this node does not serve.

Each of the three now decides and acts under one acquisition of the `tenants` write lock, held across the directory work:

- `create_tenant` takes the write lock, then asks the map it is holding (`contains_key`) and `tenant_dir`, writes `tenant.json` and inserts, all under it. Same refusal as before — the directory still counts as "exists", so a tenant another node made is not created over — but the check can no longer be raced past.
- `remove_tenant` holds it from the `remove` through `remove_dir_all`. There is no moment when the map misses and the directory is still readable.
- `resolve` keeps its read-lock fast path; a miss takes the write lock, **re-checks the map**, and only then reads the directory and inserts. That is what makes `remove_tenant`'s hold sufficient: the restore cannot run beside the removal.

`create_tenant` was the last caller in the daemon of `Store::tenant`, and calling it under the lock would deadlock, so it asks the map directly. `Store::tenant` is `#[cfg(test)]` now: every read path in the daemon reports *why* a tenant is missing and so goes through `resolve`.

### The lock order, and why it cannot invert

`tenants` is the outermost of the store's locks. Under it, and only under it, are taken:

- `bases` — `resolve` → `read_tenant` → `Store::base`. Nothing takes `bases` and then `tenants`: `add_base` and `Store::base` release before returning, and `reload_base` calls `self.tenants()` only after `add_base` has finished.
- `failed` — a `BTreeMap` touched by `resolve`, `remove_tenant` and `restore`, never held across anything.
- a tenant's own `overlay` — `resolve` → `read_tenant` → `Tenant::restore_overlay`. A `Tenant` has no reference to the `Store`, so no path exists back up.

The transform cache (`Engine::cache`, `inflight`, `last_js`) and the compile gate sit below all of them and cannot invert with any: `Engine` is handed an `&Arc<Tenant>` and never sees the `Store` (`src/transform/mod.rs` names no `Store` outside its own tests), so no store lock is ever requested while a cache or gate lock is held. A handler resolves the tenant, drops the store lock, and only then builds.

The cost, and it is a real one: a delete or a restore-from-disk now holds off every other tenant lookup for as long as its directory work takes. It is written down in `ARCHITECTURE.md` with the rest.

## #96 — a torn delete says so

`Tenant::delete` returned `io::Result<u64>`, which cannot carry `WriteError::Torn`, so it called `staged.rollback()` and dropped the paths on the floor. It returns `Result<u64, WriteError>` like `write` and `write_many` and uses `staged.undo(cause)`, so ARCHITECTURE.md's "all three writers" is true of all three.

`api::delete_file` and `ai::file_tool` render the error through `Display` and pick up the fuller message with no change; a delete cannot exceed the quota, so there is no `WriteError::Quota` arm to add beside `write_file`'s.

## The tests

In `src/store.rs`, all three run in `cargo test`:

- `one_create_of_an_id_wins_and_every_other_caller_is_refused` — eight threads on one barrier: exactly one `Ok`, seven `already exists`, and `Arc::ptr_eq` between the winner and what the store then resolves.
- `a_tenant_deleted_while_a_request_resolves_it_stays_deleted` — 200 rounds of `remove_tenant` racing `tenant()`: the delete answers 204, and afterwards the map has nothing and `<data-dir>/acme` does not exist. On `main` this is the 1-in-200 the issue measured.
- `a_delete_whose_undo_fails_names_the_paths_that_are_neither_way` — `deleted.json` left read-only, so the tombstone rewrite fails and the undo's rewrite of it fails too: the answer must be `Torn` naming `deleted.json`, with the cause still in the message.

## CI

Green on `2aef35e`, both jobs: https://github.com/productdevbook/sandbox-lite/actions/runs/34084945070 — fmt, clippy `-D warnings`, `cargo test`, release build, `sandbox-lite check`, the smoke test, `bench/mem.sh`, the dev-server comparison, and Playwright.

The first push on this branch was red for one thing worth knowing: with `create_tenant` no longer calling it, `Store::tenant` had no caller left in the daemon and `-D dead-code` said so. It is `#[cfg(test)]` rather than kept alive by a caller invented for it.

## Noticed, not fixed

- **A request already in flight can still write into a deleted tenant.** A caller that resolved the tenant before the delete holds the `Arc` and may write after `remove_dir_all` has run, recreating `<data-dir>/<id>/files/…` (or `chats/`, via `api::delete_tenant`'s `chats.forget` before the removal) without `tenant.json` — which `restore` skips. The 204's invariant now holds for the map and the directory; making it hold for an in-flight request needs a "removed" flag on `Tenant` that the writers check, which is more than either issue asks for.
- **`Staged::rollback` over-reports.** `std::fs::write` on a read-only file fails at `open`, before truncating, so the file is exactly what it was — and the undo then reports it as torn because rewriting it failed. All three writers share this: `Torn` means "the undo failed", not "this path is definitely damaged". Worth narrowing, not here.
- **The torn test cannot run as root**, where the mode is not enforced and the write it needs to fail would succeed. It prints one line and returns. CI runs as `runner`, so CI does exercise it.
- **Nothing makes a create exclusive across nodes.** Two daemons on one `--data-dir` still race: no `O_EXCL` marker, no lock file. `docs/multi-node.md` already sets that limit, and this fix is per process.
- **`Store::restore` still inserts under one acquisition per tenant.** It runs before the listener is up, so nothing races it, but it is the shape #92 was about.
- **The single acquisition is the blunt version.** A per-id lock, or an id marked "being removed" for the duration, would keep the map free during a long `remove_dir_all`. I took the one that cannot be got subtly wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
