### PR TITLE
limits: bound the file count and the chat, and stop re-summing the overlay

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -796,13 +796,20 @@ response.
 The request body is `{messages, chat?}`. `chat` names a stored conversation
 (`src/http/chats.rs`, one JSON file per chat under `<data-dir>/<id>/chats/`, or
 in memory with `--no-persist`), whose turns come before `messages`.
-`Conversation::for_model` replays the last `--chat-window` turns in full; when a
-conversation crosses that, `compact` folds everything older into one summary
-written by a second call to the same API and stored with the conversation, and
-sent as its opening turn from then on. A summary the API will not write is not
-fatal: the turns stay stored and are cut from the request anyway. A save past
-`--chats-per-tenant` drops the tenant's least recently updated conversation
-(`evictable`).
+`Conversation::for_model` replays the last `--chat-window` stored turns in
+full and puts the request's own `messages` through the same normalisation after
+them — empty turns dropped, same-role neighbours joined, a leading assistant
+turn refused, all three of which the Messages API requires; when a conversation
+crosses the window, `compact` folds everything older into one summary written by
+a second call to the same API and stored with the conversation, and sent as its
+opening turn from then on. A summary the API will not write is not fatal: the
+turns stay stored and are cut from the request anyway. What bounds the request's
+own messages instead of the window is `Chats::admits`, asked in `chat` before
+the model is called: `--chat-message-kb` for what one request may add and
+`--chat-quota-kb` for what the conversation may then hold, each refused with
+`413` naming the flag. A save past `--chats-per-tenant`, or past that many times
+`--chat-quota-kb` of bytes, drops the tenant's least recently updated
+conversation (`evictable`).
 
 `Chats::sizes` holds what each tenant's conversations weigh, `<tenant> → <chat
 id> → bytes`, seeded from the store the first time a tenant is touched and

--- a/README.md
+++ b/README.md
@@ -122,8 +122,10 @@ cache that is not shared — it is keyed by tenant and version, because which
 files went into it is a question only the build can answer. The cache has a byte
 budget (`--cache-mb`, default 64), so its share of the daemon's memory is
 bounded regardless of tenant count; each overlay is capped by
-`--tenant-quota-mb` (default 64), and a write that would push a tenant past it
-is refused with `413`.
+`--tenant-quota-mb` (default 64) and by `--tenant-max-files` (default 10000),
+and a write past either is refused with `413`. The count is not the bytes: an
+empty file weighs nothing and still costs an inode, a directory entry and a line
+of tombstone bookkeeping.
 
 ## Install
 
@@ -188,9 +190,14 @@ A conversation does not grow without end. The last `--chat-window` turns
 everything older is folded into one summary — written once by the same API,
 stored with the conversation and sent as its opening turn from then on. Should
 that call fail, the turns stay stored and the window is applied to the request
-anyway. Conversations are outside the tenant quota, so `--chats-per-tenant`
-(default 50) is what bounds them: saving past it drops the tenant's least
-recently updated conversation.
+anyway. Conversations are outside the tenant quota, so their own limits are
+what bound them: `--chat-message-kb` (default 64) is the most one request's
+`messages` may weigh, `--chat-quota-kb` (default 2048) the most one conversation
+may hold — a request past either is refused with `413` naming the one it hit —
+and `--chats-per-tenant` (default 50) is how many a tenant keeps, saving past it
+dropping the least recently updated. The last two multiply out to the ceiling on
+`<data-dir>/<id>/chats/`, which is what `/api/stats` reports as
+`chats.max_bytes_per_tenant`.
 
 `--chrome PATH` adds a sixth tool, `screenshot`, which renders one page of the
 tenant's live preview in headless Chrome and hands the PNG back to the model,
@@ -225,7 +232,10 @@ its 20 s deadline is killed and reaped before its profile directory goes.
 --chrome-jobs N      screenshots that may run at once (default 1)
 --chat-window N      turns of a conversation replayed to the model in full (default 24)
 --chats-per-tenant N conversations a tenant may keep (default 50)
+--chat-message-kb N  largest one chat request's messages may be, in KiB (default 64)
+--chat-quota-kb N    largest one conversation may hold, in KiB (default 2048)
 --tenant-quota-mb N  edited files a tenant may hold, in MiB (default 64)
+--tenant-max-files N edited files a tenant may hold, whatever they weigh (default 10000)
 --cookie-samesite lax|none
                      SameSite of the preview cookie; none also sets Secure
                      (default: none with --preview-secret, lax without)
@@ -234,8 +244,10 @@ its 20 s deadline is killed and reaped before its profile directory goes.
 `SANDBOX_LITE_API_TOKEN`, `SANDBOX_LITE_PREVIEW_SECRET`,
 `SANDBOX_LITE_TENANT_QUOTA_MB`, `SANDBOX_LITE_MAX_COMPILES`,
 `SANDBOX_LITE_COMPILE_TIMEOUT_MS`,
-`SANDBOX_LITE_CHROME`, `SANDBOX_LITE_CHROME_JOBS`, `SANDBOX_LITE_CHAT_WINDOW`
-and `SANDBOX_LITE_CHATS_PER_TENANT` are read as defaults for those flags, and
+`SANDBOX_LITE_CHROME`, `SANDBOX_LITE_CHROME_JOBS`, `SANDBOX_LITE_CHAT_WINDOW`,
+`SANDBOX_LITE_CHATS_PER_TENANT`, `SANDBOX_LITE_CHAT_MESSAGE_KB`,
+`SANDBOX_LITE_CHAT_QUOTA_KB` and `SANDBOX_LITE_TENANT_MAX_FILES` are read as
+defaults for those flags, and
 `SANDBOX_LITE_ANTHROPIC_BASE` points the chat at another Messages API
 endpoint (default `https://api.anthropic.com`). With a
 preview secret set, `/api/tenants` returns each tenant's `preview_token`;

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -230,18 +230,25 @@ container, or a network namespace of its own.
   import may write them. What the preview refuses to serve is unchanged
   (`is_private_path`), and both routes are on the editor/API router, whose
   audience is already every file of every tenant.
-- **Per-tenant write volume** is capped by `--tenant-quota-mb` (default 64):
-  a write that would take the tenant's edited files past it is refused with
-  `413` before anything reaches disk or memory, and the chat `write_file` tool
-  gets the same error. Rewriting a file is charged only for the difference.
-- **Conversations** are outside that quota, so they have their own two limits:
-  `--chats-per-tenant` (default 50) drops a tenant's least recently updated
-  conversation when a save would take it past the cap, and `--chat-window`
-  (default 24) is how many turns of one conversation reach the model — older
+- **Per-tenant write volume** is capped by `--tenant-quota-mb` (default 64)
+  and by `--tenant-max-files` (default 10000): a write that would take the
+  tenant's edited files past either is refused with `413` before anything
+  reaches disk or memory, and the chat `write_file` tool and the import get the
+  same error. Rewriting a file is charged only for the difference. The count is
+  a separate limit because bytes do not bound it — an empty file weighs nothing
+  and still costs an inode and a directory entry.
+- **Conversations** are outside that quota, so they have their own limits:
+  `--chat-message-kb` (default 64) is the most one request's `messages` may
+  weigh and `--chat-quota-kb` (default 2048) the most one conversation may
+  hold, both refused with `413` before the model is called and before anything
+  is stored; `--chats-per-tenant` (default 50) drops a tenant's least recently
+  updated conversation when a save would take it past the cap or past
+  `--chats-per-tenant` × `--chat-quota-kb` of chats directory; and
+  `--chat-window` (default 24) is how many stored turns reach the model — older
   turns are folded into a stored summary, and are cut from the request even
   when that summary could not be written. `/api/stats` reports what the chats
