### PR TITLE
record every write, and refuse one to a deleted tenant

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -88,7 +88,21 @@ replaces or removes aside instead of deleting it. The overlay is swapped only
 once every step has succeeded, so a failure anywhere puts the directory back
 and memory and disk cannot end up describing different tenants. The one case
 that cannot be undone — the undo itself failing — is `WriteError::Torn`, which
-names the paths that are neither way instead of reporting a clean refusal.
+names the paths that are neither way instead of reporting a clean refusal. It
+means exactly that the undo failed on those paths: a file is recorded for the
+undo only once the open has truncated it, so a write that never got that far
+leaves nothing for `Torn` to name.
+
+All three also take `Tenant::writable` before they touch the directory and hold
+it until they are done. It is the read half of a lock whose write half
+`Store::remove_tenant` takes before it removes anything, so a request that
+resolved the tenant before the delete — it still holds the `Arc` — either
+finishes before the directory goes or is refused with `WriteError::Removed`. It
+cannot write the files back afterwards, which used to put
+`<data-dir>/<id>/files/` there without `tenant.json`: invisible to
+`Store::restore`, and on disk for ever (issue #101). `Chats::save` takes the
+same hold, because `chats/` is recreated by a late save exactly as `files/` is
+by a late write.
 
 With a `--data-dir`, the overlay is persisted as
 `<data-dir>/<id>/tenant.json` (`{"base": name}`), `<data-dir>/<id>/files/<path>`
@@ -116,8 +130,9 @@ the daemon reports that reason, so `resolve` is the whole of the read path;
 
 Because that fallback makes the data directory as much a source of tenants as
 the map, the two operations that decide whether a tenant exists consult both:
-`Store::remove_tenant` drops the map entry and removes `<data-dir>/<id>`,
-answering "no such tenant" only when neither holds it, and `create_tenant`
+`Store::remove_tenant` drops the map entry, marks the tenant removed and
+removes `<data-dir>/<id>`, answering "no such tenant" only when neither holds
+it, and `create_tenant`
 refuses an id whose directory is already there even when it cannot build a
 tenant from it — its base may not be loaded on this node. `Store::tenants` is
 the exception, and stays a list of what this daemon has loaded: it answers
@@ -827,14 +842,29 @@ sixth, `screenshot` (`tools`), which renders one page of the tenant's own
 preview in headless Chrome on the daemon's host and hands the PNG back as an
 image block; `SECURITY.md` says what that costs. The loop runs at most 16
 rounds (`MAX_ITERATIONS`) and answers
-`{text, changes, iterations, version, chat}`. Writes go through the same
+`{text, changes, iterations, version, stop, chat}`. Writes go through the same
 `Tenant::write` as the editor, so previews follow.
+
+`stop` is why the loop ended, and only `end_turn` is a turn the model
+finished: `max_tokens` is a turn cut off part-way — possibly inside a
+`tool_use` block, whose tool therefore never ran — and `max_iterations` is the
+ceiling reached with the model still asking for tools. Both carry a `note` for
+the customer, and neither leaves the previous iteration's `text` standing as
+the reply.
 
 Every turn is streamed from the API whichever way the caller asked for it
 (`converse`). With `Accept: text/event-stream` the endpoint answers SSE —
 `text`, `tool`, `tool_result` events as they happen, then one `done` carrying
 that same JSON, or `error`; otherwise the JSON is buffered and returned in one
 response.
+
+The tool loop edits the tenant's files as it goes, so what it did is recorded
+before any failure is reported (issue #91): the turn and its tool calls are
+pushed to the conversation and saved whether or not the request as a whole
+succeeded, and the `error` body carries the same `changes` and `version` a
+`done` would, so the editor can reconcile. A save that fails is a 500 rather
+than a 200 carrying a `chat` id that answers 404 on the next turn; the id is in
+the reply only once the conversation behind it is stored.
 
 The request body is `{messages, chat?}`. `chat` names a stored conversation
 (`src/http/chats.rs`, one JSON file per chat under `<data-dir>/<id>/chats/`, or

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Editor host (`localhost`):
 | GET/PUT/DELETE | `/api/t/{id}/file/{path}` | raw file bytes |
 | GET | `/api/t/{id}/events` | SSE: `update` / `delete` with the new version and a `kind` (`css`, `style`, `module`) |
 | GET | `/api/t/{id}/check` | compile every source file under one compile permit, return diagnostics |
-| POST | `/api/t/{id}/chat` | `{messages:[{role,content}], chat?}` → `{text, changes, iterations, version, chat}`, or SSE with `Accept: text/event-stream` |
+| POST | `/api/t/{id}/chat` | `{messages:[{role,content}], chat?}` → `{text, changes, iterations, version, stop, chat}`, or SSE with `Accept: text/event-stream` |
 | GET | `/api/t/{id}/chats` | saved conversations, newest first |
 | GET/DELETE | `/api/t/{id}/chats/{chat}` | one conversation with its turns / remove it |
 

--- a/assets/editor.html
+++ b/assets/editor.html
@@ -530,9 +530,17 @@ $("#chatForm").addEventListener("submit", async (e) => {
       if (name === "text") { streamed += d.text; setMsg(reply, streamed); }
       else if (name === "tool") running = addChip(reply, chipLabel({ name: d.name, path: d.input }), true);
       else if (name === "tool_result") { if (running) { running.className = ""; running.title = d.result; running = null; } }
-      else if (name === "error") { const m = typeof d.error === "string" ? d.error : JSON.stringify(d.error); setMsg(reply, streamed ? `${streamed}\n\nfailed: ${m}` : "failed: " + m); }
+      // a turn that failed part-way still edited the files it names, and the conversation it was
+      // recorded in is the one to carry on from
+      else if (name === "error") {
+        const m = typeof d.error === "string" ? d.error : JSON.stringify(d.error);
+        setMsg(reply, streamed ? `${streamed}\n\nfailed: ${m}` : "failed: " + m);
+        for (const p of d.changes || []) addChip(reply, p);
+        if (d.chat && d.chat !== state.chatId) { state.chatId = d.chat; loadChats(d.chat); }
+      }
       else if (name === "done") {
-        setMsg(reply, d.text || streamed || "(no reply)");
+        const body = d.text || streamed || "(no reply)";
+        setMsg(reply, d.note ? `${body}\n\n${d.note}` : body);
         for (const p of d.changes || []) addChip(reply, p);
         if (d.chat !== state.chatId) { state.chatId = d.chat; loadChats(d.chat); } else loadChats();
       }

--- a/src/http/ai.rs
+++ b/src/http/ai.rs
@@ -413,11 +413,10 @@ impl Emitter {
 
 struct Fail {
     status: StatusCode,
-    error: Value,
-    /// What the turn had already done when it failed. The tool loop writes the tenant's files as
-    /// it goes, so the error has to carry the same `changes` and `version` a `done` would, or the
-    /// editor cannot find out which files moved under it (issue #91).
-    progress: Value,
+    /// The whole error body, `{ "error": … }` and whatever `with` has folded under it. One field
+    /// rather than two: a `Fail` is the `Err` half of every result in this module, and two
+    /// `Value`s put that half past what clippy will carry unboxed.
+    body: Value,
 }
 
 impl Fail {
@@ -426,19 +425,25 @@ impl Fail {
     }
 
     fn new(status: StatusCode, error: Value) -> Fail {
-        Fail { status, error, progress: Value::Null }
+        Fail { status, body: json!({ "error": error }) }
     }
 
+    /// Folds in what the turn had already done when it failed. The tool loop writes the tenant's
+    /// files as it goes, so the error carries the same `changes` and `version` a `done` would, or
+    /// the editor cannot find out which files moved under it (issue #91).
     fn with(mut self, progress: Value) -> Fail {
-        self.progress = progress;
+        if let Value::Object(fields) = progress
+            && let Some(body) = self.body.as_object_mut()
+        {
+            for (key, value) in fields {
+                body.entry(key).or_insert(value);
+            }
+        }
         self
     }
 
-    /// The error body: what the turn managed, with the reason it stopped over the top.
     fn payload(self) -> Value {
-        let mut body = if self.progress.is_object() { self.progress } else { json!({}) };
-        body["error"] = self.error;
-        body
+        self.body
     }
 }
 

--- a/src/http/ai.rs
+++ b/src/http/ai.rs
@@ -414,31 +414,99 @@ impl Emitter {
 struct Fail {
     status: StatusCode,
     error: Value,
+    /// What the turn had already done when it failed. The tool loop writes the tenant's files as
+    /// it goes, so the error has to carry the same `changes` and `version` a `done` would, or the
+    /// editor cannot find out which files moved under it (issue #91).
+    progress: Value,
 }
 
 impl Fail {
     fn gateway(message: impl Into<String>) -> Fail {
-        Fail { status: StatusCode::BAD_GATEWAY, error: Value::String(message.into()) }
+        Fail::new(StatusCode::BAD_GATEWAY, Value::String(message.into()))
+    }
+
+    fn new(status: StatusCode, error: Value) -> Fail {
+        Fail { status, error, progress: Value::Null }
+    }
+
+    fn with(mut self, progress: Value) -> Fail {
+        self.progress = progress;
+        self
+    }
+
+    /// The error body: what the turn managed, with the reason it stopped over the top.
+    fn payload(self) -> Value {
+        let mut body = if self.progress.is_object() { self.progress } else { json!({}) };
+        body["error"] = self.error;
+        body
     }
 }
 
+/// Why the tool loop stopped. Only `Done` is a turn the model finished: a `max_tokens` turn can be
+/// cut off inside a `tool_use` block, whose input never parses and whose tool therefore never runs,
+/// and the iteration ceiling leaves the model still asking for tools. Both used to reach the caller
+/// as an ordinary `done` (issue #91).
+#[derive(Default, Clone, Copy)]
+enum Stop {
+    Done,
+    Truncated,
+    Ceiling,
+    Gone,
+    #[default]
+    Failed,
+}
+
+impl Stop {
+    fn as_str(self) -> &'static str {
+        match self {
+            Stop::Done => "end_turn",
+            Stop::Truncated => "max_tokens",
+            Stop::Ceiling => "max_iterations",
+            Stop::Gone => "client_gone",
+            Stop::Failed => "error",
+        }
+    }
+
+    /// What to tell the customer when the turn did not finish. The files the loop already wrote
+    /// are on disk either way, so this is a note on a `done` rather than an error.
+    fn note(self) -> Option<&'static str> {
+        match self {
+            Stop::Truncated => Some("The reply ran out of room part-way through, so whatever it was about to do was not done. Ask again."),
+            Stop::Ceiling => Some("The assistant used every step it is allowed in one turn and stopped part-way. Ask it to carry on."),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Default)]
 struct Answer {
     text: String,
     changes: Vec<String>,
     iterations: usize,
     tools: Vec<ToolCall>,
+    stop: Stop,
 }
 
 /// The tool loop. Every turn is streamed from the API, forwarded to `out` as it arrives, and put
 /// back together as content blocks so the next request can echo it as the assistant's message.
-async fn converse(st: &State, t: &Arc<Tenant>, key: &str, mut messages: Vec<Value>, out: &Emitter) -> Result<Answer, Fail> {
+/// `answer` is filled in as the loop goes rather than built at the end: a failure part-way through
+/// leaves the files the tool calls already wrote on disk, so the caller has to be able to record
+/// what happened before it reports the failure (issue #91).
+async fn converse(
+    st: &State,
+    t: &Arc<Tenant>,
+    key: &str,
+    mut messages: Vec<Value>,
+    out: &Emitter,
+    answer: &mut Answer,
+) -> Result<(), Fail> {
     let client = reqwest::Client::new();
-    let mut changes: Vec<String> = Vec::new();
-    let mut tools_used: Vec<ToolCall> = Vec::new();
-    let mut text = String::new();
-    let mut iterations = 0;
-    while iterations < MAX_ITERATIONS && !out.gone() {
-        iterations += 1;
+    while answer.iterations < MAX_ITERATIONS {
+        if out.gone() {
+            answer.stop = Stop::Gone;
+            return Ok(());
+        }
+        answer.iterations += 1;
         let body = json!({
             "model": st.model,
             "max_tokens": 8192,
@@ -460,7 +528,7 @@ async fn converse(st: &State, t: &Arc<Tenant>, key: &str, mut messages: Vec<Valu
         };
         if !resp.status().is_success() {
             let body = resp.text().await.unwrap_or_default();
-            return Err(Fail { status: StatusCode::BAD_GATEWAY, error: serde_json::from_str(&body).unwrap_or(Value::String(body)) });
+            return Err(Fail::new(StatusCode::BAD_GATEWAY, serde_json::from_str(&body).unwrap_or(Value::String(body))));
         }
         let mut frames = Frames::default();
         let mut reply = Reply::default();
@@ -491,25 +559,29 @@ async fn converse(st: &State, t: &Arc<Tenant>, key: &str, mut messages: Vec<Valu
             return Err(Fail::gateway("the upstream stream ended before the message did"));
         }
         let turn = reply.text();
-        if !turn.is_empty() {
-            text = turn;
+        let truncated = reply.stop_reason() == Some("max_tokens");
+        // A finished turn with nothing to say leaves the last one's words standing; a truncated
+        // turn must not, or the caller reads an earlier iteration's text as this turn's reply.
+        if !turn.is_empty() || truncated {
+            answer.text = turn;
         }
         if reply.stop_reason() != Some("tool_use") {
-            break;
+            answer.stop = if truncated { Stop::Truncated } else { Stop::Done };
+            return Ok(());
         }
         messages.push(json!({ "role": "assistant", "content": reply.content() }));
         let mut results = Vec::new();
         for (id, name, input) in reply.tool_calls() {
-            let done = run_tool(st, t, &name, &input, &mut changes).await;
-            tools_used.push(ToolCall { name: name.clone(), path: input.get("path").and_then(|p| p.as_str()).unwrap_or("").to_string() });
+            let done = run_tool(st, t, &name, &input, &mut answer.changes).await;
+            answer.tools.push(ToolCall { name: name.clone(), path: input.get("path").and_then(|p| p.as_str()).unwrap_or("").to_string() });
             out.send("tool_result", json!({ "name": name, "result": done.summary })).await;
             results.push(json!({ "type": "tool_result", "tool_use_id": id, "content": done.content }));
         }
         messages.push(json!({ "role": "user", "content": results }));
     }
-    changes.sort();
-    changes.dedup();
-    Ok(Answer { text, changes, iterations, tools: tools_used })
+    // the ceiling reached with `tool_use` still set: the model is mid-task, not at the end of one
+    answer.stop = Stop::Ceiling;
+    Ok(())
 }
 
 /// The turns past the window, as one transcript for the summarizer. Newest first while the budget
@@ -584,28 +656,58 @@ async fn run(st: State, t: Arc<Tenant>, key: String, req: ChatReq, mut conv: Con
     compact(&st, &key, &mut conv).await;
     // through the same normalisation as the stored turns, not appended to the windowed list raw
     let messages = conv.for_model(st.chats.window(), &adding);
-    let answer = converse(&st, &t, &key, messages, &out).await?;
-    for turn in adding {
-        conv.push(turn);
-    }
-    conv.push(Turn { role: "assistant".into(), text: answer.text.clone(), tools: answer.tools });
-    // `save` writes the file and then evicts, which once a tenant is at `--chats-per-tenant` reads
-    // and parses every conversation the tenant has (#94). The answer is already produced, so a
-    // failure to store it is logged rather than thrown away with the reply.
-    let (saver, saved, chat_id) = (st.clone(), t.clone(), conv.id.clone());
-    let stored = tokio::task::spawn_blocking(move || saver.chats.save(&saved, &conv)).await;
-    match stored {
-        Ok(Ok(())) => {}
-        Ok(Err(e)) => eprintln!("tenant {}: cannot save chat {chat_id}: {e}", t.id),
-        Err(e) => eprintln!("tenant {}: cannot save chat {chat_id}: {e}", t.id),
-    }
-    Ok(json!({
+    let mut answer = Answer::default();
+    let outcome = converse(&st, &t, &key, messages, &out, &mut answer).await;
+    answer.changes.sort();
+    answer.changes.dedup();
+
+    // The tool loop has already edited the tenant's files, so the turn is recorded whether or not
+    // the request as a whole succeeded: a failure that keeps the edits and drops the record of them
+    // leaves the conversation describing a site that is no longer there (issue #91). A turn that
+    // said and did nothing is not worth a conversation, so a request that failed before the model
+    // answered at all still stores nothing.
+    let ran = !answer.tools.is_empty() || !answer.text.trim().is_empty();
+    let recorded = outcome.is_ok() || ran;
+    let saved = if recorded {
+        for turn in adding {
+            conv.push(turn);
+        }
+        conv.push(Turn { role: "assistant".into(), text: answer.text.clone(), tools: std::mem::take(&mut answer.tools) });
+        // `save` writes the file and then evicts, which once a tenant is at `--chats-per-tenant`
+        // reads and parses every conversation it has (#94), so it runs off the async workers.
+        let (saver, of, storing) = (st.clone(), t.clone(), conv.clone());
+        match tokio::task::spawn_blocking(move || saver.chats.save(&of, &storing)).await {
+            Ok(r) => r,
+            Err(e) => Err(std::io::Error::other(e.to_string())),
+        }
+    } else {
+        Ok(())
+    };
+
+    let mut done = json!({
         "text": answer.text,
         "changes": answer.changes,
         "iterations": answer.iterations,
         "version": t.version(),
-        "chat": chat_id,
-    }))
+        "stop": answer.stop.as_str(),
+    });
+    if let Some(note) = answer.stop.note() {
+        done["note"] = Value::String(note.into());
+    }
+    // The id goes back only once the conversation behind it is stored. Handed back after a failed
+    // save it answers 404 on the next turn, while the files that turn wrote stay (issue #91).
+    if let Err(e) = saved {
+        eprintln!("tenant {}: cannot save chat {}: {e}", t.id, conv.id);
+        let message = format!("the turn ran and its edits are on disk, but the conversation could not be saved: {e}");
+        return Err(Fail::new(StatusCode::INTERNAL_SERVER_ERROR, Value::String(message)).with(done));
+    }
+    if recorded {
+        done["chat"] = Value::String(conv.id.clone());
+    }
+    match outcome {
+        Ok(()) => Ok(done),
+        Err(f) => Err(f.with(done)),
+    }
 }
 
 /// The request's messages as turns, the shape both the model input and the store hold them in.
@@ -653,7 +755,7 @@ pub async fn chat(AxState(st): AxState<State>, Path(id): Path<String>, headers: 
     if !accept.contains("text/event-stream") {
         return match run(st, t, key, req, conv, Emitter { tx: None }).await {
             Ok(done) => Json(done).into_response(),
-            Err(f) => (f.status, Json(json!({ "error": f.error }))).into_response(),
+            Err(f) => (f.status, Json(f.payload())).into_response(),
         };
     }
     let (tx, rx) = mpsc::channel(64);
@@ -661,7 +763,7 @@ pub async fn chat(AxState(st): AxState<State>, Path(id): Path<String>, headers: 
         let out = Emitter { tx: Some(tx.clone()) };
         let (event, data) = match run(st, t, key, req, conv, out).await {
             Ok(done) => ("done", done),
-            Err(f) => ("error", json!({ "error": f.error })),
+            Err(f) => ("error", f.payload()),
         };
         let _ = tx.send(Ok(Event::default().event(event).data(data.to_string()))).await;
     });
@@ -710,6 +812,26 @@ mod tests {
             json!({"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":text}}),
             json!({"type":"content_block_stop","index":0}),
             json!({"type":"message_delta","delta":{"stop_reason":"end_turn"}}),
+            json!({"type":"message_stop"}),
+        ])
+    }
+
+    /// A turn that dies on the wire part-way through, the way an `overloaded_error` does.
+    fn turn_that_breaks() -> String {
+        events(&[
+            json!({"type":"message_start","message":{"id":"msg_3","role":"assistant","content":[]}}),
+            json!({"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}),
+        ])
+    }
+
+    /// A turn that runs out of `max_tokens` inside a `tool_use` block: no `content_block_stop`
+    /// arrives, so the input never parses and the tool never runs.
+    fn turn_cut_off_mid_tool_call() -> String {
+        events(&[
+            json!({"type":"message_start","message":{"id":"msg_4","role":"assistant","content":[]}}),
+            json!({"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_2","name":"write_file","input":{}}}),
+            json!({"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"path\":\"src/pages/half.astro\""}}),
+            json!({"type":"message_delta","delta":{"stop_reason":"max_tokens"}}),
             json!({"type":"message_stop"}),
         ])
     }
@@ -998,6 +1120,79 @@ mod tests {
         let (status, body) = post_chat(&broken, None, ask("hi", None)).await;
         assert_eq!(status, StatusCode::BAD_GATEWAY);
         assert!(serde_json::from_str::<Value>(&body).unwrap()["error"].is_string());
+    }
+
+    /// Issue #91: every `return Err` inside the tool loop skipped the `conv.push`/`save` below it,
+    /// so a failure on the second iteration kept the file the first one wrote and threw away every
+    /// record of it — the turn, the tool call, the `changes` list and the version.
+    #[tokio::test]
+    async fn a_failure_after_a_write_still_reports_the_file_and_records_the_turn() {
+        let f = fixture(vec![turn_with_tool(), turn_that_breaks()], true).await;
+        let (status, body) = post_chat(&f.st, None, ask("add a page", None)).await;
+        assert_eq!(status, StatusCode::BAD_GATEWAY, "{body}");
+        let v: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["error"], "Overloaded");
+        assert_eq!(v["stop"], "error");
+        assert_eq!(v["iterations"], 2);
+        assert_eq!(v["changes"], json!(["src/pages/new.astro"]), "the error names what the loop wrote: {v}");
+        assert!(v["version"].as_u64().unwrap() > 0, "and the version it wrote it at: {v}");
+
+        let t = f.st.store.tenant("acme").unwrap();
+        assert_eq!(t.read_text("src/pages/new.astro").unwrap().as_deref(), Some("<h1>hi</h1>"), "the write landed");
+
+        let chat_id = v["chat"].as_str().expect("a chat the caller can carry on");
+        let stored = f.st.chats.load(&t, chat_id).unwrap().expect("the turn is stored, not dropped with the error");
+        assert_eq!(stored.messages[0].text, "add a page");
+        assert_eq!(stored.messages[1].tools, vec![ToolCall { name: "write_file".into(), path: "src/pages/new.astro".into() }]);
+    }
+
+    /// Issue #91: a save that failed was printed and then answered 200 with the id it had not
+    /// written, so the client's next turn was a 404 while the files that turn wrote stayed.
+    #[tokio::test]
+    async fn a_conversation_that_cannot_be_saved_is_an_error_rather_than_a_dangling_id() {
+        let f = fixture(vec![turn_with_tool(), turn_with_text("All done.")], true).await;
+        // `chats/` cannot be created because a file of that name is in the way
+        std::fs::write(f.root.join("data").join("acme").join("chats"), b"in the way").unwrap();
+
+        let (status, body) = post_chat(&f.st, None, ask("add a page", None)).await;
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR, "{body}");
+        let v: Value = serde_json::from_str(&body).unwrap();
+        assert!(v["error"].as_str().unwrap().contains("could not be saved"), "{v}");
+        assert!(v["chat"].is_null(), "no id the next turn would 404 on: {v}");
+        assert_eq!(v["changes"], json!(["src/pages/new.astro"]), "and the edits it made are still named: {v}");
+
+        let t = f.st.store.tenant("acme").unwrap();
+        assert_eq!(t.read_text("src/pages/new.astro").unwrap().as_deref(), Some("<h1>hi</h1>"));
+    }
+
+    /// Issue #91: a turn cut off inside a `tool_use` block emits no `Emit::Tool`, so the tool never
+    /// runs — and `max_tokens` is not `tool_use`, so the loop used to break and call it a finished
+    /// turn, carrying the previous iteration's text over as the reply.
+    #[tokio::test]
+    async fn a_turn_truncated_mid_tool_call_says_so_and_does_not_carry_the_last_text_over() {
+        let f = fixture(vec![turn_with_tool(), turn_cut_off_mid_tool_call()], true).await;
+        let (status, body) = post_chat(&f.st, None, ask("add two pages", None)).await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        let v: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["stop"], "max_tokens", "distinguishable from a finished turn: {v}");
+        assert!(v["note"].as_str().unwrap().contains("ran out of room"), "{v}");
+        assert_eq!(v["text"], "", "not 'Adding the page.' from the iteration before it: {v}");
+        assert_eq!(v["changes"], json!(["src/pages/new.astro"]), "the first iteration's write is still reported: {v}");
+
+        let t = f.st.store.tenant("acme").unwrap();
+        assert!(!t.exists("src/pages/half.astro"), "the truncated call never ran");
+    }
+
+    /// The other way the loop ends mid-task: the model is still asking for tools at the ceiling.
+    #[tokio::test]
+    async fn the_iteration_ceiling_is_not_reported_as_a_finished_turn() {
+        let f = fixture(vec![turn_with_tool(); MAX_ITERATIONS], false).await;
+        let (status, body) = post_chat(&f.st, None, ask("keep going", None)).await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        let v: Value = serde_json::from_str(&body).unwrap();
+        assert_eq!(v["stop"], "max_iterations", "{v}");
+        assert_eq!(v["iterations"], json!(MAX_ITERATIONS));
+        assert!(v["note"].as_str().unwrap().contains("carry on"), "{v}");
     }
 
     #[test]

--- a/src/http/api.rs
+++ b/src/http/api.rs
@@ -331,6 +331,8 @@ pub async fn write_file(AxState(st): AxState<State>, Path((id, path)): Path<(Str
     match written {
         Ok(Ok(version)) => Json(json!({ "path": path, "version": version })).into_response(),
         Ok(Err(e @ (WriteError::Quota { .. } | WriteError::Files { .. }))) => err(StatusCode::PAYLOAD_TOO_LARGE, e.to_string()),
+        // the tenant went while this write was in flight; nothing was written (issue #101)
+        Ok(Err(e @ WriteError::Removed)) => err(StatusCode::NOT_FOUND, e.to_string()),
         Ok(Err(e)) => err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
         Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
     }
@@ -350,6 +352,7 @@ pub async fn delete_file(AxState(st): AxState<State>, Path((id, path)): Path<(St
     let p2 = path.clone();
     match tokio::task::spawn_blocking(move || t.delete(&p2)).await {
         Ok(Ok(version)) => Json(json!({ "path": path, "version": version })).into_response(),
+        Ok(Err(e @ WriteError::Removed)) => err(StatusCode::NOT_FOUND, e.to_string()),
         Ok(Err(e)) => err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
         Err(e) => err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
     }

--- a/src/http/archive.rs
+++ b/src/http/archive.rs
@@ -251,6 +251,9 @@ pub async fn import(AxState(st): AxState<State>, Path(id): Path<String>, RawQuer
         Err(e @ WriteError::Io(_)) => (StatusCode::INTERNAL_SERVER_ERROR, refused(e.to_string())).into_response(),
         // it could not, so there are no counts to give: the message names what is neither way
         Err(e @ WriteError::Torn { .. }) => err(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()),
+        // the tenant was deleted while the archive was being unpacked, which is a 404 rather than
+        // an import that half landed: `write_many` refused before it touched the directory (#101)
+        Err(e @ WriteError::Removed) => (StatusCode::NOT_FOUND, refused(e.to_string())).into_response(),
     }
 }
 

--- a/src/http/chats.rs
+++ b/src/http/chats.rs
@@ -297,6 +297,11 @@ impl Chats {
     }
 
     pub fn save(&self, t: &Tenant, chat: &Conversation) -> io::Result<()> {
+        // `chats/` is a sibling of `files/` and a save after the delete recreates the tenant's
+        // directory exactly as a write of its files would, so it takes the same hold (issue #101)
+        let Some(_live) = t.writable() else {
+            return Err(io::Error::other(format!("tenant '{}' has been removed", t.id)));
+        };
         self.seed(t)?;
         let raw = serde_json::to_vec(chat)?;
         let bytes = raw.len() as u64;
@@ -673,6 +678,28 @@ mod tests {
         assert!(matches!(over, TooBig::Conversation { limit: 4096, .. }), "{over}");
         assert!(over.to_string().contains("--chat-quota-kb"), "{over}");
         assert_eq!(chats.tenant_quota(), 4 * 4096, "the cap is spent in bytes: four conversations of the budget");
+    }
+
+    /// Issue #101: `chats/` is recreated by a save that outlives the delete exactly as `files/` is
+    /// by a write, and the directory it puts back holds no `tenant.json` for `Store::restore`.
+    #[test]
+    fn a_save_through_a_handle_to_a_deleted_tenant_fails_and_writes_nothing() {
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        let root =
+            std::env::temp_dir().join(format!("sandbox-lite-chats-removed-{}-{}", std::process::id(), SEQ.fetch_add(1, Ordering::Relaxed)));
+        std::fs::create_dir_all(&root).unwrap();
+        let store = Store::new(Some(root.clone()), u64::MAX);
+        let base = Path::new(env!("CARGO_MANIFEST_DIR")).join("examples/starter");
+        store.add_base(Base::load("starter", &base).unwrap());
+        let held = store.create_tenant("acme", "starter").unwrap();
+        let chats = Chats::default();
+        chats.save(&held, &conversation("c0", 2)).unwrap();
+
+        assert!(store.remove_tenant("acme").unwrap());
+        let e = chats.save(&held, &conversation("c1", 2)).unwrap_err();
+        assert!(e.to_string().contains("removed"), "{e}");
+        assert!(!root.join("acme").exists(), "no chat file put the tenant directory back");
+        std::fs::remove_dir_all(&root).unwrap();
     }
 
     fn tenant(persist: bool) -> (Arc<Tenant>, PathBuf) {

--- a/src/silent_failures.rs
+++ b/src/silent_failures.rs
@@ -60,7 +60,7 @@ const TOLERATED: [(&str, &str); 8] = [
         "the body of an upstream response that already failed; its status is what is reported",
     ),
     (
-        "return Err(Fail { status: StatusCode::BAD_GATEWAY, error: serde_json::from_str(&body).unwrap_or(Value::String(body)) });",
+        "return Err(Fail::new(StatusCode::BAD_GATEWAY, serde_json::from_str(&body).unwrap_or(Value::String(body))));",
         "an upstream error body that is not JSON is passed through verbatim, so the diagnostic survives either way",
     ),
     (

--- a/src/store.rs
+++ b/src/store.rs
@@ -355,13 +355,13 @@ impl Tenant {
     /// `chats/` without going through the overlay — so the delete either waits for the write or
     /// the write is refused, and neither can put the directory back (issue #101).
     pub fn writable(&self) -> Option<RwLockReadGuard<'_, bool>> {
-        let removed = self.removed.read().unwrap();
+        let removed = self.removed.shared();
         (!*removed).then_some(removed)
     }
 
     /// Refuses every later write and waits for the ones already running.
     fn mark_removed(&self) {
-        *self.removed.write().unwrap() = true;
+        *self.removed.exclusive() = true;
     }
 
     pub fn base(&self) -> Arc<Base> {

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,9 +1,10 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fmt;
 use std::io;
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, RwLock, RwLockReadGuard};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use tokio::sync::broadcast;
@@ -203,12 +204,17 @@ pub enum WriteError {
         after: usize,
     },
     Io(io::Error),
-    /// A write that failed and could not be put back. The named paths are neither what they were nor
-    /// what the write asked for, so the caller is told that rather than that nothing landed.
+    /// A write that failed and could not be put back. Every path named is one the undo itself
+    /// failed on, so it is neither what it was nor what the write asked for. A step that never ran
+    /// is not named here: `Staged::write` records a file only once the open has truncated it.
     Torn {
         cause: io::Error,
         paths: Vec<String>,
     },
+    /// A write through a handle to a tenant `Store::remove_tenant` has already taken. Its
+    /// directory is gone, and writing the file back would put `<data-dir>/<id>/files/` there
+    /// without `tenant.json` — a directory `Store::restore` skips for ever (issue #101).
+    Removed,
 }
 
 impl fmt::Display for WriteError {
@@ -230,6 +236,7 @@ impl fmt::Display for WriteError {
                 paths.len(),
                 paths.join(", ")
             ),
+            WriteError::Removed => write!(f, "the tenant has been removed"),
         }
     }
 }
@@ -306,6 +313,11 @@ pub struct Tenant {
     dir: Option<PathBuf>,
     quota: u64,
     max_files: usize,
+    /// Set by `Store::remove_tenant` before it removes anything. A request that resolved the tenant
+    /// earlier still holds the `Arc` after the delete, and every writer takes the read half of this
+    /// across its own disk work, so such a write is refused rather than recreating the directory
+    /// (issue #101).
+    removed: RwLock<bool>,
 }
 
 pub struct Entry {
@@ -334,7 +346,22 @@ impl Tenant {
             dir,
             quota,
             max_files,
+            removed: RwLock::new(false),
         }
+    }
+
+    /// A hold on the tenant being alive, `None` once it has been removed. Every writer keeps one
+    /// for as long as it touches `<data-dir>/<id>` — including `Chats::save`, which writes
+    /// `chats/` without going through the overlay — so the delete either waits for the write or
+    /// the write is refused, and neither can put the directory back (issue #101).
+    pub fn writable(&self) -> Option<RwLockReadGuard<'_, bool>> {
+        let removed = self.removed.read().unwrap();
+        (!*removed).then_some(removed)
+    }
+
+    /// Refuses every later write and waits for the ones already running.
+    fn mark_removed(&self) {
+        *self.removed.write().unwrap() = true;
     }
 
     pub fn base(&self) -> Arc<Base> {
@@ -403,6 +430,9 @@ impl Tenant {
     /// answer for a stylesheet, and proving `Style` takes a compile — `Engine::update_kind` — which
     /// is why it does not happen here.
     pub fn write(&self, path: &str, bytes: Vec<u8>, kind: UpdateKind) -> Result<u64, WriteError> {
+        // held across the disk work: a delete that has started refuses this write, and one that
+        // has not waits for it rather than leaving the file behind (issue #101)
+        let _live = self.writable().ok_or(WriteError::Removed)?;
         // held across the disk write so a concurrent write cannot slip past the quota check
         let mut overlay = self.overlay.exclusive();
         let after = overlay.bytes - overlay.size_of(path) + bytes.len() as u64;
@@ -436,6 +466,7 @@ impl Tenant {
     /// succeeded. A failure puts the directory back, so what the caller is told and what a restart
     /// reads are the same tenant.
     pub fn write_many(&self, files: Vec<(String, Vec<u8>)>, deleted: &[String], replace: bool) -> Result<Applied, WriteError> {
+        let _live = self.writable().ok_or(WriteError::Removed)?;
         let mut overlay = self.overlay.exclusive();
         let incoming: BTreeSet<&str> = files.iter().map(|(p, _)| p.as_str()).collect();
         let keep = |path: &str, data: &Option<FileData>| !replace || data.is_none() || incoming.contains(path);
@@ -474,6 +505,9 @@ impl Tenant {
     }
 
     pub fn delete(&self, path: &str) -> Result<u64, WriteError> {
+        // a delete rewrites `deleted.json`, which is a write to the tenant's directory like any
+        // other and puts it back if the tenant has already been removed
+        let _live = self.writable().ok_or(WriteError::Removed)?;
         // held across the disk work, as a write is: the file leaves the directory and the tombstone
         // list is rewritten before the overlay hears about it, and a failure puts both back
         let mut overlay = self.overlay.exclusive();
@@ -627,9 +661,11 @@ impl Staged {
         let target = dir.join("files").join(path);
         self.create_dirs(&target)?;
         self.move_aside(&dir, &target)?;
-        // recorded before the write, because a write that fails partway still leaves a file
+        // between the open and the bytes: an open that failed created nothing to undo, and one that
+        // succeeded has already truncated the file even if not a byte of it lands (issue #101)
+        let mut file = std::fs::File::create(&target)?;
         self.created.push(target.clone());
-        std::fs::write(&target, &bytes)?;
+        file.write_all(&bytes)?;
         if bytes.len() as u64 > INLINE_LIMIT { Ok(FileData::Disk(target, bytes.len() as u64)) } else { Ok(FileData::Mem(bytes.into())) }
     }
 
@@ -1037,9 +1073,17 @@ impl Store {
     /// The map's write lock is held across the directory removal. Released after the drop, the
     /// directory was still there for `resolve` to rebuild the tenant from and put back in the map,
     /// so a 204 left a tenant serving traffic from a directory that was about to go (issue #92).
+    /// The tenant is also marked removed, which is what stops a request that resolved it before
+    /// the delete from writing its files back afterwards (issue #101).
     pub fn remove_tenant(&self, id: &str) -> io::Result<bool> {
         let mut tenants = self.tenants.exclusive();
         let dropped = tenants.remove(id);
+        // Before any directory work, and waiting for the writes already in flight: a request that
+        // resolved the tenant earlier still holds the `Arc`, and its write would otherwise put
+        // `files/` back without `tenant.json` — invisible to `restore`, on disk for ever (#101).
+        if let Some(t) = &dropped {
+            t.mark_removed();
+        }
         self.failed.exclusive().remove(id);
         let dir = dropped.as_ref().and_then(|t| t.dir.clone()).or_else(|| self.tenant_dir(id));
         let mut held = dropped.is_some();
@@ -1527,6 +1571,36 @@ mod tests {
             assert!(store.tenant("acme").is_none(), "so nothing may serve it afterwards, round {round}");
             assert!(!data.join("acme").exists(), "and its data directory is gone, round {round}");
         }
+        std::fs::remove_dir_all(&root).unwrap();
+    }
+
+    /// Issue #101: the delete is atomic against a *lookup*, not against a request that resolved
+    /// the tenant before it. That request holds the `Arc` still, and its write used to recreate
+    /// `<data-dir>/<id>/files/` without `tenant.json` — a directory `restore` skips, so the bytes
+    /// sit there for ever and no daemon serves them.
+    #[test]
+    fn a_write_through_a_handle_to_a_deleted_tenant_is_refused_and_leaves_nothing_on_disk() {
+        let root = temp("removed-tenant");
+        seed(root.join("theme").join(PAGE), "<h1>base</h1>\n");
+        let data = root.join("data");
+        let store = Store::new(Some(data.clone()), 1 << 20);
+        store.add_base(Base::load("theme", &root.join("theme")).unwrap());
+        let held = store.create_tenant("acme", "theme").unwrap();
+        held.write("a.txt", b"one".to_vec(), UpdateKind::Module).unwrap();
+
+        assert!(store.remove_tenant("acme").unwrap());
+        assert!(!data.join("acme").exists(), "the delete took the directory");
+
+        let write = held.write("b.txt", b"two".to_vec(), UpdateKind::Module).unwrap_err();
+        assert!(matches!(write, WriteError::Removed), "{write:?}");
+        assert!(write.to_string().contains("removed"), "{write}");
+        // every writer, not only the one the editor calls: the import and the delete's own
+        // rewrite of `deleted.json` put the directory back just as readily
+        assert!(matches!(held.delete(PAGE), Err(WriteError::Removed)));
+        assert!(matches!(held.write_many(vec![("c.txt".into(), b"three".to_vec())], &[], false), Err(WriteError::Removed)));
+
+        assert!(!data.join("acme").exists(), "and nothing came back on disk");
+        assert_eq!(store.restore().unwrap(), 0, "so a restart finds nothing to restore");
         std::fs::remove_dir_all(&root).unwrap();
     }
 


### PR DESCRIPTION
Closes #91
Closes #101

Both are one fault in two places: **a write happened and the record of it did not.**

## #91 — the chat turn edits files and the conversation says nothing

`converse` built its `Answer` at the end, so every `return Err` inside the tool
loop jumped over the `conv.push`/`save` under it. The files the loop had already
written stayed on disk and the version had moved; the turn, the tool calls, the
`changes` list and the version went with the error.

- `converse` now fills an `Answer` **in place** and `run` records what happened
  before it reports anything. The `error` body carries the same `changes`,
  `version`, `iterations` and `stop` a `done` does, so the editor can reconcile
  which files moved under it. A request that failed before the model said or did
  anything still stores nothing — there is no turn to record.
- A save that fails is a **500**, not a 200 carrying a chat id that answers 404
  on the next turn while that turn's file edits stay. The id is in the reply only
  once the conversation behind it is stored.
- `stop` says why the loop ended. Only `end_turn` is a turn the model finished:
  `max_tokens` is one cut off part-way — possibly inside a `tool_use` block,
  whose input never parses and whose tool therefore never ran — and
  `max_iterations` is the ceiling reached with the model still asking for tools.
  Both carry a `note` for the customer, and a truncated turn **replaces** `text`
  rather than leaving the previous iteration's words standing as this turn's
  reply.

The editor now shows the changes and adopts the chat id on an `error` too, and
renders `note` under a `done`.

## #101 — a request holding a deleted tenant writes its files back

A request that resolved a tenant before the delete still holds the `Arc`. Its
`write` after `remove_dir_all` put `<data-dir>/<id>/files/` back without
`tenant.json` — a directory `Store::restore` skips, so the bytes sat there for
ever and no daemon served them.

`Tenant::writable` is the read half of a lock every writer holds across its own
disk work; `remove_tenant` takes the write half before it removes anything. So a
delete already under way refuses the late write with `WriteError::Removed` (404
over HTTP), and one that has not started yet waits for a write already running
rather than leaving its file behind. All three tenant writers take it — the
editor's write, the import's `write_many`, the delete's own rewrite of
`deleted.json` — and so does `Chats::save`, because `chats/` is recreated by a
late save exactly as `files/` is by a late write.

## `Staged::rollback`

`Staged::write` now records a file for the undo **between** the open and the
bytes rather than before both: an open that failed created nothing to undo, one
that succeeded has already truncated the file. So every path `WriteError::Torn`
names is one the undo itself failed on, which is what its documentation now
says.

## Tests

- a tool loop that fails after writing a file still shows the file in `changes`,
  with the version, and the turn and its tool call in the stored conversation
- a save that cannot be written is a 500 with no `chat` id, and still names the
  edits it made
- a turn truncated mid tool call reports `stop: max_tokens`, does not carry the
  previous iteration's text over, and the truncated call never ran
- the iteration ceiling is likewise not an `end_turn`
- a write, a delete and an import through a handle to a deleted tenant are each
  `WriteError::Removed`, nothing comes back on disk, and `restore` finds nothing
- a `Chats::save` through such a handle fails and puts no directory back

CI: run
[34088366248](https://github.com/productdevbook/sandbox-lite/actions/runs/34088366248)
on `fix/writes-that-vanish` — fmt, clippy `-D warnings`, tests, release build,
`sandbox-lite check`, smoke, `bench/mem.sh`, the dev-server comparison and
Playwright.

## Noticed, not fixed

- `Engine::last_js` (`src/transform/mod.rs`) is keyed by `(tenant id, path)` and
  nothing purges it when a tenant is deleted. It is bounded — the map clears at
  4096 entries — but a tenant recreated under the same id can match a
  fingerprint from its predecessor and be told `Style` for a write that should
  reload. Not a disk leak, so out of scope here.
- `Stop::Gone` (the client disconnecting mid-loop) is reported like the others
  but nothing reads it: the SSE receiver is already gone, and the JSON path
  cannot reach it. It is there so the ceiling is not blamed for a hang-up.
- `remove_tenant` marks only the tenant it found in the map. One that is on disk
  and not loaded has no `Arc` for anyone to hold — `resolve` hands one out only
  under the `tenants` write lock the delete is holding — so there is nothing to
  mark, but that argument is a comment rather than a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015BuWsTSmPksvja8c2Haa8L
