### PR TITLE
content: cache it, bound it, and stop hiding 503s in the 500 bucket

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -450,6 +450,11 @@ whole-project compile takes one permit and holds it for the whole run, so
 per-file compile deadline is untouched — each build inside still gets its own
 thread and its own wall clock.
 
+`Engine::collection` takes one permit for the same reason and gives it back the
+same way: a collection is read and parsed as a whole, so it costs one place in
+the queue however many entries it has, and a build that cannot have that permit
+is refused with 503 before a single entry file is read (#90).
+
 ### How long one compile may run
 
 A permit is only a bound if something takes it back. `astro_codegen`, oxc and
@@ -649,6 +654,25 @@ collection with no entries and nothing else — a page rendered from a failed
 build is indistinguishable from a page rendered from a tenant that has no posts
 (issue #48).
 
+The build runs through `Engine::collection`, so the one endpoint that touches
+every file of a project is bounded the way a compile is (issue #90). It takes
+**one permit for the whole collection** — as `Engine::sweep` does for a whole
+project, not one per entry — runs inside `Engine::deadlined`, so an entry file
+that cannot be parsed within `--compile-timeout-ms` is given up on rather than
+held open, and caches its JSON in the transform cache under the tenant's
+version. A second identical request is therefore a cache hit that asks the gate
+for nothing, and any write bumps the version and rebuilds. The key is the
+version rather than the bytes that went into the build because *which* files
+those are is itself a question only the build can answer; the cost is that an
+edit to any file rebuilds every collection that is asked for again.
+
+What is still unbounded is the size of an entry file. `--max-source-kb` is
+applied to `content.config.ts` and to the sources a module build parses, and
+`parses_source` deliberately leaves `.md` out — long articles are legitimate
+and markdown has never overflowed the stack at any size the cap allows — so a
+60 MiB `.md` under the tenant's byte quota is still read and parsed. What
+bounds it now is the deadline and the permit, not a cap.
+
 Which files those are comes from `src/content.config.ts` (or the Astro 2–4
 `src/content/config.ts`), parsed with oxc and never executed. `parse_config`
 maps `export const collections = { name: … }` to the `defineCollection({…})`
@@ -700,14 +724,24 @@ for compile latency, over the fixed bucket set 1 ms, 5 ms, 20 ms, 50 ms,
 100 ms, 500 ms, 1 s, 5 s. It lives in an `Arc` shared by `AppState` and
 `Engine`, so `check` gets its own throwaway instance.
 
+The status classes are `200`, `400`, `404`, `500` and `503`, and anything
+unmapped falls into `500`. 503 is a label of its own because it is the only
+externally visible sign that the compile gate is saturated or that the runaway
+cap has pinned it, and folded into `500` it read exactly like a tenant with a
+syntax error (issue #95). 401, 403 and 413 never reach this counter: the
+preview token and the `strip-ts` body limit are layers above the handler, and
+the counter is written inside it.
+
 Only two places write to it. `preview::module` adds one to the counter for the
 status it is about to return — a cache hit therefore costs one atomic add.
-`Engine::build` times what a cache miss costs — the `on_parser_stack` hop onto
-the big-stack thread and the `compile` it runs there, failures and a failed
-spawn included; a hit is not a compile and is not timed. A `Style`/`Script`
-compile calls `build` again for the module it needs, so on a cold cache the
-module's time is counted once on its own and once inside the style's
-observation.
+`Engine::build` times what a cache miss costs — the `deadlined` hop onto the
+big-stack thread and the `compile` it runs there, failures and a failed spawn
+included; a hit is not a compile and is not timed. A `Style`/`Script` compile
+calls `build` again for the module it needs, so on a cold cache the module's
+time is counted once on its own and once inside the style's observation. A
+collection build is not timed at all: `sandbox_lite_compile_seconds` is per
+`Kind` and a collection is not one of them, so what it costs shows up in the
+gate's gauges rather than in a histogram.
 
 `GET /metrics` (`api::metrics`) renders those counters plus the gauges
 `/api/stats` already had — tenants, overlay bytes, cache entries and bytes,

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -124,7 +124,8 @@ the exception, and stays a list of what this daemon has loaded: it answers
 (`Tenant::set_base`, a `RwLock<Arc<Base>>`). Each of those tenants is bumped and
 gets one `update` event, so open previews reload; overlays are untouched, so an
 edited file still wins over the new base copy. The transform cache needs no
-invalidation, being content-addressed: a changed file hashes to a new key.
+invalidation: a module entry is content-addressed, so a changed file hashes to a
+new key, and a collection entry carries the version the bump just changed.
 
 `POST /api/bases/{name}/reload` calls it on the blocking pool.
 `--watch-bases N` runs `Store::reload_changed_bases` every N seconds, also on

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ Tenant host (`<id>.<domain>`):
 | `/__sl/raw/<path>` | file as-is (assets, `@import`ed CSS) |
 | `/__sl/routes.json` | route table built from `src/pages`, in Astro priority order |
 | `/__sl/renderers.json` | framework renderers to register, derived from `package.json` (`@astrojs/react`, `@astrojs/preact`, `@astrojs/vue`, `@astrojs/svelte`) or `sandbox-lite.json` |
-| `/__sl/content/<collection>` | `{entries, dates}` — the collection's entries and the schema's date fields; Markdown arrives rendered, MDX entries render through their compiled module |
+| `/__sl/content/<collection>` | `{entries, dates}` — the collection's entries and the schema's date fields; Markdown arrives rendered, MDX entries render through their compiled module. Built under one compile permit and the compile deadline, and cached until the tenant's next write |
 | `/__sl/shim/astro-*.js` | browser stand-ins for `astro:content`, `astro:assets`, `astro:transitions`, …; `astro-jsx-runtime.js` is Astro's JSX runtime and `astro:jsx` renderer |
 | `/__sl/astro.js` | Astro's runtime + container API, bundled once per Astro version |
 | `/__sl/events` | same SSE stream as the API; the page swaps CSS or reloads itself on it |

--- a/README.md
+++ b/README.md
@@ -57,23 +57,25 @@ and all, `defineProps<Props>()` included);
 project, edits one file in each, loads the preview module graph of each, and
 reads the daemon's RSS from `/proc`. CI runs it on every push, so the figures
 below are a CI run's and not a laptop's — `bench/mem.sh 100 4398` on
-`ubuntu-latest`, at commit `49be004`, in
-[run 34060501537](https://github.com/productdevbook/sandbox-lite/actions/runs/34060501537).
+`ubuntu-latest`, in
+[run 34085002823](https://github.com/productdevbook/sandbox-lite/actions/runs/34085002823),
+which names the commit it ran on.
 Every tenant there has one edited page and a loaded preview, with all five
 `examples/` projects loaded as bases:
 
 | | daemon RSS |
 |---|---|
 | idle | 7.4 MB |
-| after 100 tenants (edit + preview each) | 14.6 MB — 72 kB per tenant |
+| after 100 tenants (edit + preview each) | 14.6 MB — 74 kB per tenant |
 
 Creating a tenant, writing its edit and fetching its whole module graph took
-~90 ms per tenant through the HTTP API. The transform cache then held 108
-entries in 66 kB — 100 unique edited pages plus the 8 shared modules every
-tenant reuses — at 793 hits to 108 misses. 100 is the count CI runs, so 100 is
-the count this table reports; `bench/mem.sh N` takes any other, and the
-per-tenant figure is the marginal cost at the count it was measured at rather
-than a constant to multiply.
+~80 ms per tenant through the HTTP API. The transform cache then held 208
+entries in 440 kB — 100 unique edited pages, the 8 shared modules every tenant
+reuses, and each tenant's `posts` collection, which is cached per tenant
+because its key carries the tenant's version — at 793 hits to 208 misses. 100
+is the count CI runs, so 100 is the count this table reports; `bench/mem.sh N`
+takes any other, and the per-tenant figure is the marginal cost at the count it
+was measured at rather than a constant to multiply.
 
 ### The same project, the other way
 
@@ -115,10 +117,13 @@ daemon's own host; `SECURITY.md` says what that means.)
 
 Per-tenant state is the overlay (only edited files) plus a content-addressed
 transform cache shared by every tenant: two tenants with the same `Header.astro`
-share one compiled output. The cache has a byte budget (`--cache-mb`, default
-64), so its share of the daemon's memory is bounded regardless of tenant count;
-each overlay is capped by `--tenant-quota-mb` (default 64), and a write that
-would push a tenant past it is refused with `413`.
+share one compiled output. A built content collection is the one entry in that
+cache that is not shared — it is keyed by tenant and version, because which
+files went into it is a question only the build can answer. The cache has a byte
+budget (`--cache-mb`, default 64), so its share of the daemon's memory is
+bounded regardless of tenant count; each overlay is capped by
+`--tenant-quota-mb` (default 64), and a write that would push a tenant past it
+is refused with `413`.
 
 ## Install
 

--- a/src/http/preview.rs
+++ b/src/http/preview.rs
@@ -11,7 +11,7 @@ use super::api::{check_tenant, err, no_tenant, sse};
 use super::{AppState, State, TenantId, mime};
 use crate::resolve::{Resolver, renderers};
 use crate::store::{Tenant, clean_path, is_private_path};
-use crate::transform::{BuildError, JS, Kind, content, css, js, json_str};
+use crate::transform::{BuildError, JS, Kind, css, js, json_str};
 
 const ASTRO_JS: &str = include_str!("../../assets/astro.js");
 const SHELL_HTML: &str = include_str!("../../assets/shell.html");
@@ -145,6 +145,10 @@ pub async fn check(AxState(st): AxState<State>, Extension(id): Extension<TenantI
 
 /// Issue #48: every way this can fail answers 500 with the diagnostic. An empty collection is a
 /// tenant with no entries, and a page rendered from one looks exactly like a page that is right.
+///
+/// Issue #90: the build itself goes through `Engine::collection`, so the endpoint that reads every
+/// entry file of a project is bounded the way a compile is — one permit for the whole collection,
+/// the compile deadline, and a cache entry that stands until the tenant's next write.
 pub async fn content(AxState(st): AxState<State>, Extension(id): Extension<TenantId>, Path(name): Path<String>) -> Response {
     let t = match tenant(&st, &id) {
         Ok(t) => t,
@@ -155,18 +159,11 @@ pub async fn content(AxState(st): AxState<State>, Extension(id): Extension<Tenan
     }
     let st2 = st.clone();
     let collection = name.clone();
-    let joined = tokio::task::spawn_blocking(move || {
-        let max = st2.engine.cfg.max_source_bytes;
-        st2.engine.on_parser_stack(move || content::collection_json(&t, &collection, max))
-    })
-    .await;
-    let out = match joined {
-        Ok(Ok(Ok(out))) => out,
-        Ok(Ok(Err(e))) => return build_error(e),
-        Ok(Err(e)) => return err(StatusCode::INTERNAL_SERVER_ERROR, format!("{name}: cannot start a compiler thread: {e}")),
-        Err(e) => return err(StatusCode::INTERNAL_SERVER_ERROR, format!("{name}: {e}")),
-    };
-    ([(header::CACHE_CONTROL, "no-cache")], Json(out)).into_response()
+    match tokio::task::spawn_blocking(move || st2.engine.collection(&t, &collection)).await {
+        Ok(Ok(built)) => text(built.body.clone(), built.content_type, "no-cache"),
+        Ok(Err(e)) => build_error(e),
+        Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, format!("{name}: {e}")),
+    }
 }
 
 /// Issue #52: `@vue/compiler-sfc` builds a component's runtime props out of the types in
@@ -381,6 +378,7 @@ pub async fn page(AxState(st): AxState<State>, Extension(id): Extension<TenantId
 mod tests {
     use std::path::Path;
     use std::sync::Arc;
+    use std::time::Duration;
 
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
@@ -388,8 +386,10 @@ mod tests {
     use tower::ServiceExt;
 
     use super::percent_decode;
-    use crate::http::{AppState, app};
+    use crate::http::{AppState, State, app};
+    use crate::metrics::STATUSES;
     use crate::store::{Base, Store, UpdateKind};
+    use crate::transform::{Config, Engine};
 
     #[test]
     fn percent_decode_takes_any_string() {
@@ -409,6 +409,18 @@ mod tests {
             t.write(path, body.as_bytes().to_vec(), UpdateKind::from_path(path)).unwrap();
         }
         app(Arc::new(AppState { store, ..AppState::for_tests() }))
+    }
+
+    /// A daemon with no compile permit to give anyone: a gate whose limit is zero refuses every
+    /// compile without a test having to hold one.
+    fn saturated_app() -> (axum::Router, State) {
+        let store = Store::new(None, u64::MAX);
+        let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("examples/starter");
+        store.add_base(Base::load("starter", &root).unwrap());
+        store.create_tenant("acme", "starter").unwrap();
+        let engine = Engine::for_tests_gated(Config::default(), 0, Duration::from_millis(20), 1);
+        let st = Arc::new(AppState { store, metrics: engine.metrics(), engine, ..AppState::for_tests() });
+        (app(st.clone()), st)
     }
 
     async fn collection(app: &axum::Router, name: &str) -> (StatusCode, Value) {
@@ -442,6 +454,29 @@ mod tests {
         for name in super::SHELL_HTML.split('%').skip(1).step_by(2) {
             assert!(!body.contains(&format!("%{name}%")), "%{name}% was not substituted");
         }
+    }
+
+    /// Issue #90: the endpoint that reads every entry file of a project takes a compile permit like
+    /// everything else, so a daemon that has none left says so instead of reading them anyway.
+    #[tokio::test]
+    async fn a_collection_request_with_no_permit_left_is_refused() {
+        let (app, _st) = saturated_app();
+        let (status, body) = collection(&app, "posts").await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+        assert!(body["error"].as_str().unwrap().contains("content/posts"), "{body}");
+    }
+
+    /// Issue #95: what a saturated gate answers has a metrics row of its own. Counted as `"500"` it
+    /// was indistinguishable from a tenant whose module does not compile.
+    #[tokio::test]
+    async fn a_module_request_the_gate_refuses_is_counted_as_503() {
+        let (app, st) = saturated_app();
+        let req = Request::builder().uri("/__sl/m/src/pages/index.astro").header("host", "acme.localhost").body(Body::empty()).unwrap();
+        let res = app.oneshot(req).await.unwrap();
+        assert_eq!(res.status(), StatusCode::SERVICE_UNAVAILABLE);
+        let at = |status: &str| STATUSES.iter().position(|s| *s == status).expect("status label");
+        let row = st.metrics.requests()[0];
+        assert_eq!((row[at("503")], row[at("500")]), (1, 0));
     }
 
     async fn strip_ts(app: &axum::Router, query: &str, script: &str) -> (StatusCode, String) {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -6,7 +6,14 @@ use std::time::Duration;
 use crate::transform::Kind;
 
 pub const KINDS: [&str; 5] = ["module", "style", "script", "raw", "url"];
-pub const STATUSES: [&str; 4] = ["200", "400", "404", "500"];
+/// Every status `preview::module` returns, each with a label of its own. Issue #95: 503 folded into
+/// `"500"`, so a daemon out of compile permits — the one thing an operator would page on, and the
+/// only externally visible sign that `--max-compiles` is saturated or the runaway cap has pinned
+/// the gate — read exactly like a tenant with a syntax error.
+///
+/// 401, 403 and 413 are not here because this counter never sees them: the preview token and the
+/// `strip-ts` body limit are layers above the handler, and the counter is written inside it.
+pub const STATUSES: [&str; 5] = ["200", "400", "404", "500", "503"];
 pub const BUCKETS: [f64; 8] = [0.001, 0.005, 0.02, 0.05, 0.1, 0.5, 1.0, 5.0];
 const SLOTS: usize = BUCKETS.len() + 1;
 
@@ -20,11 +27,14 @@ fn kind_index(kind: Kind) -> usize {
     }
 }
 
+/// Anything unmapped still lands in `"500"`: a status nobody has thought of is a failure, and a
+/// row nobody watches is better than a label that appears the day the daemon starts returning it.
 fn status_index(status: u16) -> usize {
     match status {
         200 => 0,
         400 => 1,
         404 => 2,
+        503 => 4,
         _ => 3,
     }
 }
@@ -315,6 +325,20 @@ mod tests {
         assert_eq!(m.compiles()[0].count(), 0);
     }
 
+    /// Issue #95: a saturated compile gate and a project that does not compile are different
+    /// facts, and the second was the only one the counter could tell you about.
+    #[test]
+    fn a_503_is_not_counted_as_a_500() {
+        let at = |status: &str| STATUSES.iter().position(|s| *s == status).expect("status label");
+        let m = Metrics::default();
+        m.module_request(Kind::Module, 503);
+        m.module_request(Kind::Module, 500);
+        m.module_request(Kind::Module, 418);
+        let row = m.requests()[0];
+        assert_eq!(row[at("503")], 1, "the refusal has a row of its own");
+        assert_eq!(row[at("500")], 2, "a broken project, and a status nobody has mapped");
+    }
+
     #[test]
     fn renders_the_prometheus_text_format() {
         let m = Metrics::default();
@@ -456,22 +480,27 @@ sandbox_lite_module_requests_total{kind="module",status="200"} 3
 sandbox_lite_module_requests_total{kind="module",status="400"} 0
 sandbox_lite_module_requests_total{kind="module",status="404"} 1
 sandbox_lite_module_requests_total{kind="module",status="500"} 0
+sandbox_lite_module_requests_total{kind="module",status="503"} 0
 sandbox_lite_module_requests_total{kind="style",status="200"} 0
 sandbox_lite_module_requests_total{kind="style",status="400"} 0
 sandbox_lite_module_requests_total{kind="style",status="404"} 0
 sandbox_lite_module_requests_total{kind="style",status="500"} 0
+sandbox_lite_module_requests_total{kind="style",status="503"} 0
 sandbox_lite_module_requests_total{kind="script",status="200"} 0
 sandbox_lite_module_requests_total{kind="script",status="400"} 0
 sandbox_lite_module_requests_total{kind="script",status="404"} 0
 sandbox_lite_module_requests_total{kind="script",status="500"} 0
+sandbox_lite_module_requests_total{kind="script",status="503"} 0
 sandbox_lite_module_requests_total{kind="raw",status="200"} 0
 sandbox_lite_module_requests_total{kind="raw",status="400"} 0
 sandbox_lite_module_requests_total{kind="raw",status="404"} 0
 sandbox_lite_module_requests_total{kind="raw",status="500"} 0
+sandbox_lite_module_requests_total{kind="raw",status="503"} 0
 sandbox_lite_module_requests_total{kind="url",status="200"} 0
 sandbox_lite_module_requests_total{kind="url",status="400"} 0
 sandbox_lite_module_requests_total{kind="url",status="404"} 0
-sandbox_lite_module_requests_total{kind="url",status="500"} 2
+sandbox_lite_module_requests_total{kind="url",status="500"} 0
+sandbox_lite_module_requests_total{kind="url",status="503"} 2
 # HELP sandbox_lite_compile_seconds Seconds spent compiling one file after a transform-cache miss; a style or script compile includes any module compile it triggers.
 # TYPE sandbox_lite_compile_seconds histogram
 sandbox_lite_compile_seconds_bucket{kind="module",le="0.001"} 1

--- a/src/proptests.rs
+++ b/src/proptests.rs
@@ -96,8 +96,11 @@ fn css() -> impl Strategy<Value = String> {
 /// The stack `Engine::build` gives every parser; running one here on the 2 MiB test-thread stack
 /// aborts the whole test binary instead of failing a case.
 fn parser_stack<T: Send>(f: impl FnOnce() -> T + Send) -> T {
-    let engine = Engine::for_tests_with(Config::default());
-    engine.on_parser_stack(f).expect("compiler thread")
+    let bytes = Engine::for_tests_with(Config::default()).parser_stack_bytes();
+    std::thread::scope(|scope| {
+        let handle = std::thread::Builder::new().stack_size(bytes).spawn_scoped(scope, f).expect("compiler thread");
+        handle.join().unwrap_or_else(|payload| std::panic::resume_unwind(payload))
+    })
 }
 
 fn assert_inside_tenant(path: &str) -> Result<(), TestCaseError> {

--- a/src/transform/mod.rs
+++ b/src/transform/mod.rs
@@ -100,9 +100,15 @@ impl Built {
         let globs = glob::find(&body);
         Built { specs, globs, env_banner: true, ..Built::js(body) }
     }
+
+    /// A collection's JSON, cached in the same map a module build's is.
+    fn json(body: String) -> Built {
+        Built { content_type: JSON, ..Built::js(body) }
+    }
 }
 
 pub const JS: &str = "text/javascript; charset=utf-8";
+pub const JSON: &str = "application/json; charset=utf-8";
 
 /// oxc, astro_codegen, satteri-mdxjs and grass are recursive-descent, so a source byte can cost a
 /// stack frame and a stack overflow aborts the process (`panic = "abort"`). The two shapes measured
@@ -154,26 +160,6 @@ thread_local! {
     /// Counted per calling thread so parallel tests cannot see each other's spawns.
     #[cfg(test)]
     static SPAWNED: Cell<usize> = const { Cell::new(0) };
-}
-
-/// Runs `f` on a thread with a stack the parsers cannot walk off. The reservation is virtual
-/// address space; only the pages a compile actually touches become resident. A `?type=style` or
-/// `?type=script` build asks for the module first, so the flag keeps that inner build on the stack
-/// this one already reserved instead of reserving a second one.
-fn with_big_stack<T: Send>(stack_bytes: usize, f: impl FnOnce() -> T + Send) -> std::io::Result<T> {
-    if ON_PARSER_STACK.get() {
-        return Ok(f());
-    }
-    std::thread::scope(|scope| {
-        let body = || {
-            ON_PARSER_STACK.set(true);
-            f()
-        };
-        let handle = std::thread::Builder::new().stack_size(stack_bytes).spawn_scoped(scope, body)?;
-        #[cfg(test)]
-        SPAWNED.set(SPAWNED.get() + 1);
-        Ok(handle.join().unwrap_or_else(|payload| std::panic::resume_unwind(payload)))
-    })
 }
 
 fn refused(path: &str, text: String, hint: &str) -> BuildError {
@@ -550,11 +536,6 @@ impl Engine {
         self.cfg.max_source_bytes.saturating_mul(STACK_PER_SOURCE_BYTE).max(MIN_PARSER_STACK)
     }
 
-    /// For the parsers reached outside `build` — the content config, which oxc walks.
-    pub fn on_parser_stack<T: Send>(&self, f: impl FnOnce() -> T + Send) -> std::io::Result<T> {
-        with_big_stack(self.parser_stack_bytes(), f)
-    }
-
     pub fn stats(&self) -> CacheStats {
         let c = self.cache.lock().unwrap();
         CacheStats { entries: c.map.len(), bytes: c.bytes, hits: c.hits, misses: c.misses, coalesced: c.coalesced }
@@ -638,6 +619,51 @@ impl Engine {
         let _permit = self.gate.enter().map_err(BuildError::busy)?;
         let _compiling = Compiling::enter();
         Ok(f())
+    }
+
+    /// A collection's `{entries, dates}` JSON, built the way a module is. Issue #90: this reads and
+    /// parses every entry file of a collection — the one thing the daemon does that touches every
+    /// file of a project — and it went through none of what bounds a compile, so a 200-entry blog
+    /// cost 1.3 s of CPU per page view with nothing limiting how many ran at once.
+    ///
+    /// The key is the tenant's version rather than the bytes that went into the build: what the
+    /// entries are is itself a question only the build can answer, and every write and every base
+    /// reload bumps the version, so an edit anywhere invalidates the collection.
+    pub fn collection(&self, tenant: &Arc<Tenant>, name: &str) -> Result<Arc<Built>, BuildError> {
+        let mut h = Vec::with_capacity(tenant.id.len() + name.len() + 32);
+        h.extend_from_slice(b"c\0");
+        h.extend_from_slice(tenant.id.as_bytes());
+        h.push(0);
+        h.extend_from_slice(&tenant.version().to_le_bytes());
+        h.extend_from_slice(name.as_bytes());
+        let key = xxh3_128(&h);
+        if let Some(b) = self.cached(key) {
+            return Ok(b);
+        }
+        let lead = match self.join(key) {
+            Join::Lead(lead) => Some(lead),
+            Join::Solo => None,
+            Join::Waited(outcome) => return outcome,
+        };
+        let outcome = self.collection_once(tenant, name, key);
+        if let Some(lead) = lead {
+            lead.settle(&outcome);
+        }
+        outcome
+    }
+
+    /// One permit for the whole collection, as `sweep` takes one for a whole project (#54): a page
+    /// asking for two hundred entries should cost one place in the queue, not two hundred. Inside
+    /// it is one `deadlined` thread, so an entry file nobody can parse in time is given up on
+    /// rather than held open.
+    fn collection_once(&self, tenant: &Arc<Tenant>, name: &str, key: u128) -> Result<Arc<Built>, BuildError> {
+        let path = format!("content/{name}");
+        let _permit = self.gate.enter().map_err(|e| BuildError::busy(format!("{path}: {e}")))?;
+        let (t, collection, max) = (tenant.clone(), name.to_string(), self.cfg.max_source_bytes);
+        let json = self.deadlined(&path, move || content::collection_json(&t, &collection, max).map(|v| v.to_string()))?;
+        let built = Arc::new(Built::json(json));
+        self.insert(key, built.clone());
+        Ok(built)
     }
 
     pub fn build(&self, tenant: &Arc<Tenant>, path: &str, kind: Kind) -> Result<Arc<Built>, BuildError> {
@@ -1493,6 +1519,66 @@ mod tests {
         assert!(e.message.contains("waited 100 ms"), "{}", e.message);
         assert!(started.elapsed() < Duration::from_secs(1), "the sweep waited {:?}", started.elapsed());
         assert_eq!(engine.compile_stats().refused, 1);
+    }
+
+    const POST: &str = "---\ntitle: a post\n---\n# heading\n\nbody\n";
+
+    /// Issue #90: the collection endpoint read and parsed every entry of a collection on every
+    /// request, so a page calling `getCollection` paid for the whole collection on every load. The
+    /// second request for an unchanged collection must cost nothing — no build, and no permit.
+    #[test]
+    fn a_second_collection_build_is_a_cache_hit_and_takes_no_permit() {
+        let t = tenant(&[("src/content/posts/a.md", POST), ("src/content/posts/b.md", POST)]);
+        let engine = engine_gated(capped(CAP), 1, Duration::from_millis(50));
+        let first = engine.collection(&t, "posts").unwrap();
+        assert!(first.body.contains("heading"), "{}", first.body);
+        engine.gate.limit.store(0, Ordering::Relaxed);
+        let second = engine.collection(&t, "posts").unwrap();
+        assert_eq!(first.body, second.body);
+        let cache = engine.stats();
+        assert_eq!((cache.misses, cache.hits), (1, 1), "one build, then a hit");
+        assert_eq!(engine.compile_stats().refused, 0, "the hit never asked the gate for anything");
+    }
+
+    /// And an edit invalidates it: the key carries the tenant's version, which every write bumps.
+    #[test]
+    fn an_edit_rebuilds_the_collection() {
+        let t = tenant(&[("src/content/posts/a.md", POST)]);
+        let engine = engine_gated(capped(CAP), 1, Duration::from_millis(50));
+        assert!(!engine.collection(&t, "posts").unwrap().body.contains("written later"));
+        let later = "---\ntitle: written later\n---\n";
+        t.write("src/content/posts/b.md", later.as_bytes().to_vec(), UpdateKind::Module).unwrap();
+        assert!(engine.collection(&t, "posts").unwrap().body.contains("written later"));
+        assert_eq!(engine.stats().misses, 2, "the write invalidated what the first build cached");
+    }
+
+    /// One permit for the whole collection, taken before a single entry is read: a build that
+    /// cannot have one waits for it and is refused with the 503 a module build gives.
+    #[test]
+    fn a_collection_build_that_cannot_have_a_permit_is_refused() {
+        let t = tenant(&[("src/content/posts/a.md", POST)]);
+        let engine = engine_gated(capped(CAP), 0, Duration::from_millis(100));
+        let started = Instant::now();
+        let e = build_err(engine.collection(&t, "posts"));
+        assert_eq!(e.status, 503);
+        assert!(e.message.contains("content/posts"), "{}", e.message);
+        assert!(e.message.contains("waited 100 ms"), "{}", e.message);
+        assert!(started.elapsed() >= Duration::from_millis(100), "it waited {:?}", started.elapsed());
+        assert_eq!((engine.compile_stats().refused, engine.stats().entries), (1, 0));
+    }
+
+    /// A collection the deadline runs out on is answered with a diagnostic rather than held open:
+    /// nothing caps the size of an entry file, so a 60 MiB `.md` under the tenant's quota is parsed
+    /// on a thread the request must be able to give up on.
+    #[test]
+    fn a_collection_past_the_deadline_answers_with_a_diagnostic() {
+        let long = format!("---\ntitle: long\n---\n{}", "# heading\n\n".repeat(20_000));
+        let t = tenant(&[("src/content/posts/long.md", long.as_str())]);
+        let engine = engine_gated(Config { compile_timeout: Duration::from_millis(1), ..capped(CAP) }, 1, Duration::from_millis(50));
+        let e = build_err(engine.collection(&t, "posts"));
+        assert!(e.message.contains("content/posts: compile did not finish within 1 ms"), "{}", e.message);
+        assert_eq!(e.diagnostics.len(), 1);
+        assert_eq!(engine.compile_stats().timeouts, 1);
     }
 
     const CARD: &str = "---\nconst n = 1;\n---\n<p>{n}</p>\n<style>p{color:red}</style>\n<script>console.log(1)</script>\n";


### PR DESCRIPTION
Closes #90
Closes #95

## #90 — the collection endpoint went through none of what bounds a compile

`GET /__sl/content/{name}` reads and parses every entry file of a collection.
It is the one endpoint that touches every file of a project, and it took no
gate permit, ran under no deadline and cached nothing: 1.27 s for 200 entries,
the same 1.21 s on the second identical request, and sixteen running together
under `--max-compiles 1`.

`Engine::collection` now builds it the way a module is built:

- **one permit for the whole collection**, taken before a single entry file is
  read — as `Engine::sweep` takes one for a whole project rather than one per
  file (#54). A build that cannot have it waits the queue deadline once and is
  refused with the same 503 a module build gives.
- **the compile deadline**, through the same `Engine::deadlined` thread every
  compile runs on. `with_big_stack` joined its thread unconditionally; nothing
  caps the size of an entry file, so the request had no way to give up.
- **a cache entry** in the same `HashMap<u128, Arc<Built>>` `Engine::build`
  uses, so a second identical request is a hit that asks the gate for nothing.

**Cache key**: `xxh3_128("c\0" + tenant id + "\0" + tenant version + name)`.
Content-addressing the way `build` does would mean hashing the bytes of the
files that went in — but *which* files those are is itself a question only the
build can answer (the config, the globs, the directory listing). Every write,
delete and base reload bumps the tenant's version, so an edit anywhere
invalidates every collection, and stale entries age out of the FIFO budget.
The `astro:content` shim already appends `?v=<version>` for the browser's own
cache, so the two agree. The cost is that an edit to any file rebuilds a
collection the next time it is asked for; the benefit is that the common case —
a page load on an unchanged tenant — costs one atomic add.

**What this does not fix**: the size of an entry file is still uncapped.
`--max-source-kb` is applied to `content.config.ts` and to the sources a module
build parses, and `parses_source` leaves `.md` out on purpose — long articles
are legitimate and markdown has never overflowed the stack at any size the cap
allows. Capping it here would refuse a post that `/__sl/m/` compiles happily,
which is a decision to argue for on its own rather than a side effect of this
one. The deadline and the permit are what bound a 60 MiB `.md` now.

`with_big_stack` and `Engine::on_parser_stack` had no caller left and are gone;
the proptest that wanted a parser stack spawns one itself.

## #95 — a saturated gate looked exactly like a broken project

`status_index` folded everything but 200/400/404 into `"500"`, so the 503 from
`BuildError::busy` — the only externally visible sign that `--max-compiles` is
saturated or that the runaway cap has pinned the gate — was counted in the same
row as a syntax error. `STATUSES` gains `"503"`; anything unmapped still falls
into 500. 401, 403 and 413 stay out on purpose: the preview token and the
`strip-ts` body limit are layers above the handler, and the counter is written
inside it, so it never sees them. `/api/stats` and `render` follow from the
constant — twenty cells instead of sixteen. The render test asserted the
aliasing (`module_request(Kind::Url, 503)` landing in `"500"`); it now asserts
the two rows.

## Proof

- `a_second_collection_build_is_a_cache_hit_and_takes_no_permit` — build once,
  then set the gate's limit to zero: the second call still answers, and
  `CacheStats` reads one miss and one hit with no refusal.
- `an_edit_rebuilds_the_collection` — a write bumps the version, the next call
  misses and the new entry is in the JSON.
- `a_collection_build_that_cannot_have_a_permit_is_refused` — a gate no compile
  can pass: 503, after waiting the full 100 ms, with `compiles.refused` at 1 and
  nothing in the cache.
- `a_collection_past_the_deadline_answers_with_a_diagnostic` — a 1 ms deadline
  over 20 000 headings answers with the diagnostic and counts one timeout.
- `a_collection_request_with_no_permit_left_is_refused` — the same through the
  HTTP handler.
- `a_module_request_the_gate_refuses_is_counted_as_503` — a gate-refused module
  request over the router leaves `{status="503"}` at 1 and `{status="500"}` at 0.
- `a_503_is_not_counted_as_a_500` — and an unmapped status still lands in 500.

CI green on both pushes: fmt, clippy `-D warnings`, tests, release build,
`sandbox-lite check`, smoke, `bench/mem.sh`, the dev-server comparison and
Playwright —
[run 34085002823](https://github.com/productdevbook/sandbox-lite/actions/runs/34085002823)
(the code) and
[run 34085481946](https://github.com/productdevbook/sandbox-lite/actions/runs/34085481946)
(the docs commit).

`bench/mem.sh 100` in the first run moved from 108 cache entries in 66 kB to 208
in 440 kB, and from 72 to 74 kB of RSS per tenant: each tenant now keeps its
built `posts` collection, which is exactly the trade — 1.3 s of CPU per page
view for 3.7 kB per tenant, inside the `--cache-mb` budget. README's figures
and the two places that called the cache content-addressed are updated to say
which half they mean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