-  directory holds across every tenant it has loaded (`Store::tenants` is this
-  daemon's memory, not a census of `--data-dir`).
+  directory holds across every tenant it has loaded, and the ceiling it is held
+  to (`Store::tenants` is this daemon's memory, not a census of `--data-dir`).
 - **The screenshot tool** runs `--chrome-jobs` browsers at once (default 1).
   A call that waits 10 s without a slot is answered "busy" rather than queued,
   and one whose browser overruns its 20 s deadline is killed and reaped before

--- a/src/http/ai.rs
+++ b/src/http/ai.rs
@@ -529,12 +529,13 @@ async fn summarize_conversation(st: &State, key: &str, prompt: String) -> Option
 /// Runs one request end to end and records it. The value is the `done` payload, which is also the
 /// JSON body of the non-streaming reply.
 async fn run(st: State, t: Arc<Tenant>, key: String, req: ChatReq, mut conv: Conversation, out: Emitter) -> Result<Value, Fail> {
+    let adding = turns_of(&req);
     compact(&st, &key, &mut conv).await;
-    let mut messages = conv.for_model(st.chats.window());
-    messages.extend(req.messages.iter().map(|m| json!({ "role": m.role, "content": m.content })));
+    // through the same normalisation as the stored turns, not appended to the windowed list raw
+    let messages = conv.for_model(st.chats.window(), &adding);
     let answer = converse(&st, &t, &key, messages, &out).await?;
-    for m in &req.messages {
-        conv.push(Turn { role: m.role.clone(), text: m.content.clone(), tools: Vec::new() });
+    for turn in adding {
+        conv.push(turn);
     }
     conv.push(Turn { role: "assistant".into(), text: answer.text.clone(), tools: answer.tools });
     if let Err(e) = st.chats.save(&t, &conv) {
@@ -547,6 +548,16 @@ async fn run(st: State, t: Arc<Tenant>, key: String, req: ChatReq, mut conv: Con
         "version": t.version(),
         "chat": conv.id,
     }))
+}
+
+/// The request's messages as turns, the shape both the model input and the store hold them in.
+fn turns_of(req: &ChatReq) -> Vec<Turn> {
+    req.messages.iter().map(|m| Turn { role: m.role.clone(), text: m.content.clone(), tools: Vec::new() }).collect()
+}
+
+/// What the request would add to the conversation, counted the way it is stored.
+fn adding_bytes(req: &ChatReq) -> u64 {
+    req.messages.iter().map(|m| (m.role.len() + m.content.len()) as u64).sum()
 }
 
 pub async fn chat(AxState(st): AxState<State>, Path(id): Path<String>, headers: HeaderMap, Json(req): Json<ChatReq>) -> Response {
@@ -565,8 +576,14 @@ pub async fn chat(AxState(st): AxState<State>, Path(id): Path<String>, headers: 
         },
         None => Conversation::new(super::chats::new_id()),
     };
-    if conv.messages.is_empty() && req.messages.is_empty() {
+    // a message of no content is nothing to answer: the API refuses it, which reached the caller
+    // as a 502 from a request that was never worth making (issue #89)
+    if conv.messages.is_empty() && req.messages.iter().all(|m| m.content.trim().is_empty()) {
         return err(StatusCode::BAD_REQUEST, "no messages");
+    }
+    // before the model is called and before anything is stored, so a refusal writes nothing
+    if let Err(over) = st.chats.admits(&conv, adding_bytes(&req)) {
+        return err(StatusCode::PAYLOAD_TOO_LARGE, over.to_string());
     }
     let accept = headers.get(header::ACCEPT).and_then(|a| a.to_str().ok()).unwrap_or("");
     if !accept.contains("text/event-stream") {
@@ -837,6 +854,71 @@ mod tests {
         let t = f.st.store.tenant("acme").unwrap();
         assert_eq!(f.st.chats.load(&t, &chat_id).unwrap().unwrap().messages.len(), 4, "in memory, without a data dir");
         assert_eq!(f.st.chats.list(&t).unwrap().len(), 1);
+    }
+
+    /// Issue #89: the window was applied to the stored turns and the request's own appended after
+    /// it, so one POST could store 64 MB in `chats/` — outside the tenant quota, and reported as
+    /// zero by everything that reports a tenant's size.
+    #[tokio::test]
+    async fn a_chat_request_past_the_message_budget_is_refused_and_stores_nothing() {
+        let f = fixture(vec![turn_with_text("Never asked.")], false).await;
+        let st: State = Arc::new(AppState {
+            store: Store::new(Some(f.root.join("budgets")), TEST_QUOTA),
+            api_key: Some("test-key".into()),
+            api_base: f.st.api_base.clone(),
+            chats: crate::http::chats::Chats::new(50, 24).with_budgets(1, 8),
+            ..AppState::for_tests()
+        });
+        st.store.add_base(Base::load("test", &f.root.join("base")).unwrap());
+        let t = st.store.create_tenant("acme", "test").unwrap();
+
+        let (status, body) = post_chat(&st, None, ask(&"x".repeat(2000), None)).await;
+        assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE, "{body}");
+        let error = serde_json::from_str::<Value>(&body).unwrap()["error"].as_str().unwrap().to_string();
+        assert!(error.contains("--chat-message-kb"), "{error}");
+        assert!(st.chats.list(&t).unwrap().is_empty(), "a refused request writes nothing");
+        assert_eq!(st.chats.usage(&t).unwrap(), (0, 0));
+        assert!(f.seen.lock().unwrap().is_empty(), "and never calls the model");
+
+        // and a conversation already at the budget is refused by the other limit, by name
+        let mut full = Conversation::new("full".into());
+        while full.bytes() + 900 <= 8 << 10 {
+            full.push(Turn { role: "user".into(), text: "y".repeat(500), tools: Vec::new() });
+        }
+        st.chats.save(&t, &full).unwrap();
+        let (status, body) = post_chat(&st, None, ask(&"z".repeat(900), Some("full"))).await;
+        assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE, "{body}");
+        let error = serde_json::from_str::<Value>(&body).unwrap()["error"].as_str().unwrap().to_string();
+        assert!(error.contains("--chat-quota-kb"), "{error}");
+        assert_eq!(st.chats.load(&t, "full").unwrap().unwrap().messages.len(), full.messages.len(), "unchanged");
+    }
+
+    /// The same normalisation as the stored turns, asserted on what went upstream rather than on
+    /// the reply: an empty `content` used to be forwarded verbatim and come back as a 502.
+    #[tokio::test]
+    async fn the_requests_own_messages_reach_the_api_normalised() {
+        let f = fixture(vec![turn_with_text("Fine.")], false).await;
+        let req = ChatReq {
+            messages: vec![
+                ChatMsg { role: "user".into(), content: "one".into() },
+                ChatMsg { role: "user".into(), content: "   ".into() },
+                ChatMsg { role: "user".into(), content: "two".into() },
+            ],
+            chat: None,
+        };
+        let (status, body) = post_chat(&f.st, None, req).await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        let seen = f.seen.lock().unwrap();
+        assert_eq!(seen[0]["messages"], json!([{"role":"user","content":"one\n\ntwo"}]));
+    }
+
+    #[tokio::test]
+    async fn a_message_of_no_content_is_refused_rather_than_forwarded() {
+        let f = fixture(Vec::new(), false).await;
+        let req = ChatReq { messages: vec![ChatMsg { role: "user".into(), content: String::new() }], chat: None };
+        let (status, body) = post_chat(&f.st, None, req).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+        assert!(f.seen.lock().unwrap().is_empty(), "the API is never asked to answer nothing");
     }
 
     #[tokio::test]

--- a/src/http/api.rs
+++ b/src/http/api.rs
@@ -108,6 +108,9 @@ pub async fn stats(AxState(st): AxState<State>) -> Response {
         "conversations": conversations,
         "bytes": chat_bytes,
         "max_per_tenant": st.chats.cap(),
+        // what the count was always taken to mean: conversations are outside the tenant quota, so
+        // a number of files of no particular size said nothing about what the tenant holds (#89)
+        "max_bytes_per_tenant": st.chats.tenant_quota(),
         "window_turns": st.chats.window(),
     });
     let failed = st.store.failed_tenants();
@@ -247,6 +250,8 @@ fn tenant_json(st: &AppState, t: &Tenant) -> Value {
         "version": t.version(),
         "overlay_files": files,
         "overlay_bytes": bytes,
+        "max_files": t.max_files(),
+        "quota_bytes": t.quota(),
         "preview": preview_url(st, &t.id),
         "preview_token": st.preview_secret.as_ref().map(|s| super::preview_token(s, &t.id)),
     })
@@ -315,7 +320,7 @@ pub async fn write_file(AxState(st): AxState<State>, Path((id, path)): Path<(Str
     .await;
     match written {
         Ok(Ok(version)) => Json(json!({ "path": path, "version": version })).into_response(),
-        Ok(Err(e @ WriteError::Quota { .. })) => err(StatusCode::PAYLOAD_TOO_LARGE, e.to_string()),
+        Ok(Err(e @ (WriteError::Quota { .. } | WriteError::Files { .. }))) => err(StatusCode::PAYLOAD_TOO_LARGE, e.to_string()),
         Ok(Err(e)) => err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
         Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
     }

--- a/src/http/archive.rs
+++ b/src/http/archive.rs
@@ -155,7 +155,10 @@ impl<R: Read> Read for Capped<R> {
 /// is cut off at `stream_cap`, which also bounds what `tar` reads without ever showing it as an
 /// entry (a GNU long name, a pax payload, padding). So an archive that decompresses past the quota
 /// is refused without being decompressed.
-fn unpack(body: &[u8], quota: u64) -> Result<Unpacked, (StatusCode, String)> {
+///
+/// `max_files` is the other half of it, and the half `quota` cannot do: a zero-byte entry never
+/// moves `total`, so a 64 MiB quota admitted about 160,000 empty entries per request (issue #88).
+fn unpack(body: &[u8], quota: u64, max_files: usize) -> Result<Unpacked, (StatusCode, String)> {
     let cap = stream_cap(body.len() as u64, quota);
     let tripped = Arc::new(AtomicBool::new(false));
     let mut archive = Archive::new(Capped { inner: GzDecoder::new(body), read: 0, limit: cap, tripped: tripped.clone() });
@@ -202,6 +205,12 @@ fn unpack(body: &[u8], quota: u64) -> Result<Unpacked, (StatusCode, String)> {
         }
         let Some(path) = entry_path(&name) else { return Err(reject(&name, "path escapes the tenant tree")) };
         files.insert(path, bytes);
+        // counted where the file is kept rather than per entry, so the same path twice costs once,
+        // exactly as it will in the overlay `write_many` builds
+        if files.len() > max_files {
+            let over = format!("the archive holds more than {max_files} files, the most a tenant may hold (--tenant-max-files)");
+            return Err((StatusCode::PAYLOAD_TOO_LARGE, over));
+        }
     }
     Ok(Unpacked { files: files.into_iter().collect(), deleted })
 }
@@ -218,8 +227,8 @@ pub async fn import(AxState(st): AxState<State>, Path(id): Path<String>, RawQuer
         Err(r) => return r,
     };
     let replace = flag(query.as_deref(), "replace");
-    let quota = t.quota();
-    let unpacked = match tokio::task::spawn_blocking(move || unpack(&body, quota)).await {
+    let (quota, max_files) = (t.quota(), t.max_files());
+    let unpacked = match tokio::task::spawn_blocking(move || unpack(&body, quota, max_files)).await {
         Ok(Ok(u)) => u,
         Ok(Err((status, message))) => return (status, refused(message)).into_response(),
         Err(e) => return err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
@@ -228,7 +237,9 @@ pub async fn import(AxState(st): AxState<State>, Path(id): Path<String>, RawQuer
         Ok(Applied { version, written, deleted }) => {
             Json(json!({ "files": written, "deleted": deleted, "version": version })).into_response()
         }
-        Err(e @ WriteError::Quota { .. }) => (StatusCode::PAYLOAD_TOO_LARGE, refused(e.to_string())).into_response(),
+        Err(e @ (WriteError::Quota { .. } | WriteError::Files { .. })) => {
+            (StatusCode::PAYLOAD_TOO_LARGE, refused(e.to_string())).into_response()
+        }
         // the batch put itself back, so the tenant is what it was and the counts say it
         Err(e @ WriteError::Io(_)) => (StatusCode::INTERNAL_SERVER_ERROR, refused(e.to_string())).into_response(),
         // it could not, so there are no counts to give: the message names what is neither way
@@ -268,12 +279,16 @@ mod tests {
 
     /// A base of three files, a data dir, and two tenants on it.
     fn fixture(name: &str, quota: u64) -> Fixture {
+        fixture_holding(name, quota, crate::store::DEFAULT_MAX_FILES)
+    }
+
+    fn fixture_holding(name: &str, quota: u64, max_files: usize) -> Fixture {
         let root = std::env::temp_dir().join(format!("sandbox-lite-{name}-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&root);
         seed(root.join("base/src/pages/index.astro"), "<h1>base</h1>\n");
         seed(root.join("base/src/data.ts"), "export const n = 1;\n");
         seed(root.join("base/readme.md"), "base readme\n");
-        let store = Store::new(Some(root.join("data")), quota);
+        let store = Store::new(Some(root.join("data")), quota).with_max_files(max_files);
         store.add_base(Base::load("b", &root.join("base")).unwrap());
         store.create_tenant("a", "b").unwrap();
         store.create_tenant("bb", "b").unwrap();
@@ -427,6 +442,36 @@ mod tests {
         assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
         assert_eq!(f.state.store.tenant("a").unwrap().overlay_stats(), (1, 40));
         assert!(!f.root.join("data/a/files/src/huge.ts").exists());
+    }
+
+    /// Issue #88: an entry of no bytes never moved the byte total, so `--tenant-quota-mb` let an
+    /// import carry as many empty files as `stream_cap` had room to read — about 160,000 per
+    /// request at the default quota, and another 160,000 on the next one.
+    #[tokio::test]
+    async fn an_import_of_empty_files_is_refused_at_the_file_limit() {
+        let f = fixture_holding("import-count", 1 << 20, 3);
+        let flood: Vec<(&str, EntryType, &[u8])> =
+            ["src/e0.ts", "src/e1.ts", "src/e2.ts", "src/e3.ts"].iter().map(|p| (*p, EntryType::Regular, &b""[..])).collect();
+        let (status, body) = call(&f, "POST", "/api/tenants/a/import", tar_gz(&flood)).await;
+        assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE, "{}", String::from_utf8_lossy(&body));
+        let body: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!((body["files"].as_u64(), body["deleted"].as_u64()), (Some(0), Some(0)));
+        assert!(body["error"].as_str().unwrap().contains("--tenant-max-files"), "{body}");
+        assert_eq!(f.state.store.tenant("a").unwrap().overlay_stats(), (0, 0));
+        assert!(!f.root.join("data/a/files/src/e0.ts").exists());
+
+        // three of them fit, and a second request of three does not double up on the first
+        let three = &flood[..3];
+        let (status, _) = call(&f, "POST", "/api/tenants/a/import", tar_gz(three)).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(f.state.store.tenant("a").unwrap().overlay_stats(), (3, 0));
+        let more: Vec<(&str, EntryType, &[u8])> =
+            ["src/f0.ts", "src/f1.ts", "src/f2.ts"].iter().map(|p| (*p, EntryType::Regular, &b""[..])).collect();
+        let (status, body) = call(&f, "POST", "/api/tenants/a/import", tar_gz(&more)).await;
+        assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE, "?replace=0 adds to what the tenant already holds");
+        let body: Value = serde_json::from_slice(&body).unwrap();
+        assert!(body["error"].as_str().unwrap().contains("--tenant-max-files"), "{body}");
+        assert_eq!(f.state.store.tenant("a").unwrap().overlay_stats(), (3, 0));
     }
 
     #[tokio::test]

--- a/src/http/chats.rs
+++ b/src/http/chats.rs
@@ -2,9 +2,13 @@
 //! `--no-persist`. They are not site files: they never go through the tenant overlay, so they are
 //! invisible to the preview, to `/api/t/{id}/files` and to the tenant quota. What bounds them
 //! instead is here: a window of turns per conversation, with everything older folded into a
-//! stored summary, and a cap on how many conversations one tenant keeps.
+//! stored summary, a byte budget for what one request may add and what one conversation may hold,
+//! and a cap on how many conversations one tenant keeps. The cap and the budget together are the
+//! ceiling on `<data-dir>/<tenant>/chats/`, which `evict` holds the tenant to — the count alone
+//! bounded nothing, because nothing bounded a conversation (issue #89).
 
 use std::collections::{BTreeMap, HashMap};
+use std::fmt;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::RwLock;
@@ -27,9 +31,16 @@ const TITLE_CHARS: usize = 80;
 /// Turns of a conversation replayed to the model in full. Everything older is folded into
 /// `Conversation::summary`, so the request stops growing with the conversation.
 pub const DEFAULT_WINDOW_TURNS: usize = 24;
-/// Conversations one tenant may keep. They do not count against the tenant quota, so this is the
-/// only thing bounding what the chats directory holds.
+/// Conversations one tenant may keep. Together with `DEFAULT_CHAT_KB` this is what bounds the
+/// chats directory; on its own it bounded a count of files of no particular size.
 pub const DEFAULT_MAX_CHATS: usize = 50;
+/// The largest one request's `messages` may weigh, in KiB. The window is applied to the stored
+/// turns, so it never bounded these: one POST could store 64 MB (issue #89).
+pub const DEFAULT_MESSAGE_KB: usize = 64;
+/// The largest one conversation may hold, in KiB. Comfortably above `DEFAULT_WINDOW_TURNS` turns of
+/// `DEFAULT_MESSAGE_KB`, so it is the backstop for a conversation compaction could not shrink —
+/// a summary the API would not write — rather than a limit an ordinary chat runs into.
+pub const DEFAULT_CHAT_KB: usize = 2048;
 /// The summary is prompt text on every later turn, so it is capped like one.
 const MAX_SUMMARY_CHARS: usize = 2000;
 /// How the summary reaches the model: as the opening user turn, which is also the shape
@@ -79,14 +90,18 @@ impl Conversation {
     }
 
     /// The stored turns as Messages API input: the summary of what came before, then the last
-    /// `keep` turns and no more. Tool calls stay behind as a record for the editor; what they did
-    /// is already in the tenant's files. Empty turns are dropped and same-role neighbours joined,
-    /// because the API refuses empty content and two messages in a row from the same role.
+    /// `keep` turns and no more, and then `adding` — the turns this request carries. Tool calls
+    /// stay behind as a record for the editor; what they did is already in the tenant's files.
     ///
     /// `compact` normally keeps the conversation inside the window, so nothing is cut here. The
     /// cut is what bounds the request when it could not: a summary the API refused to write, or a
     /// conversation stored before the window existed.
-    pub fn for_model(&self, keep: usize) -> Vec<Value> {
+    ///
+    /// `adding` goes through the same normalisation as the stored turns rather than being appended
+    /// raw: appending it raw is how an empty `content` reached the API — a 502 to the caller — and
+    /// how two `user` messages in a row could, which the API refuses too (issue #89). The window is
+    /// not applied to it; what bounds it is `Chats::admits`, before either is sent or stored.
+    pub fn for_model(&self, keep: usize, adding: &[Turn]) -> Vec<Value> {
         let start = self.messages.len().saturating_sub(keep.max(1));
         let head = (!self.summary.is_empty()).then(|| Turn {
             role: "user".into(),
@@ -94,16 +109,8 @@ impl Conversation {
             tools: Vec::new(),
         });
         let mut out: Vec<(String, String)> = Vec::new();
-        for turn in head.iter().chain(&self.messages[start..]).filter(|t| !t.text.trim().is_empty()) {
-            if out.last().is_some_and(|(role, _)| *role == turn.role) {
-                if let Some((_, text)) = out.last_mut() {
-                    text.push_str("\n\n");
-                    text.push_str(&turn.text);
-                }
-            } else if !out.is_empty() || turn.role == "user" {
-                out.push((turn.role.clone(), turn.text.clone()));
-            }
-        }
+        normalise(&mut out, head.iter().chain(&self.messages[start..]));
+        normalise(&mut out, adding.iter());
         out.into_iter().map(|(role, content)| json!({ "role": role, "content": content })).collect()
     }
 
@@ -126,6 +133,11 @@ impl Conversation {
         self.summary = summary.chars().take(MAX_SUMMARY_CHARS).collect::<String>().trim().to_string();
     }
 
+    /// What the conversation weighs where it is stored, which is what the budget is spent in.
+    pub fn bytes(&self) -> u64 {
+        serialized_bytes(self)
+    }
+
     fn brief(&self) -> Value {
         json!({
             "id": self.id,
@@ -138,12 +150,68 @@ impl Conversation {
     }
 }
 
-/// The ids to remove so that at most `cap` conversations remain, least recently updated first.
-/// `keep` is the conversation the save was for and is never evicted, however old it looks.
-pub fn evictable(newest_first: &[Conversation], cap: usize, keep: &str) -> Vec<String> {
-    let over = newest_first.len().saturating_sub(cap.max(1));
-    newest_first.iter().rev().filter(|c| c.id != keep).take(over).map(|c| c.id.clone()).collect()
+/// Empty turns dropped, same-role neighbours joined and a leading assistant turn refused, appended
+/// to whatever `out` already holds — the API takes none of those three.
+fn normalise<'a>(out: &mut Vec<(String, String)>, turns: impl Iterator<Item = &'a Turn>) {
+    for turn in turns.filter(|t| !t.text.trim().is_empty()) {
+        if out.last().is_some_and(|(role, _)| *role == turn.role) {
+            if let Some((_, text)) = out.last_mut() {
+                text.push_str("\n\n");
+                text.push_str(&turn.text);
+            }
+        } else if !out.is_empty() || turn.role == "user" {
+            out.push((turn.role.clone(), turn.text.clone()));
+        }
+    }
 }
+
+/// The ids to remove so that at most `cap` conversations remain and together they weigh at most
+/// `budget`, least recently updated first. `keep` is the conversation the save was for and is never
+/// evicted, however old it looks — so a tenant holding one conversation over the budget keeps it,
+/// and the next save of it is what is refused.
+pub fn evictable(newest_first: &[Conversation], cap: usize, budget: u64, keep: &str) -> Vec<String> {
+    let mut over = newest_first.len().saturating_sub(cap.max(1));
+    let mut held: u64 = newest_first.iter().map(Conversation::bytes).sum();
+    let mut out = Vec::new();
+    for c in newest_first.iter().rev().filter(|c| c.id != keep) {
+        if over == 0 && held <= budget {
+            break;
+        }
+        over = over.saturating_sub(1);
+        held -= c.bytes();
+        out.push(c.id.clone());
+    }
+    out
+}
+
+/// Why a chat request was refused, and by which of the two limits — the caller cannot tell what to
+/// send next from a bare 413.
+#[derive(Debug, PartialEq)]
+pub enum TooBig {
+    /// What this one request carries.
+    Request { bytes: u64, limit: u64 },
+    /// What the conversation it is added to would then hold.
+    Conversation { held: u64, adding: u64, limit: u64 },
+}
+
+impl fmt::Display for TooBig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TooBig::Request { bytes, limit } => {
+                write!(
+                    f,
+                    "chat request too large: its messages are {bytes} bytes, the most one request may add is {limit} (--chat-message-kb)"
+                )
+            }
+            TooBig::Conversation { held, adding, limit } => write!(
+                f,
+                "chat too large: this conversation holds {held} bytes and the request would add {adding}, past the {limit} bytes one conversation may hold (--chat-quota-kb); start a new conversation"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for TooBig {}
 
 /// Disk is the store when the tenant has a data directory; the map holds everything otherwise.
 pub struct Chats {
@@ -156,6 +224,8 @@ pub struct Chats {
     sizes: RwLock<HashMap<String, BTreeMap<String, u64>>>,
     cap: usize,
     window: usize,
+    message_bytes: u64,
+    chat_bytes: u64,
 }
 
 impl Default for Chats {
@@ -166,7 +236,40 @@ impl Default for Chats {
 
 impl Chats {
     pub fn new(cap: usize, window: usize) -> Chats {
-        Chats { mem: RwLock::new(HashMap::new()), sizes: RwLock::new(HashMap::new()), cap: cap.max(1), window: window.max(2) }
+        Chats {
+            mem: RwLock::new(HashMap::new()),
+            sizes: RwLock::new(HashMap::new()),
+            cap: cap.max(1),
+            window: window.max(2),
+            message_bytes: (DEFAULT_MESSAGE_KB as u64) << 10,
+            chat_bytes: (DEFAULT_CHAT_KB as u64) << 10,
+        }
+    }
+
+    /// `--chat-message-kb` and `--chat-quota-kb`, in KiB.
+    pub fn with_budgets(mut self, message_kb: usize, chat_kb: usize) -> Chats {
+        self.message_bytes = (message_kb.max(1) as u64) << 10;
+        self.chat_bytes = (chat_kb.max(1) as u64) << 10;
+        self
+    }
+
+    /// What one request may add, and what the conversation it is added to may then hold. Asked
+    /// before the model is called, so a refusal writes nothing to `chats/`.
+    pub fn admits(&self, conv: &Conversation, adding: u64) -> Result<(), TooBig> {
+        if adding > self.message_bytes {
+            return Err(TooBig::Request { bytes: adding, limit: self.message_bytes });
+        }
+        let held = conv.bytes();
+        if held + adding > self.chat_bytes {
+            return Err(TooBig::Conversation { held, adding, limit: self.chat_bytes });
+        }
+        Ok(())
+    }
+
+    /// The ceiling on `<data-dir>/<tenant>/chats/`: `--chats-per-tenant` conversations of
+    /// `--chat-quota-kb` each. `evict` holds the tenant to it after every save.
+    pub fn tenant_quota(&self) -> u64 {
+        self.chat_bytes.saturating_mul(self.cap as u64)
     }
 
     /// Turns `for_model` replays in full; see `DEFAULT_WINDOW_TURNS`.
@@ -232,23 +335,18 @@ impl Chats {
         Ok(())
     }
 
-    /// Brings the tenant back under the cap after a save. The count is taken first because it
-    /// costs one `read_dir`, where choosing what to drop costs a parse of every conversation.
+    /// Brings the tenant back under both caps after a save — the count, and the bytes the count was
+    /// meant to stand for. Both come off the maintained counters, so the ordinary save costs two
+    /// comparisons; choosing what to drop is what costs a parse of every conversation.
     fn evict(&self, t: &Tenant, saved: &str) -> io::Result<()> {
-        if self.count(t)? <= self.cap {
+        let (count, bytes) = self.usage(t)?;
+        if count <= self.cap && bytes <= self.tenant_quota() {
             return Ok(());
         }
-        for id in evictable(&self.list(t)?, self.cap, saved) {
+        for id in evictable(&self.list(t)?, self.cap, self.tenant_quota(), saved) {
             self.delete(t, &id)?;
         }
         Ok(())
-    }
-
-    fn count(&self, t: &Tenant) -> io::Result<usize> {
-        match dir(t) {
-            Some(dir) => Ok(chat_files(&dir)?.len()),
-            None => Ok(self.mem.read().unwrap().get(&t.id).map_or(0, BTreeMap::len)),
-        }
     }
 
     /// What the tenant's conversations hold, from the counters rather than the disk: the tenant is
@@ -397,7 +495,7 @@ pub async fn remove(AxState(st): AxState<State>, AxPath((id, chat)): AxPath<(Str
 
 #[cfg(test)]
 mod tests {
-    use super::{Chats, Conversation, DEFAULT_WINDOW_TURNS, SUMMARY_PREFIX, Turn, evictable, new_id};
+    use super::{Chats, Conversation, DEFAULT_WINDOW_TURNS, SUMMARY_PREFIX, TooBig, Turn, evictable, new_id};
     use crate::store::{Base, Store, Tenant};
     use serde_json::json;
     use std::path::{Path, PathBuf};
@@ -425,7 +523,7 @@ mod tests {
             c.push(t);
         }
         assert_eq!(
-            c.for_model(DEFAULT_WINDOW_TURNS),
+            c.for_model(DEFAULT_WINDOW_TURNS, &[]),
             vec![
                 json!({"role":"user","content":"one"}),
                 json!({"role":"assistant","content":"two"}),
@@ -477,7 +575,7 @@ mod tests {
         assert_eq!(c.messages.iter().map(|t| t.text.clone()).collect::<Vec<_>>(), ["turn 4", "turn 5"]);
         assert_eq!(c.title, "turn 0", "the title survives the turn it was taken from");
         assert_eq!(
-            c.for_model(4),
+            c.for_model(4, &[]),
             vec![
                 json!({"role":"user","content":format!("{SUMMARY_PREFIX}they asked for a green headline\n\nturn 4")}),
                 json!({"role":"assistant","content":"turn 5"}),
@@ -491,12 +589,12 @@ mod tests {
     #[test]
     fn for_model_never_sends_more_than_the_window() {
         let mut c = conversation("c", 100);
-        let sent = c.for_model(6);
+        let sent = c.for_model(6, &[]);
         assert_eq!(sent.len(), 6);
         assert_eq!(sent[0], json!({"role":"user","content":"turn 94"}));
         assert_eq!(sent[5], json!({"role":"assistant","content":"turn 99"}));
         c.summary = "earlier".into();
-        assert_eq!(c.for_model(0).len(), 2, "a window of zero is the summary and one turn, not a slice out of bounds");
+        assert_eq!(c.for_model(0, &[]).len(), 2, "a window of zero is the summary and one turn, not a slice out of bounds");
     }
 
     #[test]
@@ -520,11 +618,54 @@ mod tests {
             c.updated = 100 - i as u64;
         }
         // `list` is newest first, the order `Chats::list` returns
-        assert_eq!(evictable(&list, 3, "c0"), vec!["c4".to_string(), "c3".to_string()]);
-        assert_eq!(evictable(&list, 5, "c0"), Vec::<String>::new());
-        assert_eq!(evictable(&list, 9, "c0"), Vec::<String>::new());
-        assert_eq!(evictable(&list, 3, "c4"), vec!["c3".to_string(), "c2".to_string()], "the saved one is skipped, two others go");
-        assert_eq!(evictable(&list, 0, "c0"), vec!["c4".to_string(), "c3".to_string(), "c2".to_string(), "c1".to_string()]);
+        let room = u64::MAX;
+        assert_eq!(evictable(&list, 3, room, "c0"), vec!["c4".to_string(), "c3".to_string()]);
+        assert_eq!(evictable(&list, 5, room, "c0"), Vec::<String>::new());
+        assert_eq!(evictable(&list, 9, room, "c0"), Vec::<String>::new());
+        assert_eq!(evictable(&list, 3, room, "c4"), vec!["c3".to_string(), "c2".to_string()], "the saved one is skipped, two others go");
+        assert_eq!(evictable(&list, 0, room, "c0"), vec!["c4".to_string(), "c3".to_string(), "c2".to_string(), "c1".to_string()]);
+    }
+
+    /// Issue #89: `--chats-per-tenant` bounded a count of files of no particular size, so the real
+    /// per-tenant ceiling was the disk. The budget is what the count is spent in.
+    #[test]
+    fn eviction_takes_the_bytes_as_well_as_the_count() {
+        let mut list: Vec<Conversation> = (0..5).map(|i| conversation(&format!("c{i}"), 1)).collect();
+        for (i, c) in list.iter_mut().enumerate() {
+            c.updated = 100 - i as u64;
+        }
+        // taken from the conversations rather than assumed: `updated` is serialized, so two of
+        // them weigh the same only while they have the same number of digits
+        let weighing = |ids: &[&str]| list.iter().filter(|c| ids.contains(&c.id.as_str())).map(Conversation::bytes).sum::<u64>();
+        let all = weighing(&["c0", "c1", "c2", "c3", "c4"]);
+        assert_eq!(evictable(&list, 9, all, "c0"), Vec::<String>::new(), "inside the budget nothing goes");
+        assert_eq!(
+            evictable(&list, 9, weighing(&["c0", "c1", "c2"]), "c0"),
+            vec!["c4".to_string(), "c3".to_string()],
+            "oldest first, until what is left fits"
+        );
+        assert_eq!(evictable(&list, 9, 0, "c0").len(), 4, "everything but the one just saved");
+    }
+
+    /// Issue #89: what one request may add, and what the conversation may then hold. Both are
+    /// asked before the model is called, and the refusal says which one was hit.
+    #[test]
+    fn a_request_past_either_budget_is_refused_by_name() {
+        let chats = Chats::new(4, 8).with_budgets(1, 4);
+        let empty = Conversation::new("c".into());
+        assert_eq!(chats.admits(&empty, 1024), Ok(()));
+        let over = chats.admits(&empty, 1025).unwrap_err();
+        assert!(matches!(over, TooBig::Request { bytes: 1025, limit: 1024 }), "{over}");
+        assert!(over.to_string().contains("--chat-message-kb"), "{over}");
+
+        let mut long = Conversation::new("c".into());
+        while long.bytes() + 1024 <= 4096 {
+            long.push(turn("user", &"x".repeat(200)));
+        }
+        let over = chats.admits(&long, 1024).unwrap_err();
+        assert!(matches!(over, TooBig::Conversation { limit: 4096, .. }), "{over}");
+        assert!(over.to_string().contains("--chat-quota-kb"), "{over}");
+        assert_eq!(chats.tenant_quota(), 4 * 4096, "the cap is spent in bytes: four conversations of the budget");
     }
 
     fn tenant(persist: bool) -> (Arc<Tenant>, PathBuf) {
@@ -558,6 +699,57 @@ mod tests {
             assert!(bytes > 0, "persist={persist}");
             let _ = std::fs::remove_dir_all(&root);
         }
+    }
+
+    /// Issue #89: a conversation had no budget, so `--chats-per-tenant 50` bounded gigabytes that
+    /// `/api/t/{id}/files`, the tenant quota and 413 all reported as zero. The directory is held to
+    /// the cap times the budget, whatever a conversation that reached the store weighs.
+    #[test]
+    fn the_chats_directory_cannot_exceed_the_cap_times_the_budget() {
+        for persist in [true, false] {
+            let (t, root) = tenant(persist);
+            let chats = Chats::new(4, 8).with_budgets(64, 1);
+            assert_eq!(chats.tenant_quota(), 4 << 10);
+            for i in 0..8 {
+                // each one over the per-conversation budget on its own, which `admits` refuses at
+                // the door and `evict` has to survive anyway: an older store wrote what it liked
+                let mut c = conversation(&format!("c{i}"), 2);
+                c.push(turn("user", &"x".repeat(1500)));
+                c.updated = 1000 + i as u64;
+                chats.save(&t, &c).unwrap();
+                let (count, bytes) = chats.usage(&t).unwrap();
+                assert!(count <= 4, "persist={persist}, after {i}: {count} conversations");
+                assert!(bytes <= chats.tenant_quota(), "persist={persist}, after {i}: {bytes} bytes");
+            }
+            assert!(chats.load(&t, "c0").unwrap().is_none(), "persist={persist}");
+            assert!(chats.load(&t, "c7").unwrap().is_some(), "persist={persist}: the one just saved stays");
+            let _ = std::fs::remove_dir_all(&root);
+        }
+    }
+
+    /// Issue #89: `run` windowed the stored turns and then appended the request's own raw, so an
+    /// empty `content` and two `user` messages in a row both reached an API that refuses them.
+    #[test]
+    fn the_requests_own_messages_are_normalised_like_the_stored_ones() {
+        let mut c = Conversation::new("c".into());
+        c.push(turn("user", "one"));
+        c.push(turn("assistant", ""));
+        let adding = [turn("user", "two"), turn("user", ""), turn("user", "three")];
+        assert_eq!(
+            c.for_model(DEFAULT_WINDOW_TURNS, &adding),
+            vec![json!({"role":"user","content":"one\n\ntwo\n\nthree"})],
+            "the empty turns go, and what is left joins rather than sending the same role twice"
+        );
+        assert_eq!(
+            Conversation::new("c".into()).for_model(DEFAULT_WINDOW_TURNS, &[turn("user", "  ")]),
+            Vec::<serde_json::Value>::new(),
+            "a message of nothing is nothing to send"
+        );
+        assert_eq!(
+            Conversation::new("c".into()).for_model(DEFAULT_WINDOW_TURNS, &[turn("assistant", "hi")]),
+            Vec::<serde_json::Value>::new(),
+            "the API refuses a leading assistant turn, from the request as much as from the store"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,20 +34,26 @@ struct Args {
     api_token: Option<String>,
     preview_secret: Option<String>,
     tenant_quota_mb: u64,
+    tenant_max_files: usize,
     cookie_samesite: Option<http::SameSite>,
     chrome: Option<PathBuf>,
     chrome_jobs: usize,
     chat_window: usize,
     chats_per_tenant: usize,
+    chat_message_kb: usize,
+    chat_quota_kb: usize,
 }
 
 fn usage() -> ! {
     eprintln!(
-        "sandbox-lite {}\n\nUsage: sandbox-lite [options]\n       sandbox-lite check [--json] DIR...   compile every source file of an Astro project and print diagnostics + a feature census\n\n  --listen ADDR        bind address (default 127.0.0.1:4321)\n  --domain NAME        preview domain; tenants are served at http://<id>.NAME:PORT/ (default localhost)\n  --bases DIR          directory whose sub-directories are base projects (default ./examples if present)\n  --base NAME=PATH     add one base project (repeatable)\n  --watch-bases N      re-read every base project when its files change, polled every N seconds (default: off)\n  --data-dir DIR       where tenant edits are persisted (default ./data)\n  --no-persist         keep tenant edits in memory only\n  --cdn URL            where bare npm imports are fetched from in the browser (default https://esm.sh)\n  --cache-mb N         transform cache budget in MiB (default 64)\n  --max-source-kb N    largest .astro/.ts/.js/.mdx/.scss file the compilers accept, in KiB (default 64)\n  --sass-timeout-ms N  deadline for one Sass compile, after which the request fails (default 5000)\n  --compile-timeout-ms N\n                       deadline for one compile of any kind; past it the request is answered with a\n                       diagnostic and the compiler thread, which cannot be interrupted, is abandoned\n                       and counted under `compiles` in /api/stats (default 10000)\n  --max-compiles N     compiles that may run at once; one that waits too long for a slot is refused with 503 (default: one per core)\n  --model NAME         Claude model for the built-in chat (default claude-fable-5-1)\n  --api-token TOKEN    require `Authorization: Bearer TOKEN` (or ?token=) on /api/*\n  --preview-secret S   tenant hosts need a per-tenant token derived from S (the API hands it out)\n  --chrome PATH        chrome or chromium binary for the chat's screenshot tool (default: off)\n  --chrome-jobs N      screenshots that may run at once; a call that waits longer than 10s is told the tool is busy (default {})\n  --chat-window N      turns of a conversation replayed to the model in full; older ones are folded into a stored summary (default {})\n  --chats-per-tenant N conversations a tenant may keep; saving past it drops the least recently updated (default {})\n  --tenant-quota-mb N  edited files a tenant may hold, in MiB; a write past it is refused with 413 (default 64)\n  --cookie-samesite lax|none\n                       SameSite of the preview cookie; none also sets Secure. With --preview-secret the\n                       default is none, because a framed preview is cross-site and a browser\n                       drops a Lax cookie there; otherwise lax\n\nEnvironment: ANTHROPIC_API_KEY enables the chat endpoint; SANDBOX_LITE_API_TOKEN, SANDBOX_LITE_PREVIEW_SECRET, SANDBOX_LITE_TENANT_QUOTA_MB, SANDBOX_LITE_MAX_COMPILES, SANDBOX_LITE_COMPILE_TIMEOUT_MS, SANDBOX_LITE_CHROME, SANDBOX_LITE_CHROME_JOBS, SANDBOX_LITE_CHAT_WINDOW and SANDBOX_LITE_CHATS_PER_TENANT are read as defaults for those flags; SANDBOX_LITE_ANTHROPIC_BASE points the chat at another Messages API endpoint (default https://api.anthropic.com).",
+        "sandbox-lite {}\n\nUsage: sandbox-lite [options]\n       sandbox-lite check [--json] DIR...   compile every source file of an Astro project and print diagnostics + a feature census\n\n  --listen ADDR        bind address (default 127.0.0.1:4321)\n  --domain NAME        preview domain; tenants are served at http://<id>.NAME:PORT/ (default localhost)\n  --bases DIR          directory whose sub-directories are base projects (default ./examples if present)\n  --base NAME=PATH     add one base project (repeatable)\n  --watch-bases N      re-read every base project when its files change, polled every N seconds (default: off)\n  --data-dir DIR       where tenant edits are persisted (default ./data)\n  --no-persist         keep tenant edits in memory only\n  --cdn URL            where bare npm imports are fetched from in the browser (default https://esm.sh)\n  --cache-mb N         transform cache budget in MiB (default 64)\n  --max-source-kb N    largest .astro/.ts/.js/.mdx/.scss file the compilers accept, in KiB (default 64)\n  --sass-timeout-ms N  deadline for one Sass compile, after which the request fails (default 5000)\n  --compile-timeout-ms N\n                       deadline for one compile of any kind; past it the request is answered with a\n                       diagnostic and the compiler thread, which cannot be interrupted, is abandoned\n                       and counted under `compiles` in /api/stats (default 10000)\n  --max-compiles N     compiles that may run at once; one that waits too long for a slot is refused with 503 (default: one per core)\n  --model NAME         Claude model for the built-in chat (default claude-fable-5-1)\n  --api-token TOKEN    require `Authorization: Bearer TOKEN` (or ?token=) on /api/*\n  --preview-secret S   tenant hosts need a per-tenant token derived from S (the API hands it out)\n  --chrome PATH        chrome or chromium binary for the chat's screenshot tool (default: off)\n  --chrome-jobs N      screenshots that may run at once; a call that waits longer than 10s is told the tool is busy (default {})\n  --chat-window N      turns of a conversation replayed to the model in full; older ones are folded into a stored summary (default {})\n  --chats-per-tenant N conversations a tenant may keep; saving past it drops the least recently updated (default {})\n  --chat-message-kb N  largest one chat request's messages may be, in KiB; a request past it is refused with 413 (default {})\n  --chat-quota-kb N    largest one conversation may hold, in KiB; times --chats-per-tenant, the ceiling on the chats directory (default {})\n  --tenant-quota-mb N  edited files a tenant may hold, in MiB; a write past it is refused with 413 (default 64)\n  --tenant-max-files N edited files a tenant may hold, whatever they weigh; a write past it is refused with 413 (default {})\n  --cookie-samesite lax|none\n                       SameSite of the preview cookie; none also sets Secure. With --preview-secret the\n                       default is none, because a framed preview is cross-site and a browser\n                       drops a Lax cookie there; otherwise lax\n\nEnvironment: ANTHROPIC_API_KEY enables the chat endpoint; SANDBOX_LITE_API_TOKEN, SANDBOX_LITE_PREVIEW_SECRET, SANDBOX_LITE_TENANT_QUOTA_MB, SANDBOX_LITE_MAX_COMPILES, SANDBOX_LITE_COMPILE_TIMEOUT_MS, SANDBOX_LITE_CHROME, SANDBOX_LITE_CHROME_JOBS, SANDBOX_LITE_CHAT_WINDOW, SANDBOX_LITE_CHATS_PER_TENANT, SANDBOX_LITE_CHAT_MESSAGE_KB, SANDBOX_LITE_CHAT_QUOTA_KB and SANDBOX_LITE_TENANT_MAX_FILES are read as defaults for those flags; SANDBOX_LITE_ANTHROPIC_BASE points the chat at another Messages API endpoint (default https://api.anthropic.com).",
         env!("CARGO_PKG_VERSION"),
         http::ai::DEFAULT_CHROME_JOBS,
         http::chats::DEFAULT_WINDOW_TURNS,
-        http::chats::DEFAULT_MAX_CHATS
+        http::chats::DEFAULT_MAX_CHATS,
+        http::chats::DEFAULT_MESSAGE_KB,
+        http::chats::DEFAULT_CHAT_KB,
+        store::DEFAULT_MAX_FILES
     );
     std::process::exit(2)
 }
@@ -83,11 +89,14 @@ fn parse_args() -> Args {
             .ok()
             .filter(|v| !v.is_empty())
             .map_or(64, |v| v.parse().unwrap_or_else(|_| usage())),
+        tenant_max_files: env_usize("SANDBOX_LITE_TENANT_MAX_FILES", store::DEFAULT_MAX_FILES),
         cookie_samesite: None,
         chrome: std::env::var("SANDBOX_LITE_CHROME").ok().filter(|v| !v.is_empty()).map(PathBuf::from),
         chrome_jobs: env_usize("SANDBOX_LITE_CHROME_JOBS", http::ai::DEFAULT_CHROME_JOBS),
         chat_window: env_usize("SANDBOX_LITE_CHAT_WINDOW", http::chats::DEFAULT_WINDOW_TURNS),
         chats_per_tenant: env_usize("SANDBOX_LITE_CHATS_PER_TENANT", http::chats::DEFAULT_MAX_CHATS),
+        chat_message_kb: env_usize("SANDBOX_LITE_CHAT_MESSAGE_KB", http::chats::DEFAULT_MESSAGE_KB),
+        chat_quota_kb: env_usize("SANDBOX_LITE_CHAT_QUOTA_KB", http::chats::DEFAULT_CHAT_KB),
     };
     let mut it = std::env::args().skip(1);
     while let Some(a) = it.next() {
@@ -114,11 +123,14 @@ fn parse_args() -> Args {
             "--api-token" => args.api_token = Some(value()),
             "--preview-secret" => args.preview_secret = Some(value()),
             "--tenant-quota-mb" => args.tenant_quota_mb = value().parse().unwrap_or_else(|_| usage()),
+            "--tenant-max-files" => args.tenant_max_files = value().parse().unwrap_or_else(|_| usage()),
             "--cookie-samesite" => args.cookie_samesite = Some(value().parse().unwrap_or_else(|_| usage())),
             "--chrome" => args.chrome = Some(PathBuf::from(value())),
             "--chrome-jobs" => args.chrome_jobs = value().parse().unwrap_or_else(|_| usage()),
             "--chat-window" => args.chat_window = value().parse().unwrap_or_else(|_| usage()),
             "--chats-per-tenant" => args.chats_per_tenant = value().parse().unwrap_or_else(|_| usage()),
+            "--chat-message-kb" => args.chat_message_kb = value().parse().unwrap_or_else(|_| usage()),
+            "--chat-quota-kb" => args.chat_quota_kb = value().parse().unwrap_or_else(|_| usage()),
             "-h" | "--help" => usage(),
             _ => usage(),
         }
@@ -146,8 +158,9 @@ async fn main() {
         check_command(&argv[1..]);
     }
     let args = parse_args();
-    let store =
-        store::Store::new(args.data_dir.clone(), args.tenant_quota_mb.saturating_mul(1 << 20)).with_bases_dir(args.bases_dir.clone());
+    let store = store::Store::new(args.data_dir.clone(), args.tenant_quota_mb.saturating_mul(1 << 20))
+        .with_max_files(args.tenant_max_files)
+        .with_bases_dir(args.bases_dir.clone());
     // `--base NAME=PATH` and the `--bases` scan are contained by the one rule `POST /api/bases`
     // applies, so a path outside `--bases` cannot become a base whichever way it arrives.
     let mut bases = Vec::new();
@@ -214,7 +227,7 @@ async fn main() {
             metrics.clone(),
         ),
         metrics,
-        chats: http::chats::Chats::new(args.chats_per_tenant, args.chat_window),
+        chats: http::chats::Chats::new(args.chats_per_tenant, args.chat_window).with_budgets(args.chat_message_kb, args.chat_quota_kb),
         domain: args.domain.clone(),
         port,
         model: args.model.clone(),

--- a/src/store.rs
+++ b/src/store.rs
@@ -10,6 +10,9 @@ use tokio::sync::broadcast;
 use xxhash_rust::xxh3::xxh3_64;
 
 const INLINE_LIMIT: u64 = 256 * 1024;
+/// Edited files one tenant may hold, what `--tenant-max-files` sets. The byte quota bounds none of
+/// them: 32,001 empty files fit a 1 KiB quota, and each is an inode of its own (issue #88).
+pub const DEFAULT_MAX_FILES: usize = 10_000;
 const SKIP_DIRS: &[&str] = &["node_modules", ".git", "dist", ".astro", ".vercel", ".netlify", ".output"];
 
 #[derive(Clone)]
@@ -191,6 +194,12 @@ pub enum WriteError {
         quota: u64,
         after: u64,
     },
+    /// The other half of the quota. An empty file weighs nothing and still costs an inode, a
+    /// directory entry and a line of tombstone bookkeeping, so bytes alone bound none of them.
+    Files {
+        limit: usize,
+        after: usize,
+    },
     Io(io::Error),
     /// A write that failed and could not be put back. The named paths are neither what they were nor
     /// what the write asked for, so the caller is told that rather than that nothing landed.
@@ -205,6 +214,12 @@ impl fmt::Display for WriteError {
         match self {
             WriteError::Quota { quota, after } => {
                 write!(f, "tenant quota exceeded: edited files would total {after} bytes, the quota is {quota} bytes (--tenant-quota-mb)")
+            }
+            WriteError::Files { limit, after } => {
+                write!(
+                    f,
+                    "tenant file limit exceeded: the tenant would hold {after} edited files, the limit is {limit} (--tenant-max-files)"
+                )
             }
             WriteError::Io(e) => fmt::Display::fmt(e, f),
             WriteError::Torn { cause, paths } => write!(
@@ -225,14 +240,70 @@ impl From<io::Error> for WriteError {
     }
 }
 
+/// A tenant's edits and what they weigh. Both totals move with every insert, replace and tombstone
+/// rather than being summed when asked: the quota is checked under the write lock, and a walk of the
+/// map there makes one write O(files) and blocks every read of the tenant while it runs (issue #88).
+#[derive(Default)]
+struct Overlay {
+    files: BTreeMap<String, Option<FileData>>,
+    /// What the written files hold. A tombstone is not a file and weighs nothing.
+    bytes: u64,
+    /// How many entries are written files rather than tombstones.
+    written: usize,
+}
+
+/// What one entry contributes to the two totals.
+fn weight(data: &Option<FileData>) -> (usize, u64) {
+    match data {
+        Some(d) => (1, d.size()),
+        None => (0, 0),
+    }
+}
+
+impl Overlay {
+    fn get(&self, path: &str) -> Option<&Option<FileData>> {
+        self.files.get(path)
+    }
+
+    /// What a write to `path` would replace, which the quota check gives back before charging it.
+    fn size_of(&self, path: &str) -> u64 {
+        self.files.get(path).and_then(|d| d.as_ref()).map_or(0, |d| d.size())
+    }
+
+    fn insert(&mut self, path: String, data: Option<FileData>) {
+        let (files, bytes) = weight(&data);
+        let (was_files, was_bytes) = self.files.insert(path, data).as_ref().map_or((0, 0), weight);
+        self.written = self.written - was_files + files;
+        self.bytes = self.bytes - was_bytes + bytes;
+    }
+
+    fn remove(&mut self, path: &str) {
+        if let Some(gone) = self.files.remove(path) {
+            let (files, bytes) = weight(&gone);
+            self.written -= files;
+            self.bytes -= bytes;
+        }
+    }
+
+    /// A whole new map, counted once. `write_many` builds one, so an import pays a single walk of
+    /// what it wrote rather than one per file.
+    fn replace(&mut self, files: BTreeMap<String, Option<FileData>>) {
+        let (written, bytes) = files.values().map(weight).fold((0, 0), |(n, b), (dn, db)| (n + dn, b + db));
+        self.files = files;
+        self.written = written;
+        self.bytes = bytes;
+    }
+}
+
 pub struct Tenant {
     pub id: String,
     base: RwLock<Arc<Base>>,
-    overlay: RwLock<BTreeMap<String, Option<FileData>>>,
+    overlay: RwLock<Overlay>,
     version: AtomicU64,
     pub events: broadcast::Sender<String>,
     dir: Option<PathBuf>,
     quota: u64,
+    max_files: usize,
 }
 
 pub struct Entry {
@@ -242,6 +313,7 @@ pub struct Entry {
 }
 
 /// What one `write_many` changed: files written, and overlay entries it dropped or hid.
+#[derive(Debug)]
 pub struct Applied {
     pub version: u64,
     pub written: usize,
@@ -249,16 +321,17 @@ pub struct Applied {
 }
 
 impl Tenant {
-    fn new(id: String, base: Arc<Base>, dir: Option<PathBuf>, quota: u64) -> Tenant {
+    fn new(id: String, base: Arc<Base>, dir: Option<PathBuf>, quota: u64, max_files: usize) -> Tenant {
         let (events, _) = broadcast::channel(64);
         Tenant {
             id,
             base: RwLock::new(base),
-            overlay: RwLock::new(BTreeMap::new()),
+            overlay: RwLock::new(Overlay::default()),
             version: AtomicU64::new(now_millis()),
             events,
             dir,
             quota,
+            max_files,
         }
     }
 
@@ -311,7 +384,7 @@ impl Tenant {
         let overlay = self.overlay.read().unwrap();
         let base = self.base.read().unwrap();
         let mut out: BTreeMap<String, (u64, bool)> = base.files.iter().map(|(p, d)| (p.clone(), (d.size(), false))).collect();
-        for (p, d) in overlay.iter() {
+        for (p, d) in overlay.files.iter() {
             match d {
                 Some(d) => {
                     out.insert(p.clone(), (d.size(), true));
@@ -330,14 +403,17 @@ impl Tenant {
     pub fn write(&self, path: &str, bytes: Vec<u8>, kind: UpdateKind) -> Result<u64, WriteError> {
         // held across the disk write so a concurrent write cannot slip past the quota check
         let mut overlay = self.overlay.write().unwrap();
-        let replaced = overlay.get(path).and_then(|d| d.as_ref()).map_or(0, |d| d.size());
-        let after = overlay_bytes(&overlay) - replaced + bytes.len() as u64;
+        let after = overlay.bytes - overlay.size_of(path) + bytes.len() as u64;
         if after > self.quota {
             return Err(WriteError::Quota { quota: self.quota, after });
         }
+        let files = overlay.written + usize::from(!matches!(overlay.get(path), Some(Some(_))));
+        if files > self.max_files {
+            return Err(WriteError::Files { limit: self.max_files, after: files });
+        }
         let was_tombstone = matches!(overlay.get(path), Some(None));
         let mut staged = Staged::new(self.dir.as_deref());
-        let data = match stage_write(&mut staged, &overlay, path, bytes, was_tombstone) {
+        let data = match stage_write(&mut staged, &overlay.files, path, bytes, was_tombstone) {
             Ok(data) => data,
             Err(cause) => return Err(staged.undo(cause)),
         };
@@ -362,7 +438,7 @@ impl Tenant {
         let incoming: BTreeSet<&str> = files.iter().map(|(p, _)| p.as_str()).collect();
         let keep = |path: &str, data: &Option<FileData>| !replace || data.is_none() || incoming.contains(path);
         let mut next: BTreeMap<String, Option<FileData>> =
-            overlay.iter().filter(|(p, d)| keep(p, d)).map(|(p, d)| (p.clone(), d.clone())).collect();
+            overlay.files.iter().filter(|(p, d)| keep(p, d)).map(|(p, d)| (p.clone(), d.clone())).collect();
         for path in deleted.iter().filter(|p| !incoming.contains(p.as_str())) {
             match self.base.read().unwrap().get(path) {
                 Some(_) => next.insert(path.clone(), None),
@@ -374,18 +450,22 @@ impl Tenant {
         if after > self.quota {
             return Err(WriteError::Quota { quota: self.quota, after });
         }
+        let held = next.iter().filter(|(p, d)| !incoming.contains(p.as_str()) && d.is_some()).count() + files.len();
+        if held > self.max_files {
+            return Err(WriteError::Files { limit: self.max_files, after: held });
+        }
         // `None` is untouched, `Some(true)` an edit, `Some(false)` a tombstone: a dropped edit and
         // a new tombstone both read as a change, and only writes are left out
         let overlaid = |o: &BTreeMap<String, Option<FileData>>, p: &str| o.get(p).map(Option::is_some);
-        let touched: BTreeSet<&str> = overlay.keys().chain(deleted.iter()).map(String::as_str).collect();
+        let touched: BTreeSet<&str> = overlay.files.keys().chain(deleted.iter()).map(String::as_str).collect();
         let dropped: Vec<&str> =
-            touched.into_iter().filter(|p| !incoming.contains(p) && overlaid(&overlay, p) != overlaid(&next, p)).collect();
+            touched.into_iter().filter(|p| !incoming.contains(p) && overlaid(&overlay.files, p) != overlaid(&next, p)).collect();
         let (written, removed) = (files.len(), dropped.len());
         let mut staged = Staged::new(self.dir.as_deref());
         if let Err(cause) = stage_batch(&mut staged, &mut next, &dropped, files) {
             return Err(staged.undo(cause));
         }
-        *overlay = next;
+        overlay.replace(next);
         drop(overlay);
         staged.commit();
         Ok(Applied { version: self.bump("update", "", UpdateKind::Module), written, deleted: removed })
@@ -397,7 +477,7 @@ impl Tenant {
         let mut overlay = self.overlay.write().unwrap();
         let tombstone = self.base.read().unwrap().get(path).is_some();
         let mut staged = Staged::new(self.dir.as_deref());
-        if let Err(cause) = stage_delete(&mut staged, &overlay, path, tombstone) {
+        if let Err(cause) = stage_delete(&mut staged, &overlay.files, path, tombstone) {
             return Err(staged.undo(cause));
         }
         if tombstone {
@@ -432,16 +512,23 @@ impl Tenant {
 
     /// The tenant's own edits: `Some` is a written file, `None` a tombstone over a base file.
     pub fn overlay(&self) -> Vec<(String, Option<FileData>)> {
-        self.overlay.read().unwrap().iter().map(|(p, d)| (p.clone(), d.clone())).collect()
+        self.overlay.read().unwrap().files.iter().map(|(p, d)| (p.clone(), d.clone())).collect()
     }
 
     pub fn quota(&self) -> u64 {
         self.quota
     }
 
+    /// Edited files the tenant may hold, the count the byte quota does not bound.
+    pub fn max_files(&self) -> usize {
+        self.max_files
+    }
+
+    /// Entries and bytes, read off the running totals rather than summed: `/api/stats` and
+    /// `/metrics` add this up over every loaded tenant, and the editor polls the first every 5 s.
     pub fn overlay_stats(&self) -> (usize, u64) {
         let overlay = self.overlay.read().unwrap();
-        (overlay.len(), overlay_bytes(&overlay))
+        (overlay.files.len(), overlay.bytes)
     }
 
     fn restore_overlay(&self, dir: &Path) -> io::Result<()> {
@@ -461,15 +548,13 @@ impl Tenant {
             // A tombstone list that is dropped brings deleted files back, which is not the tenant.
             let list: Vec<String> = serde_json::from_slice(&raw).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
             for p in list {
-                overlay.entry(p).or_insert(None);
+                if !overlay.files.contains_key(&p) {
+                    overlay.insert(p, None);
+                }
             }
         }
         Ok(())
     }
-}
-
-fn overlay_bytes(overlay: &BTreeMap<String, Option<FileData>>) -> u64 {
-    overlay.values().flatten().map(|d| d.size()).sum()
 }
 
 /// The disk half of one write, and what it takes to put `<data-dir>/<id>` back. Nothing there is
@@ -700,6 +785,7 @@ pub struct Store {
     data_dir: Option<PathBuf>,
     bases_dir: Option<PathBuf>,
     tenant_quota: u64,
+    tenant_max_files: usize,
 }
 
 impl Store {
@@ -711,7 +797,14 @@ impl Store {
             data_dir,
             bases_dir: None,
             tenant_quota,
+            tenant_max_files: DEFAULT_MAX_FILES,
         }
+    }
+
+    /// `--tenant-max-files`: edited files one tenant may hold, whatever they weigh.
+    pub fn with_max_files(mut self, max_files: usize) -> Store {
+        self.tenant_max_files = max_files.max(1);
+        self
     }
 
     /// `--bases`: the directory a base added through the API must live under.
@@ -838,7 +931,7 @@ impl Store {
             std::fs::write(dir.join("tenant.json"), format!(r#"{{"base":{}}}"#, serde_json::to_string(base_name).unwrap()))
                 .map_err(|e| e.to_string())?;
         }
-        let tenant = Arc::new(Tenant::new(id.to_string(), base, dir, self.tenant_quota));
+        let tenant = Arc::new(Tenant::new(id.to_string(), base, dir, self.tenant_quota, self.tenant_max_files));
         tenants.insert(id.to_string(), tenant.clone());
         Ok(tenant)
     }
@@ -918,7 +1011,7 @@ impl Store {
         let meta: serde_json::Value = serde_json::from_slice(&meta).map_err(|e| format!("tenant.json does not parse: {e}"))?;
         let base_name = meta.get("base").and_then(|b| b.as_str()).unwrap_or("");
         let base = self.base(base_name).ok_or_else(|| format!("base '{base_name}' is not loaded"))?;
-        let tenant = Tenant::new(id.to_string(), base, Some(dir.clone()), self.tenant_quota);
+        let tenant = Tenant::new(id.to_string(), base, Some(dir.clone()), self.tenant_quota, self.tenant_max_files);
         tenant.restore_overlay(&dir).map_err(|e| e.to_string())?;
         Ok(tenant)
     }
@@ -992,8 +1085,12 @@ mod tests {
     use super::*;
 
     fn tenant(quota: u64, dir: Option<PathBuf>) -> Tenant {
+        tenant_holding(quota, DEFAULT_MAX_FILES, dir)
+    }
+
+    fn tenant_holding(quota: u64, max_files: usize, dir: Option<PathBuf>) -> Tenant {
         let base = Base { name: "b".into(), root: PathBuf::from("."), stamp: 0, files: BTreeMap::new() };
-        Tenant::new("t".into(), Arc::new(base), dir, quota)
+        Tenant::new("t".into(), Arc::new(base), dir, quota, max_files)
     }
 
     fn temp(name: &str) -> PathBuf {
@@ -1217,6 +1314,61 @@ mod tests {
         assert!(!dir.join("files").join("big2").exists());
         assert_eq!(t.overlay_stats(), (1, big as u64));
         std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// Issue #88: `--tenant-quota-mb` counts bytes, and an empty file has none. A 1 KiB tenant took
+    /// 32,001 of them without one write being refused, each a real inode and a real directory entry.
+    #[test]
+    fn a_flood_of_empty_files_is_refused_at_the_file_limit() {
+        let t = tenant_holding(1024, 4, None);
+        for n in 0..4 {
+            t.write(&format!("src/e{n}.ts"), Vec::new(), UpdateKind::Module).unwrap();
+        }
+        let err = t.write("src/e4.ts", Vec::new(), UpdateKind::Module).unwrap_err();
+        assert!(matches!(err, WriteError::Files { limit: 4, after: 5 }), "{err}");
+        assert!(err.to_string().contains("--tenant-max-files"), "{err}");
+        assert_eq!(t.overlay_stats(), (4, 0), "the tenant is what it was: nothing weighed anything");
+        // the byte quota is untouched by any of it, which is the hole
+        assert!(t.write("src/e0.ts", vec![b'x'; 8], UpdateKind::Module).is_ok(), "replacing a file it already holds still fits");
+
+        // and the import cannot get round it either
+        let flood: Vec<(String, Vec<u8>)> = (0..5).map(|n| (format!("src/i{n}.ts"), Vec::new())).collect();
+        let err = tenant_holding(1024, 4, None).write_many(flood, &[], true).unwrap_err();
+        assert!(matches!(err, WriteError::Files { limit: 4, after: 5 }), "{err}");
+    }
+
+    /// Issue #88: `Tenant::write` re-summed the whole overlay under the write lock, so one write
+    /// cost O(files) — 23 s to reach 32k, with every read of that tenant blocked behind it. A
+    /// timing assertion would be flaky, so what is asserted is the property that lets the check be
+    /// O(1): the totals the overlay keeps equal a fresh sum after every kind of change, at the size
+    /// where re-summing was the cost.
+    #[test]
+    fn the_overlay_keeps_its_own_totals_at_thirty_two_thousand_files() {
+        let summed = |t: &Tenant| {
+            let held = t.overlay();
+            (held.len(), held.iter().filter_map(|(_, d)| d.as_ref()).map(|d| d.size()).sum::<u64>())
+        };
+        let t = tenant_holding(1 << 30, 40_000, None);
+        for n in 0..32_000 {
+            t.write(&format!("src/e{n}.ts"), Vec::new(), UpdateKind::Module).unwrap();
+        }
+        assert_eq!(t.overlay_stats(), (32_000, 0));
+        assert_eq!(t.overlay_stats(), summed(&t));
+
+        t.write("src/e0.ts", vec![b'x'; 100], UpdateKind::Module).unwrap();
+        assert_eq!(t.overlay_stats(), (32_000, 100), "a replacement charges the difference, not the file");
+        assert_eq!(t.overlay_stats(), summed(&t));
+
+        t.write("src/e0.ts", vec![b'x'; 10], UpdateKind::Module).unwrap();
+        assert_eq!(t.overlay_stats(), (32_000, 10));
+
+        t.delete("src/e0.ts").unwrap();
+        assert_eq!(t.overlay_stats(), (31_999, 0), "no base copy, so the entry goes rather than turning into a tombstone");
+        assert_eq!(t.overlay_stats(), summed(&t));
+
+        t.write_many(vec![("a.ts".into(), vec![b'x'; 7]), ("b.ts".into(), vec![b'y'; 3])], &[], true).unwrap();
+        assert_eq!(t.overlay_stats(), (2, 10), "`replace` dropped every edit the import did not carry");
+        assert_eq!(t.overlay_stats(), summed(&t));
     }
 
     #[test]


### PR DESCRIPTION
Closes #88

Closes #89

Two limits named after something they did not bound, and the walk that made the first of them expensive.

## #88 — the quota counts bytes, and an empty file has none

`--tenant-quota-mb` bounded bytes, so a tenant with a **1 KiB** quota accepted **32,001 files** without one write being refused — each a real inode, a real directory entry under `<data-dir>/<id>/files/` and a line of `deleted.json` bookkeeping. The import had the same hole at a higher rate: a zero-byte tar entry never moved `unpack`'s `total`, so what was left bounding an archive was `stream_cap` — about 160,000 empty entries per request at the default quota, and another 160,000 on the next one.

`--tenant-max-files` (default 10000, `SANDBOX_LITE_TENANT_MAX_FILES`) is the count beside the bytes. It is checked in `Tenant::write`, in `Tenant::write_many` against the overlay the import would leave — so `?replace=0` adds to what the tenant already holds rather than starting again — and in `unpack` before the archive is read to the end. A write or an import past it is refused with `413` and a message naming the flag, like the byte quota.

## #88 — and every write re-summed the overlay under the write lock

`overlay_bytes(&overlay)` walked the whole map on every single write, after `self.overlay.write()` had been taken and before the disk work, so one write cost O(files) and every read of that tenant — `data()`, `list()`, `/__sl/m/`, `routes::build`, `check_tenant` — blocked behind it:

```
after  2001 empty writes: batch   126ms
after 16001 empty writes: batch  5.59s
after 32001 empty writes: batch 23.33s
```

The overlay now keeps its own totals, moved by every insert, replace and tombstone, so the check is two comparisons and `overlay_stats` — which `/api/stats` and `/metrics` sum over every loaded tenant, polled every five seconds by every open editor — is O(1) as well. `write_many` builds a whole new map and counts it once.

## #89 — the chat windowed the stored turns and then bypassed the window for the request's own

`run` applied `for_model` to the conversation and then appended `req.messages` raw, so one `POST /api/t/{id}/chat` could store 64 MB in `chats/` — outside the tenant quota, and reported as zero by `/api/t/{id}/files`, by 413 and by the quota alike. `--chats-per-tenant 50` then bounded a count of files of no particular size.

- `--chat-message-kb` (default 64, `SANDBOX_LITE_CHAT_MESSAGE_KB`) bounds what one request may add.
- `--chat-quota-kb` (default 2048, `SANDBOX_LITE_CHAT_QUOTA_KB`) bounds what one conversation may hold.
- Both are asked in `chat`, before the model is called and before anything is stored, so a refusal writes nothing; the 413 names the one that was hit.
- `--chats-per-tenant` × `--chat-quota-kb` is the ceiling on `<data-dir>/<tenant>/chats/`, which `evict` now holds the tenant to in bytes as well as in count — off the counters `Chats::sizes` already keeps, which also takes a `read_dir` off every save (#60's shape).
- `/api/stats` reports that ceiling as `chats.max_bytes_per_tenant`.

The request's own messages now go through `for_model`'s normalisation instead of past it — the same empty-turn filter, same-role join and leading-assistant refusal the stored turns get. That is also what sent an empty `content` to an API that refuses it (a 502 to the caller for a request never worth making, now a 400), and what let two consecutive `user` messages through after an assistant turn was stored with empty text.

## Tests

- `a_flood_of_empty_files_is_refused_at_the_file_limit` and `an_import_of_empty_files_is_refused_at_the_file_limit` — the write and the import both refused at the count, with the flag named, nothing on disk, and a second `?replace=0` import that cannot double up on the first.
- `the_overlay_keeps_its_own_totals_at_thirty_two_thousand_files` — at 32,000 files the totals equal a fresh sum after a write, a replacement, a shrinking replacement, a delete and a `replace` import. That is the property that lets the check be O(1); a timing assertion would be flaky, so this asserts the total is maintained rather than recomputed.
- `a_chat_request_past_the_message_budget_is_refused_and_stores_nothing` — 413 naming `--chat-message-kb`, nothing written to `chats/`, the model never called; then the same for `--chat-quota-kb` on a conversation already at its budget.
- `the_chats_directory_cannot_exceed_the_cap_times_the_budget` — eight saves of conversations each over the per-conversation budget, persisted and in memory, with the count and the bytes checked after every one.
- `the_requests_own_messages_are_normalised_like_the_stored_ones` and `the_requests_own_messages_reach_the_api_normalised` — asserted on the JSON body sent upstream, not on the reply.

README, SECURITY.md and ARCHITECTURE.md updated for the three new flags and for what now bounds a conversation.

CI is green on `223e721`, rebased onto `ff9dba0`: https://github.com/productdevbook/sandbox-lite/actions/runs/34086719448 — fmt, clippy `-D warnings`, 214 tests, release build, `sandbox-lite check`, the smoke test, `bench/mem.sh`, the dev-server comparison and Playwright.

### Noticed, not fixed

- `Chats::evict` still calls `Chats::list`, which reads and `serde_json`-parses every conversation the tenant has, purely to sort them by `updated` — on a tokio worker thread rather than the blocking pool. It now runs only when a save actually crosses a cap rather than on every save, and the budget bounds what one parse costs, but the shape #89 describes is still there.
- A conversation that reaches `--chat-quota-kb` refuses further turns rather than shedding its oldest, so the caller is told to start a new conversation. Compaction normally keeps a conversation far below the budget; a conversation that gets there is one whose summary the API would not write.
- `Tenant::restore_overlay` does not apply either limit — what is on disk is loaded as it is, and the next write is what refuses. Lowering a limit therefore does not shrink a tenant already past it.
- `--tenant-max-files` counts written files, not overlay entries; a tombstone costs a `deleted.json` line and is not charged. Tombstones are bounded by the base's own file count, so this is finite, but it is not the same bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
